### PR TITLE
Incredibly minor reST syntax fixes.

### DIFF
--- a/bugwarrior/README.rst
+++ b/bugwarrior/README.rst
@@ -4,10 +4,10 @@ bugwarrior - Pull tickets from github, bitbucket, and trac into taskwarrior
 .. split here
 
 This is a command line utility for updating your local `taskwarrior
-<http://taskwarrior.org>`_ database from your forge issue trackers.
+<http://taskwarrior.org>`__ database from your forge issue trackers.
 
 Getting bugwarrior
--------------
+------------------
 
 Installing
 ++++++++++


### PR DESCRIPTION
I had the `README.rst` open to [add a reference](https://github.com/ask/python-github2/commit/057e02b886cc3700d7e76ea1a88d0b73797deac4) in `github2`, and figured I may as well quickly fix the reST warnings that popped up in my editor.  Feel free to completely ignore ;)

Thanks,

James
