### PR TITLE
Can now define prefix to be added to project name of pulled Jira tasks

### DIFF
--- a/bugwarrior/README.rst
+++ b/bugwarrior/README.rst
@@ -130,6 +130,7 @@ Create a ``~/.bugwarriorrc`` file with the following contents.
   jira.username = ralph
   jira.password = OMG_LULZ
   jira.query = assignee = ralph and status != closed and status != resolved
+  jira.project_prefix = Programming.
 
   # Here's an example of a teamlab target.
   [my_teamlab]

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -32,6 +32,7 @@ class JiraService(IssueService):
         self.url = self.config.get(self.target, 'jira.base_uri')
         default_query = 'assignee=' + self.username + ' AND status != closed and status != resolved'
         self.query = self.config.get(self.target, 'jira.query', default_query)
+        self.project_prefix = self.config.get(self.target, 'jira.project_prefix', '')
         self.jira = JIRA(options={'server': self.config.get(self.target, 'jira.base_uri')},
                          basic_auth=(self.username,
                                      self.config.get(self.target, 'jira.password')))
@@ -74,7 +75,7 @@ class JiraService(IssueService):
                 url=self.url + '/browse/' + case.key,
                 number=case.key.rsplit('-', 1)[1], cls="issue",
             ),
-            project=case.key.rsplit('-', 1)[0],
+            project=self.project_prefix + case.key.rsplit('-', 1)[0],
             priority=self.priorities.get(
                 get_priority(case.fields.priority),
                 self.default_priority,


### PR DESCRIPTION
Added a new feature which allows the definition of any prefix which is
prepended to the project name of all tasks pulled from Jira. This can
be used for simple sorting, but also for creating subprojects in
taskwarrior (e.g. "Programming.JiraProject").
