### PR TITLE
ActiveCollab3 service: Use project slug instead of project name

### DIFF
--- a/bugwarrior/services/activecollab3.py
+++ b/bugwarrior/services/activecollab3.py
@@ -46,7 +46,7 @@ class Client(object):
         # string in project slug format: "client-example-project"
         project_name = project_name.lower()
         project_name = re.sub('[\s+]', '-', project_name)
-        project_name = re.sub('[:]', '', project_name)
+        project_name = re.sub('[:,"/"]', '', project_name)
         return project_name
 
     # Return a priority of L, M, or H based on AC's priority index of -2 to 2


### PR DESCRIPTION
ActiveCollab returns a project name in the format "Client: Example Project". It would be better to use the project slug format of "client-example-project", both for autocompletion purposes and to avoid data corruption.
