### PR TITLE
Make the jira service version 4 compatible

### DIFF
--- a/bugwarrior/README.rst
+++ b/bugwarrior/README.rst
@@ -156,8 +156,10 @@ Create a ``~/.bugwarriorrc`` file with the following contents.
   jira.password = OMG_LULZ
   jira.query = assignee = ralph and status != closed and status != resolved
   jira.project_prefix = Programming.
-  # Set this to True if you are connecting to jira version 4(look at the footer to be sure)
-  jira.version4 = False
+  # Set this to your jira major version. We currently support only jira version
+  # 4 and 5(the default). You can find your particular version in the footer at
+  # the dashboard.
+  jira.version = 5
 
   # Here's an example of a teamlab target.
   [my_teamlab]

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -95,7 +95,7 @@ class JiraService(IssueService):
         }
         return result
 
-    def __issue(self, case, jira4):
+    def __issue(self, case, jira_version):
         result = dict(
             description=self.description(
                 title=case.fields.summary,
@@ -108,15 +108,17 @@ class JiraService(IssueService):
                 self.default_priority,
             )
         )
-        if not jira4:
+        if jira_version != 4:
             result.update(self.annotations(case.key))
         return result
 
     def issues(self):
         cases = self.jira.search_issues(self.query, maxResults=-1)
 
-        jira4 = self.config.getboolean(self.target, 'jira.version4')
-        if jira4:
+        jira_version = 5 # Default version number
+        if self.config.has_option(self.target, 'jira.version'):
+            jira_version = self.config.getint(self.target, 'jira.version')
+        if jira_version == 4:
             # Convert for older jira versions that don't support the new API
             cases = [self.__convert_for_jira4(case) for case in cases]
 
@@ -124,4 +126,4 @@ class JiraService(IssueService):
         log.name(self.target).debug(" Found {0} total.", len(cases))
 
 
-        return [self.__issue(case, jira4) for case in cases]
+        return [self.__issue(case, jira_version) for case in cases]


### PR DESCRIPTION
Jira4 has a far older API which doesn't behave in the same way. This commit should make both version 4 and 5 be usable. Introduced a new boolean variable jira.version4.
