### PR TITLE
Add support for include_repos

### DIFF
--- a/bugwarrior/README.rst
+++ b/bugwarrior/README.rst
@@ -96,6 +96,10 @@ Create a ``~/.bugwarriorrc`` file with the following contents.
   # two because they're spammy or something.
   exclude_repos = project_bar,project_baz
 
+  # Working with a large number of projects, instead of excluding most of them I
+  # can also simply include just a limited set.
+  include_repos = project_foo,project_foz
+
   # Note that login and username can be different.  I can login as me, but
   # scrape issues from an organization's repos.
   login = ralphbean

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -22,11 +22,19 @@ class GithubService(IssueService):
         self.auth = (login, password)
 
         self.exclude_repos = []
+        self.include_repos = []
 
         if self.config.has_option(self.target, 'exclude_repos'):
             self.exclude_repos = [
                 item.strip() for item in
                 self.config.get(self.target, 'exclude_repos')
+                    .strip().split(',')
+            ]
+
+        if self.config.has_option(self.target, 'include_repos'):
+            self.include_repos = [
+                item.strip() for item in
+                self.config.get(self.target, 'include_repos')
                     .strip().split(',')
             ]
 
@@ -68,6 +76,12 @@ class GithubService(IssueService):
 
         if self.exclude_repos:
             if repo['name'] in self.exclude_repos:
+                return False
+
+        if self.include_repos:
+            if repo['name'] in self.include_repos:
+                return True
+            else:
                 return False
 
         return True


### PR DESCRIPTION
When working with a large number of repos, instead of excluding a large list one
may instead simply include a limited set.

This is performed via the include_repos configuration key for github accounts.

Signed-off-by: Pierre-Yves Chibon pingou@pingoured.fr
