### PR TITLE
Use new taskw lingo.

### DIFF
--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -1,5 +1,5 @@
 from twiggy import log
-from taskw import TaskWarrior, TaskWarriorExperimental
+from taskw import TaskWarriorShellout, TaskWarriorDirect
 from bugwarrior.notifications import send_notification
 from bugwarrior.config import asbool, NoOptionError
 import subprocess
@@ -20,10 +20,9 @@ def synchronize(issues, conf):
     experimental = _bool_option('general', 'experimental', 'False')
 
     if experimental is True:
-        # @TODO don't hardcode path to config filename.
-        tw = TaskWarriorExperimental(config_filename='~/.bugwarrior_taskrc')
+        tw = TaskWarriorShellout()
     else:
-        tw = TaskWarrior()
+        tw = TaskWarriorDirect()
 
     # Load info about the task database
     tasks = tw.load_tasks()

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -233,7 +233,9 @@ def aggregate_issues(conf):
         zip([conf] * len(targets), targets)
     )
     log.name('bugwarrior').info("Done aggregating remote issues.")
+
     if WORKER_FAILURE in issues_by_target:
         log.name('bugwarrior').critical("A worker failed.  Aborting.")
         raise RuntimeError('Worker failure')
+
     return sum(issues_by_target, [])


### PR DESCRIPTION
This requires the changes from ralphbean/taskw#31

The 'experimental/shellout' stuff still isn't ready for prime-time.  @kostajh's advice to use the hash of the link as a UDA for the primary key (instead of the description) is the right way to go, I think.  It will just take some more time to sort it out.
