### PR TITLE
Allow one to specify tags using templates, too.

### DIFF
--- a/docs/source/common_configuration.rst
+++ b/docs/source/common_configuration.rst
@@ -41,9 +41,12 @@ service example:
   that are not assigned to anybody.
 * ``default_priority``: Assign this priority ('L', 'M', or 'H') to
   newly-imported issues.
-* ``add_tags``: Add these tags to newly-imported issues.
 * ``<fieldname>_template``: Generate the value of a field using a template.
   See `Field Templates`_ for more details.
+* ``add_tags``: A comma-separated list of tags to add to an issue.  In most
+  cases, this will just be a series of strings, but you can also make
+  tags by defining one of your tags following the example set in
+  `Field Templates`_.
 
 .. _field_templates:
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -13,7 +13,9 @@ class TestTemplates(ServiceTest):
             'priority': 'H',
         }
 
-    def get_issue(self, templates, issue=None, description=None):
+    def get_issue(
+        self, templates=None, issue=None, description=None, add_tags=None
+    ):
         templates = {} if templates is None else templates
         origin = {
             'annotation_length': 100,  # Arbitrary
@@ -21,7 +23,7 @@ class TestTemplates(ServiceTest):
             'description_length': 100,  # Arbitrary
             'templates': templates,
             'shorten': False,  # Arbitrary
-            'add_tags': [],  # Arbitrary
+            'add_tags': add_tags if add_tags else [],
         }
 
         issue = Issue({}, origin)
@@ -78,6 +80,18 @@ class TestTemplates(ServiceTest):
             'description': self.arbitrary_default_description,
             'project': 'wat_%s' % self.arbitrary_issue['project'].upper(),
             'tags': [],
+        })
+
+        self.assertEqual(record, expected_record)
+
+    def test_tag_templates(self):
+        issue = self.get_issue(add_tags=['one', '{{ project }}'])
+
+        record = issue.get_taskwarrior_record()
+        expected_record = self.arbitrary_issue.copy()
+        expected_record.update({
+            'description': self.arbitrary_default_description,
+            'tags': ['one', self.arbitrary_issue['project']]
         })
 
         self.assertEqual(record, expected_record)


### PR DESCRIPTION
I'm (hoping to) add this feature so I can accomplish a weird goal of mine --

For JIRA issues, I would much rather have the project name set to 'CMG' (my employer), but include a tag indicating which JIRA project this came from (rather than the project name indicating the JIRA project).  Setting the project name directly is accomplishable using my earlier PR, but creating tags based upon the contents of the issue was previously impossible.

I plan to later add a section to the documentation named something like "Cookbook" to cover how you might configure bugwarrior to handle things like this.

Cheers!
