### PR TITLE
Further limit which VersionOne tasks are returned to only actionable items.

### DIFF
--- a/bugwarrior/services/versionone.py
+++ b/bugwarrior/services/versionone.py
@@ -204,7 +204,11 @@ class VersionOneService(IssueService):
     def get_assignments(self, username):
         meta = self.get_meta()
         where = {
-            'IsCompleted': False
+            'IsClosed': False,
+            'IsCompleted': False,
+            'IsDead': False,
+            'IsDeleted': False,
+            'IsInactive': False,
         }
         if self.timebox_name:
             where['Parent.Timebox.Name'] = self.timebox_name


### PR DESCRIPTION
Apparently that `IsCompleted` might be `False` isn't quite sufficient -- each of these statuses appears to be independent, and each is enough to make a task non-actionable.
