### PR TITLE
Attempt to extract priorities from redmine responses appropriately.

### DIFF
--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -92,7 +92,7 @@ class RedMineIssue(Issue):
     def get_default_description(self):
         return self.build_default_description(
             title=self.record['subject'],
-            url=self.get_processed_url(self.record['url']),
+            url=self.get_processed_url(self.get_issue_url()),
             number=self.record['id'],
             cls='issue',
         )

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -18,11 +18,36 @@ class TestRedmineIssue(ServiceTest):
     def test_to_taskwarrior(self):
         arbitrary_url = 'http://lkjlj.com'
         arbitrary_issue = {
-            'project': {
-                'name': 'Something',
+            "assigned_to": {
+                "id": 35546,
+                "name": "Adam Coddington"
             },
-            'subject': 'The Subject',
-            'id': 'The ID',
+            "author": {
+                "id": 35546,
+                "name": "Adam Coddington"
+            },
+            "created_on": "2014-11-19T16:40:29Z",
+            "description": "This is a test issue.",
+            "done_ratio": 0,
+            "id": 363901,
+            "priority": {
+                "id": 4,
+                "name": "Normal"
+            },
+            "project": {
+                "id": 27375,
+                "name": "Bugwarrior"
+            },
+            "status": {
+                "id": 1,
+                "name": "New"
+            },
+            "subject": "Biscuits",
+            "tracker": {
+                "id": 4,
+                "name": "Task"
+            },
+            "updated_on": "2014-11-19T16:40:29Z"
         }
 
         issue = self.service.get_issue_for_record(arbitrary_issue)


### PR DESCRIPTION
This should hopefully fix #154.

This makes the redmine service override the base service's `get_priority`
method to extract the priority correctly from the response, and also adds a
`PRIORITY_MAP` to map the default ids onto taskwarrior priorities.

Untested!  I don't have a redmine instance still to mess with, so any critical
feedback is much appreciated.
