### PR TITLE
trac: use CSV downloads if TracXmlRpc is not available

### DIFF
--- a/bugwarrior/docs/services/trac.rst
+++ b/bugwarrior/docs/services/trac.rst
@@ -13,13 +13,16 @@ Here's an example of an Trac target::
     service = trac
     trac.base_uri = fedorahosted.org/moksha
     trac.scheme = https
+
+By default, this service uses the XML-RPC Trac plugin, which must be installed
+on the Trac instance.  If this is not available, the service can use Trac's
+built-in CSV support, but in this mode it cannot add annotations based on
+ticket comments.  To enable this mode, add ``trac.no_xmlrpc = true``.
+
+If your trac instance requires authentication to perform the query, add::
+
     trac.username = ralph
     trac.password = OMG_LULZ
-
-.. note::
-
-   Your Trac installation must have the XML-RPC plugin enabled
-   for Bugwarrior to work.
 
 The above example is the minimum required to import issues from
 Trac.  You can also feel free to use any of the

--- a/bugwarrior/services/trac.py
+++ b/bugwarrior/services/trac.py
@@ -1,4 +1,7 @@
 import offtrac
+import csv
+import cStringIO as StringIO
+import requests
 from twiggy import log
 import urllib
 
@@ -50,7 +53,7 @@ class TracIssue(Issue):
         return self.build_default_description(
             title=self.record['summary'],
             url=self.get_processed_url(self.record['url']),
-            number=self.record['number'],
+            number=self.record['id'],
             cls='issue'
         )
 
@@ -69,20 +72,26 @@ class TracService(IssueService):
         super(TracService, self).__init__(*args, **kw)
         base_uri = self.config_get('base_uri')
         scheme = self.config_get_default('scheme', default='https')
-        username = self.config_get('username')
-        password = self.config_get('password')
-        if not password or password.startswith('@oracle:'):
-            password = get_service_password(
-                self.get_keyring_service(self.config, self.target),
-                username, oracle=password,
-                interactive=self.config.interactive
-            )
+        username = self.config_get_default('username', default=None)
+        if username:
+            password = self.config_get('password')
+            if not password or password.startswith('@oracle:'):
+                password = get_service_password(
+                    self.get_keyring_service(self.config, self.target),
+                    username, oracle=password,
+                    interactive=self.config.interactive
+                )
 
-        auth = '%s:%s' % (username, password)
-        uri = '%s://%s@%s/login/xmlrpc' % (
-            scheme, urllib.quote_plus(auth), base_uri
-        )
-        self.trac = offtrac.TracServer(uri)
+            auth = urllib.quote_plus('%s:%s@' % (username, password))
+        else:
+            auth = ''
+        if self.config_get_default('no_xmlrpc', default=False):
+            uri = '%s://%s%s/' % (scheme, auth, base_uri)
+            self.uri = uri
+            self.trac = None
+        else:
+            uri = '%s://%s%s/login/xmlrpc' % (scheme, auth, base_uri)
+            self.trac = offtrac.TracServer(uri)
 
     @classmethod
     def get_keyring_service(cls, config, section):
@@ -92,14 +101,18 @@ class TracService(IssueService):
 
     @classmethod
     def validate_config(cls, config, target):
-        for option in ['trac.username', 'trac.password', 'trac.base_uri']:
-            if not config.has_option(target, option):
-                die("[%s] has no '%s'" % (target, option))
+        if not config.has_option(target, 'trac.base_uri'):
+            die("[%s] has no 'base_uri'" % target)
+        elif '://' in config.get(target, 'trac.base_uri'):
+            die("[%s] do not include scheme in 'base_uri'" % target)
 
         IssueService.validate_config(config, target)
 
     def annotations(self, tag, issue, issue_obj):
         annotations = []
+        # without offtrac, we can't get issue comments
+        if self.trac is None:
+            return annotations
         changelog = self.trac.server.ticket.changeLog(issue['number'])
         for time, author, field, oldvalue, newvalue, permament in changelog:
             if field == 'comment':
@@ -114,15 +127,33 @@ class TracService(IssueService):
 
     def issues(self):
         base_url = "https://" + self.config.get(self.target, 'trac.base_uri')
-        tickets = self.trac.query_tickets('status!=closed&max=0')
-        tickets = map(self.trac.get_ticket, tickets)
-        issues = [(self.target, ticket[3]) for ticket in tickets]
-        log.name(self.target).debug(" Found {0} total.", len(issues))
+        if self.trac:
+            tickets = self.trac.query_tickets('status!=closed&max=0')
+            tickets = map(self.trac.get_ticket, tickets)
+            issues = [(self.target, ticket[3]) for ticket in tickets]
+            for i in range(len(issues)):
+                issues[i][1]['url'] = "%s/ticket/%i" % (base_url, tickets[i][0])
+                issues[i][1]['number'] = tickets[i][0]
+        else:
+            resp = requests.get(
+                self.uri + 'query',
+                params={
+                    'status': '!closed',
+                    'max': '0',
+                    'format': 'csv',
+                    'col': ['id', 'summary', 'owner', 'priority'],
+                })
+            if resp.status_code != 200:
+                raise RuntimeError("Trac responded with %s" % resp)
+            # strip Trac's bogus BOM
+            text = resp.text[1:].lstrip(u'\ufeff')
+            tickets = list(csv.DictReader(StringIO.StringIO(text.encode('utf-8'))))
+            issues = [(self.target, ticket) for ticket in tickets]
+            for i in range(len(issues)):
+                issues[i][1]['url'] = "%s/ticket/%s" % (base_url, tickets[i]['id'])
+                issues[i][1]['number'] = int(tickets[i]['id'])
 
-        # Build a url for each issue
-        for i in range(len(issues)):
-            issues[i][1]['url'] = "%s/ticket/%i" % (base_url, tickets[i][0])
-            issues[i][1]['number'] = tickets[i][0]
+        log.name(self.target).debug(" Found {0} total.", len(issues))
 
         issues = filter(self.include, issues)
         log.name(self.target).debug(" Pruned down to {0}", len(issues))


### PR DESCRIPTION
The trac instance I'm using doesn't have the plugin.  It also doesn't require auth to do a simple query.

A few other options I could try:
- automatically fall back if offtrac fails (with a warning)
- create a separate `trac-csv` service
