### PR TITLE
Better handling for due dates for VersionOne tasks.

### DIFF
--- a/bugwarrior/docs/services/versionone.rst
+++ b/bugwarrior/docs/services/versionone.rst
@@ -52,6 +52,15 @@ example, to add imported tasks to the project 'important_project'::
 
     versionone.project_name = important_project
 
+Set the Timezone Used for Due Dates
++++++++++++++++++++++++++++++++++++
+
+You can configure the timezone used for setting your tasks' due dates
+by setting the ``versionone.timezone`` option.  By default, your local
+timezone will be used.  For example::
+
+    versionone.timezone = America/Los_Angeles
+
 Provided UDA Fields
 -------------------
 

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -3,6 +3,7 @@ import multiprocessing
 import time
 
 from dateutil.parser import parse as parse_date
+from dateutil.tz import tzlocal
 from jinja2 import Template
 import pytz
 import six
@@ -17,6 +18,10 @@ from bugwarrior.db import MARKUP, URLShortener, ABORT_PROCESSING
 # Sentinels for process completion status
 SERVICE_FINISHED_OK = 0
 SERVICE_FINISHED_ERROR = 1
+
+# Used by `parse_date` as a timezone when you would like a naive
+# date string to be parsed as if it were in your local timezone
+LOCAL_TIMEZONE = 'LOCAL_TIMEZONE'
 
 
 class IssueService(object):
@@ -328,7 +333,11 @@ class Issue(object):
         if date:
             date = parse_date(date)
             if not date.tzinfo:
-                date = date.replace(tzinfo=pytz.timezone(timezone))
+                if timezone == LOCAL_TIMEZONE:
+                    tzinfo = tzlocal()
+                else:
+                    tzinfo = pytz.timezone(timezone)
+                date = date.replace(tzinfo=tzinfo)
             return date
         return None
 

--- a/bugwarrior/services/versionone.py
+++ b/bugwarrior/services/versionone.py
@@ -1,7 +1,7 @@
 from v1pysdk import V1Meta
 from six.moves.urllib import parse
 
-from bugwarrior.services import IssueService, Issue
+from bugwarrior.services import IssueService, Issue, LOCAL_TIMEZONE
 from bugwarrior.config import die, get_service_password
 
 
@@ -108,7 +108,10 @@ class VersionOneIssue(Issue):
         return {
             'project': self.extra['project'],
             'priority': self.origin['default_priority'],
-            'due': self.parse_date(self.record['timebox']['EndDate']),
+            'due': self.parse_date(
+                self.record['timebox']['EndDate'],
+                self.origin['timezone']
+            ),
 
             self.TASK_NAME: self.record['task']['Name'],
             self.TASK_DESCRIPTION: self.record['task']['Description'],
@@ -190,6 +193,10 @@ class VersionOneService(IssueService):
                 interactive=self.config.interactive
             )
 
+        self.timezone = self.config_get_default(
+            'timezone',
+            default=LOCAL_TIMEZONE
+        )
         self.project = self.config_get_default('project_name', default='')
         self.timebox_name = self.config_get_default('timebox_name')
 
@@ -204,6 +211,11 @@ class VersionOneService(IssueService):
             parsed_address.netloc,
             parsed_address.path
         )
+
+    def get_service_metadata(self):
+        return {
+            'timezone': self.timezone
+        }
 
     @classmethod
     def validate_config(cls, config, target):


### PR DESCRIPTION
- Adds functionality to `parse_date` allowing one to specify that you'd
  like a parsed naive date string to be marked as being in the local
  timezone.
- Assumes your local timezone in situations in which you have not
  specified one.
- Adds functionality for specifying an explicit timezone name for
  imported VersionOne tasks.
