### PR TITLE
Add an option to disable SSL verification for Jira

### DIFF
--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -132,6 +132,7 @@ class JiraService(IssueService):
             options={
                 'server': self.config_get('base_uri'),
                 'rest_api_version': 'latest',
+                'verify': self.config_get_default('verify_ssl', default=None, to_type=asbool),
             },
             basic_auth=(self.username, password)
         )


### PR DESCRIPTION
My connections were getting rejected (go figure). This fixed it.
   jira.verify_ssl = False

The default behaviour remains unchanged, so this shouldn't break anything for
anyone whose SSL was already working, or who was connecting over HTTP.