### PR TITLE
Add uda export command

### DIFF
--- a/bugwarrior/__init__.py
+++ b/bugwarrior/__init__.py
@@ -1,7 +1,8 @@
 #
-from bugwarrior.command import pull, vault
+from bugwarrior.command import pull, vault, uda
 
 __all__ = [
     'pull',
     'vault',
+    'uda',
 ]

--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -13,7 +13,10 @@ from taskw.warrior import TaskWarriorBase
 
 from bugwarrior.config import get_taskrc_path, load_config
 from bugwarrior.services import aggregate_issues, SERVICES
-from bugwarrior.db import synchronize
+from bugwarrior.db import (
+    get_defined_udas_as_strings,
+    synchronize,
+)
 
 
 # We overwrite 'list' further down.
@@ -120,3 +123,10 @@ def set(target, username):
 
     keyring.set_password(target, username, getpass.getpass())
     print "Password set for %s, %s" % (target, username)
+
+
+@click.command()
+def uda():
+    conf = load_config()
+    for uda in get_defined_udas_as_strings(conf):
+        print uda

--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -128,5 +128,7 @@ def set(target, username):
 @click.command()
 def uda():
     conf = load_config()
+    print "# Bugwarrior UDAs"
     for uda in get_defined_udas_as_strings(conf):
         print uda
+    print "# END Bugwarrior UDAs"

--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -300,11 +300,10 @@ def synchronize(issue_generator, conf, dry_run=False):
 
     if uda_list:
         log.name('bugwarrior').info(
-            'Service-defined UDAs (you can optionally add these to your '
-            '~/.taskrc for use in reports):'
+            'Service-defined UDAs exist: you can optionally use the '
+            '`bugwarrior-uda` command to export a list of UDAs you can '
+            'add to your ~/.taskrc file.'
         )
-        for uda in convert_override_args_to_taskrc_settings(uda_list):
-            log.name('bugwarrior').info(uda)
 
     static_fields = static_fields_default = ['priority']
     if conf.has_option('general', 'static_fields'):
@@ -453,6 +452,15 @@ def build_key_list(targets):
     for target in targets:
         keys[target] = SERVICES[target].ISSUE_CLASS.UNIQUE_KEY
     return keys
+
+
+def get_defined_udas_as_strings(conf):
+    targets = [t.strip() for t in conf.get('general', 'targets').split(',')]
+    services = set([conf.get(target, 'service') for target in targets])
+    uda_list = build_uda_config_overrides(services)
+
+    for uda in convert_override_args_to_taskrc_settings(uda_list):
+        yield uda
 
 
 def build_uda_config_overrides(targets):

--- a/bugwarrior/docs/using.rst
+++ b/bugwarrior/docs/using.rst
@@ -14,3 +14,30 @@ adding the following to your crontab::
 
     DISPLAY=:0
     */15 * * * *  /usr/bin/bugwarrior-pull
+
+Exporting a list of UDAs
+------------------------
+
+Most services define a set of UDAs in which bugwarrior store extra information
+about the incoming ticket.  Usually, this includes things like the title
+of the ticket and its URL, but some services provide an extensive amount of
+metadata.  See each service's documentation for more information.
+
+For using this data in reports, it is recommended that you add these UDA
+definitions to your ``~/.taskrc`` file.  You can generate your list of
+UDA definitions by running the following command::
+
+    bugwarrior-uda
+
+You can add those lines verbatim to your ``~/.taskrc`` file if you would like
+Taskwarrior to know the human-readable name and data type for the defined
+UDAs.
+
+.. note::
+
+   Not adding those lines to your ``~/.taskrc`` file will have no negative
+   effects aside from Taskwarrior not knowing the human-readable name for the
+   field, but depending on what version of Taskwarrior you are using, it
+   may prevent you from changing the values of those fields or using them
+   in filter expressions.
+

--- a/setup.py
+++ b/setup.py
@@ -55,5 +55,6 @@ setup(name='bugwarrior',
       [console_scripts]
       bugwarrior-pull = bugwarrior:pull
       bugwarrior-vault = bugwarrior:vault
+      bugwarrior-uda = bugwarrior:uda
       """,
       )


### PR DESCRIPTION
Currently these are printed to the console during the sync operation, but they're prefixed with logging metadata and are likely to be missed or misused.

This adds a single command that can be ran at any time to generate the current list of active UDAs