### PR TITLE
config: add --flavor option

### DIFF
--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -97,19 +97,19 @@ def die(msg):
     sys.exit(1)
 
 
-def validate_config(config):
-    if not config.has_section('general'):
-        die("No [general] section found.")
+def validate_config(config, main_section):
+    if not config.has_section(main_section):
+        die("No [%s] section found." % main_section)
 
     twiggy.quickSetup(
-        name2level(config.get('general', 'log.level')),
-        config.get('general', 'log.file')
+        name2level(config.get(main_section, 'log.level')),
+        config.get(main_section, 'log.file')
     )
 
-    if not config.has_option('general', 'targets'):
-        die("No targets= item in [general] found.")
+    if not config.has_option(main_section, 'targets'):
+        die("No targets= item in [%s] found." % main_section)
 
-    targets = config.get('general', 'targets')
+    targets = config.get(main_section, 'targets')
     targets = [t.strip() for t in targets.split(",")]
 
     for target in targets:
@@ -129,7 +129,7 @@ def validate_config(config):
         SERVICES[service].validate_config(config, target)
 
 
-def load_config():
+def load_config(main_section):
     config = ConfigParser({'log.level': "DEBUG", 'log.file': None})
     config.readfp(
         codecs.open(
@@ -139,15 +139,15 @@ def load_config():
         )
     )
     config.interactive = False  # TODO: make this a command-line option
-    validate_config(config)
+    validate_config(config, main_section)
 
     return config
 
 
-def get_taskrc_path(conf):
+def get_taskrc_path(conf, main_section):
     path = '~/.taskrc'
-    if conf.has_option('general', 'taskrc'):
-        path = conf.get('general', 'taskrc')
+    if conf.has_option(main_section, 'taskrc'):
+        path = conf.get(main_section, 'taskrc')
     return os.path.normpath(
         os.path.expanduser(path)
     )

--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -285,7 +285,7 @@ def run_hooks(conf, name):
                     raise RuntimeError(msg)
 
 
-def synchronize(issue_generator, conf, dry_run=False):
+def synchronize(issue_generator, conf, main_section, dry_run=False):
     def _bool_option(section, option, default):
         try:
             return section in conf.sections() and \
@@ -293,7 +293,7 @@ def synchronize(issue_generator, conf, dry_run=False):
         except NoOptionError:
             return default
 
-    targets = [t.strip() for t in conf.get('general', 'targets').split(',')]
+    targets = [t.strip() for t in conf.get(main_section, 'targets').split(',')]
     services = set([conf.get(target, 'service') for target in targets])
     key_list = build_key_list(services)
     uda_list = build_uda_config_overrides(services)
@@ -306,8 +306,8 @@ def synchronize(issue_generator, conf, dry_run=False):
         )
 
     static_fields = static_fields_default = ['priority']
-    if conf.has_option('general', 'static_fields'):
-        static_fields = conf.get('general', 'static_fields').split(',')
+    if conf.has_option(main_section, 'static_fields'):
+        static_fields = conf.get(main_section, 'static_fields').split(',')
 
     # Before running CRUD operations, call the pre_import hook(s).
     run_hooks(conf, 'pre_import')
@@ -320,7 +320,7 @@ def synchronize(issue_generator, conf, dry_run=False):
         marshal=True,
     )
 
-    legacy_matching = _bool_option('general', 'legacy_matching', 'True')
+    legacy_matching = _bool_option(main_section, 'legacy_matching', 'True')
 
     issue_updates = {
         'new': [],
@@ -457,8 +457,8 @@ def build_key_list(targets):
     return keys
 
 
-def get_defined_udas_as_strings(conf):
-    targets = [t.strip() for t in conf.get('general', 'targets').split(',')]
+def get_defined_udas_as_strings(conf, main_section):
+    targets = [t.strip() for t in conf.get(main_section, 'targets').split(',')]
     services = set([conf.get(target, 'service') for target in targets])
     uda_list = build_uda_config_overrides(services)
 

--- a/bugwarrior/docs/common_configuration.rst
+++ b/bugwarrior/docs/common_configuration.rst
@@ -26,6 +26,11 @@ Optional options include:
 * ``annotation_length``: Import maximally this number of characters
   of incoming annotations.  Default: 45.
 
+In addition to the ``[general]`` section, sections may be named
+``[flavor.myflavor]`` and may be selected using the ``--flavor`` option to
+``bugwarrior-pull``. This section will then be used rather than the
+``[general]`` section.
+
 A more-detailed example configuration can be found at :ref:`example_configuration`.
 
 .. _common_configuration_options:

--- a/tests/base.py
+++ b/tests/base.py
@@ -40,6 +40,6 @@ class ServiceTest(unittest2.TestCase):
         config.get = mock.Mock(side_effect=get_option)
         config.getint = mock.Mock(side_effect=get_int)
 
-        service = service(config, section)
+        service = service(config, 'general', section)
 
         return service


### PR DESCRIPTION
Flavors allow bugwarrior to be used to populate multiple taskrc lists.
For example, one might have a task list for work and personal use
separately.

---
Fixes #189.