### PR TITLE
gitlab: remove 'username' configuration

### DIFF
--- a/bugwarrior/docs/services/gitlab.rst
+++ b/bugwarrior/docs/services/gitlab.rst
@@ -11,7 +11,6 @@ Here's an example of a Gitlab target::
 
     [my_issue_tracker]
     service = gitlab
-    gitlab.username = ralphbean
     gitlab.login = ralphbean
     gitlab.token = OMG_LULZ
 
@@ -20,13 +19,7 @@ Gitlab.  You can also feel free to use any of the
 configuration options described in :ref:`common_configuration_options`
 or described in `Service Features`_ below.
 
-Note that both ``gitlab.username`` and ``gitlab.login`` are required and can be
-set to different values.  ``gitlab.login`` is used to specify what account
-bugwarrior should use to login to gitlab.  ``gitlab.username`` indicates which
-repositories should be scraped.  For instance, I always have ``gitlab.login``
-set to ralphbean (my account).  But I have some targets with
-``gitlab.username`` pointed at organizations or other users to watch issues
-there. The ``gitlab.token`` is your private API token.
+The ``gitlab.token`` is your private API token.
 
 Service Features
 ----------------

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -155,7 +155,6 @@ class GitlabService(IssueService):
         self.login = self.config_get('login')
         token = self.config_get('token')
         if not token or token.startswith('@oracle:'):
-            username = self.config_get('username')
             token = get_service_password(
                 self.get_keyring_service(self.config, self.target),
                 self.login, oracle=password,
@@ -190,8 +189,7 @@ class GitlabService(IssueService):
     @classmethod
     def get_keyring_service(cls, config, section):
         login = config.get(section, cls._get_key('login'))
-        username = config.get(section, cls._get_key('username'))
-        return "gitlab://%s@%s/%s" % (login, host, username)
+        return "gitlab://%s@%s" % (login, host)
 
     def get_service_metadata(self):
         return {
@@ -256,8 +254,6 @@ class GitlabService(IssueService):
         return issues
 
     def issues(self):
-        user = self.config.get(self.target, 'gitlab.username')
-
         tmpl = 'https://{host}/api/v3/projects'
         all_repos = self._fetch(tmpl)
         repos = filter(self.filter_repos, all_repos)
@@ -322,9 +318,6 @@ class GitlabService(IssueService):
 
         if not config.has_option(target, 'gitlab.login'):
             die("[%s] has no 'gitlab.login'" % target)
-
-        if not config.has_option(target, 'gitlab.username'):
-            die("[%s] has no 'gitlab.username'" % target)
 
         if not config.has_option(target, 'gitlab.token'):
             die("[%s] has no 'gitlab.token'" % target)

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -13,7 +13,6 @@ class TestGitlabIssue(ServiceTest):
         'gitlab.host': 'gitlab.example.com',
         'gitlab.login': 'arbitrary_login',
         'gitlab.token': 'arbitrary_token',
-        'gitlab.username': 'arbitrary_username',
     }
     arbitrary_created = (
         datetime.datetime.utcnow() - datetime.timedelta(hours=1)


### PR DESCRIPTION
It isn't used for anything. Instead, gitlab's queries return all
repositories the user has access to.

---
Turns out it isn't used for anything in the code other than as a suffix to the `gitlab://` keyring URL. Also, the API doesn't support querying based on it anyways.