### PR TITLE
Defer importing services until they are needed.

### DIFF
--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -11,6 +11,7 @@ from twiggy import log
 
 from taskw.task import Task
 
+from bugwarrior.utils import DeferredImportingDict
 from bugwarrior.config import asbool
 from bugwarrior.db import MARKUP, URLShortener, ABORT_PROCESSING
 
@@ -22,6 +23,26 @@ SERVICE_FINISHED_ERROR = 1
 # Used by `parse_date` as a timezone when you would like a naive
 # date string to be parsed as if it were in your local timezone
 LOCAL_TIMEZONE = 'LOCAL_TIMEZONE'
+
+# Constant dict to be used all around town.
+# It will defer actually importing a service until someone tries to access it
+# in the dict.  This should help expose odd ImportErrors in a more obvious way
+# for end users.  See https://github.com/ralphbean/bugwarrior/issues/132
+SERVICES = DeferredImportingDict({
+    'github':        'bugwarrior.services.github:GithubService',
+    'gitlab':        'bugwarrior.services.gitlab:GitlabService',
+    'bitbucket':     'bugwarrior.services.bitbucket:BitbucketService',
+    'trac':          'bugwarrior.services.trac:TracService',
+    'bugzilla':      'bugwarrior.services.bz:BugzillaService',
+    'teamlab':       'bugwarrior.services.teamlab:TeamLabService',
+    'redmine':       'bugwarrior.services.redmine:RedMineService',
+    'activecollab2': 'bugwarrior.services.activecollab2:ActiveCollab2Service',
+    'activecollab':  'bugwarrior.services.activecollab:ActiveCollabService',
+    'jira':          'bugwarrior.services.jira:JiraService',
+    'megaplan':      'bugwarrior.services.megaplan:megaplanService',
+    'phabricator':   'bugwarrior.services.phabricator:phabricatorService',
+    'versionone':    'bugwarrior.services.versionone:versiononeService',
+})
 
 
 class IssueService(object):
@@ -542,60 +563,3 @@ def aggregate_issues(conf, main_section):
         yield issue
 
     log.name('bugwarrior').info("Done aggregating remote issues.")
-
-
-from .bitbucket import BitbucketService
-from .bz import BugzillaService
-from .github import GithubService
-from .gitlab import GitlabService
-from .teamlab import TeamLabService
-from .redmine import RedMineService
-from .trac import TracService
-
-
-# Constant dict to be used all around town.
-SERVICES = {
-    'github': GithubService,
-    'gitlab': GitlabService,
-    'bitbucket': BitbucketService,
-    'trac': TracService,
-    'bugzilla': BugzillaService,
-    'teamlab': TeamLabService,
-    'redmine': RedMineService,
-}
-
-try:
-    from .activecollab2 import ActiveCollab2Service
-    SERVICES['activecollab2'] = ActiveCollab2Service
-except ImportError:
-    pass
-
-try:
-    from .activecollab import ActiveCollabService
-    SERVICES['activecollab'] = ActiveCollabService
-except ImportError:
-    pass
-
-try:
-    from .jira import JiraService
-    SERVICES['jira'] = JiraService
-except ImportError:
-    pass
-
-try:
-    from .mplan import MegaplanService
-    SERVICES['megaplan'] = MegaplanService
-except ImportError:
-    pass
-
-try:
-    from .phab import PhabricatorService
-    SERVICES['phabricator'] = PhabricatorService
-except ImportError as e:
-    pass
-
-try:
-    from .versionone import VersionOneService
-    SERVICES['versionone'] = VersionOneService
-except ImportError as e:
-    pass

--- a/bugwarrior/utils.py
+++ b/bugwarrior/utils.py
@@ -1,0 +1,38 @@
+
+
+class DeferredImportingDict(object):
+    def __init__(self, d):
+        self._dict = d
+        self._cache = {}
+
+    def keys(self):
+        return self._dict.keys()
+
+    def __contains__(self, key):
+        return key in self._dict
+
+    def __getitem__(self, key):
+        if not key in self:
+            raise KeyError(key)
+
+        if not key in self._cache:
+            self._cache[key] = self._import(self._dict[key])
+
+        return self._cache[key]
+
+    @classmethod
+    def _import(cls, location):
+        """ Given the string 'module1.module2:Object', returns Object. """
+        mod_name, obj_name = location = location.strip().split(':')
+        tokens = mod_name.split('.')
+
+        fromlist = '[]'
+        if len(tokens) > 1:
+            fromlist = '.'.join(tokens[:-1])
+
+        module = __import__(mod_name, fromlist=fromlist)
+
+        try:
+            return getattr(module, obj_name)
+        except AttributeError:
+            raise ImportError("%r not found in %r" % (obj_name, mod_name))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+from nose.tools import raises
+
 import unittest2
 
 import bugwarrior.utils
@@ -7,6 +9,10 @@ class UtilsTest(unittest2.TestCase):
     def setUp(self):
         self.d = bugwarrior.utils.DeferredImportingDict({
             'chain': 'itertools:chain',
+        })
+        self.fail = bugwarrior.utils.DeferredImportingDict({
+            'dne1': 'itertools:DNE',
+            'dne2': 'notarealmodule:something',
         })
 
     def test_importing_dict_access_success(self):
@@ -22,3 +28,11 @@ class UtilsTest(unittest2.TestCase):
 
     def test_importing_dict_keys(self):
         self.assertEquals(set(self.d.keys()), set(['chain']))
+
+    @raises(ImportError)
+    def test_importing_unimportable_object(self):
+        self.fail['dne1']
+
+    @raises(ImportError)
+    def test_importing_unimportable_module(self):
+        self.fail['dne2']

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,24 @@
+import unittest2
+
+import bugwarrior.utils
+
+
+class UtilsTest(unittest2.TestCase):
+    def setUp(self):
+        self.d = bugwarrior.utils.DeferredImportingDict({
+            'chain': 'itertools:chain',
+        })
+
+    def test_importing_dict_access_success(self):
+        item = self.d['chain']
+        import itertools
+        self.assertEquals(item, itertools.chain)
+
+    def test_importing_dict_contains_success(self):
+        self.assertEquals('chain' in self.d, True)
+
+    def test_importing_dict_contains_failure(self):
+        self.assertEquals('nothing' in self.d, False)
+
+    def test_importing_dict_keys(self):
+        self.assertEquals(set(self.d.keys()), set(['chain']))


### PR DESCRIPTION
This should let us expose odd ImportErrors with dependencies in a more
natural way to users (and make the dependencies of the services somewhat
more obvious -- those deps are documented now, but this should help
too).

More informative tracebacks here should fix #132.