### PR TITLE
Fixup notification error with bad encoding

### DIFF
--- a/bugwarrior/notifications.py
+++ b/bugwarrior/notifications.py
@@ -118,6 +118,6 @@ def send_notification(issue, op, conf):
                 op, issue['description'].encode("utf-8"))
             metadata = _get_metadata(issue)
             if metadata is not None:
-                message += metadata
+                message += metadata.encode("utf-8")
 
         Notify.Notification.new("Bugwarrior", message, logo_path).show()


### PR DESCRIPTION
There were a bug when using notification if task has got accentuated caracters:
```
CRITICAL:command:oh noes
TRACE Traceback (most recent call last):
TRACE   File "/home/pferlet/.local/lib/python2.7/site-packages/bugwarrior/command.py", line 62, in pull
TRACE     synchronize(issue_generator, config, main_section, dry_run)
TRACE   File "/home/pferlet/.local/lib/python2.7/site-packages/bugwarrior/db.py", line 382, in synchronize
TRACE     send_notification(issue, 'Created', conf)
TRACE   File "/home/pferlet/.local/lib/python2.7/site-packages/bugwarrior/notifications.py", line 121, in send_notification
TRACE     message += metadata
TRACE UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 50: ordinal not in range(128)
```
This commit fixes the problem