### PR TITLE
Alter default JIRA query to handle situations in which instances do not use the column names we are expecting.

### DIFF
--- a/bugwarrior/docs/services/jira.rst
+++ b/bugwarrior/docs/services/jira.rst
@@ -37,10 +37,13 @@ Service Features
 Specify the Query to Use for Gathering Issues
 +++++++++++++++++++++++++++++++++++++++++++++
 
-You can specify the query used for gathering issues by using the
-``jira.query`` parameter.  For example, to select issues assigned to
-'ralph' having a status that is not 'closed' and is not 'resolved', you
-could add the following configuration option::
+By default, the JIRA plugin will include any issues that are assigned to you
+but do not yet have a resolution set, but you can fine-tune the query used
+for gather issues by setting the ``jira.query`` parameter.
+
+For example, to select issues assigned to 'ralph' having a status that is
+not 'closed' and is not 'resolved', you could add the following
+configuration option::
 
     jira.query = assignee = ralph and status != closed and status != resolved
 

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -126,7 +126,7 @@ class JiraService(IssueService):
             )
 
         default_query = 'assignee=' + self.username + \
-            ' AND status != closed and status != resolved'
+            ' AND resolution is null'
         self.query = self.config_get_default('query', default_query)
         self.jira = JIRA(
             options={


### PR DESCRIPTION
This will almost certainly be equivalent to the original query for most users; I just happen to have switched recently to a company that used non-standard ticket status names, and knew enough about the JIRA API to know that the proper column to check is `resolution`.

Let me know if you have any questions, sir!