### PR TITLE
Phabricator service: Adding option to filter on users and projects

### DIFF
--- a/bugwarrior/docs/services/phabricator.rst
+++ b/bugwarrior/docs/services/phabricator.rst
@@ -22,12 +22,40 @@ Here's an example of an Phabricator target::
 .. note::
 
    Although this may not look like enough information for us
-   to gather information from Phabricator, 
+   to gather information from Phabricator,
    but credentials will be gathered from the user's ``~/.arcrc``.
 
 The above example is the minimum required to import issues from
 Phabricator.  You can also feel free to use any of the
 configuration options described in :ref:`common_configuration_options`.
+
+Service Features
+----------------
+
+If you have dozens of users and projects, you might want to
+pull the tasks and code review requests only for the specific ones.
+
+If you want to show only the tasks related to a specific user,
+you just need to add its PHID to the service configuration like this::
+
+    phabricator.user_phids = PHID-USER-ab12c3defghi45jkl678
+
+If you want to show only the tasks and diffs related to a specific project or a repository,
+just add their PHIDs to the service configuration::
+
+    phabricator.project_phids = PHID-PROJ-ab12c3defghi45jkl678,PHID-REPO-ab12c3defghi45jkl678
+
+Both ``phabricator.user_phids`` and ``phabricator.project_phids`` accept
+a comma-separated (no spaces) list of PHIDs.
+
+If you specify both, you will get tasks and diffs that match one **or** the other.
+
+If you do not know PHID of a user, project or repository,
+you can find it out by querying Phabricator Conduit
+(``https://YOUR_PHABRICATOR_HOST/conduit/``) --
+the methods which return the needed info are ``user.query``, ``project.query``
+and ``repository.query`` respectively.
+
 
 Provided UDA Fields
 -------------------

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -40,7 +40,7 @@ SERVICES = DeferredImportingDict({
     'activecollab':  'bugwarrior.services.activecollab:ActiveCollabService',
     'jira':          'bugwarrior.services.jira:JiraService',
     'megaplan':      'bugwarrior.services.megaplan:MegaplanService',
-    'phabricator':   'bugwarrior.services.phabricator:PhabricatorService',
+    'phabricator':   'bugwarrior.services.phab:PhabricatorService',
     'versionone':    'bugwarrior.services.versionone:VersionOneService',
 })
 

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -88,19 +88,27 @@ class PhabricatorService(IssueService):
             except IndexError:
                 pass
 
+            this_issue_matches = False
+
+            if self.shown_user_phids is None and self.shown_project_phids is None:
+                this_issue_matches = True
+
             if self.shown_user_phids is not None:
                 # Checking whether authorPHID, ccPHIDs, ownerPHID
                 # are intersecting with self.shown_user_phids
                 issue_relevant_to = set(issue['ccPHIDs'] + [issue['ownerPHID'], issue['authorPHID']])
-                if len(issue_relevant_to.intersection(self.shown_user_phids)) == 0:
-                    continue
+                if len(issue_relevant_to.intersection(self.shown_user_phids)) > 0:
+                    this_issue_matches = True
 
             if self.shown_project_phids is not None:
                 # Checking whether projectPHIDs
                 # is intersecting with self.shown_project_phids
                 issue_relevant_to = set(issue['projectPHIDs'])
-                if len(issue_relevant_to.intersection(self.shown_user_phids)) == 0:
-                    continue
+                if len(issue_relevant_to.intersection(self.shown_user_phids)) > 0:
+                    this_issue_matches = True
+
+            if not this_issue_matches:
+                continue
 
             extra = {
                 'project': project,


### PR DESCRIPTION
WIP.

The first patch fixes the issue of the python module for phabricator service being called phab, and not phabricator.

The second introduces options to filter out the phabricator tasks and diffs according to the project and the user. (the phabricator service is not really useful now when you have a phabricator setup with many users and projects)

If there is the interest in merging this to mainline, I'll write the documentation for the new options.