### PR TITLE
Enable setuptools test command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(name='bugwarrior',
           "jira>=0.22",
           "megaplan>=1.4",
       ],
+      test_suite='nose.collector',
       entry_points="""
       [console_scripts]
       bugwarrior-pull = bugwarrior:pull


### PR DESCRIPTION
Enable the canonical setuptools test command to invoke the tests via nose as per documentation:

http://nose.readthedocs.org/en/latest/setuptools_integration.html

