### PR TITLE
Only import active Gitlab issues and merge requests

### DIFF
--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -273,6 +273,8 @@ class GitlabService(IssueService):
         tmpl = 'https://{host}/api/v3/projects/%d/issues' % rid
         issues = {}
         for issue in self._fetch_paged(tmpl):
+            if issue['state'] != 'opened':
+                continue
             issues[issue['id']] = (rid, issue)
         return issues
 
@@ -280,6 +282,8 @@ class GitlabService(IssueService):
         tmpl = 'https://{host}/api/v3/projects/%d/merge_requests' % rid
         issues = {}
         for issue in self._fetch_paged(tmpl):
+            if issue['state'] != 'opened':
+                continue
             issues[issue['id']] = (rid, issue)
         return issues
 


### PR DESCRIPTION
The Gitlab service seems to always import all issues, including closed ones. This PR changes that behaviour.