### PR TITLE
Make comment annotation configurable

### DIFF
--- a/bugwarrior/docs/common_configuration.rst
+++ b/bugwarrior/docs/common_configuration.rst
@@ -15,6 +15,10 @@ Optional options include:
 * ``shorten``: Set to ``True`` to shorten links.
 * ``inline_link``: When ``False``, links are appended as an annotation.
   Defaults to ``True``.
+* ``annotation_links``: When ``True`` will include a link to the ticket as an
+  annotation. Defaults to ``False``.
+* ``annotation_comments``: When ``True`` skips putting issue comments into
+  annotations. Defaults to ``True``.
 * ``legacy_matching``: Set to ``False`` to instruct Bugwarrior to match
   issues using only the issue's unique identifiers (rather than matching
   on description).

--- a/bugwarrior/docs/configuration.rst
+++ b/bugwarrior/docs/configuration.rst
@@ -8,17 +8,17 @@ Example Configuration
 ::
 
     # Example bugwarriorrc
-    
+
     # General stuff.
     [general]
     # Here you define a comma separated list of targets.  Each of them must have a
     # section below determining their properties, how to query them, etc.  The name
     # is just a symbol, and doesn't have any functional importance.
     targets = my_github, my_bitbucket, paj_bitbucket, moksha_trac, bz.redhat
-    
+
     # If unspecified, the default taskwarrior config will be used.
     #taskrc = /path/to/.taskrc
-    
+
     # Setting this to true will shorten links with http://da.gd/
     #shorten = False
 
@@ -38,18 +38,18 @@ Example Configuration
     # If this is false, we will only select issues having the appropriate UDA
     # fields defined
     #legacy_matching=False
-    
+
     # log.level specifices the verbosity.  The default is DEBUG.
     # log.level can be one of DEBUG, INFO, WARNING, ERROR, CRITICAL, DISABLED
     #log.level = DEBUG
-    
+
     # If log.file is specified, output will be redirected there.  If it remains
     # unspecified, output is sent to sys.stderr
     #log.file = /var/log/bugwarrior.log
-    
+
     # Configure the default description or annotation length.
     #annotation_length = 45
-    
+
     # Use hooks to run commands prior to importing from bugwarrior-pull.
     # bugwarrior-pull will run the commands in the order that they are specified
     # below.
@@ -60,7 +60,7 @@ Example Configuration
     # exit early.
     [hooks]
     pre_import = /home/someuser/backup.sh, /home/someuser/sometask.sh
-    
+
     # This section is for configuring notifications when bugwarrior-pull runs,
     # and when issues are created, updated, or deleted by bugwarrior-pull.
     # Three backend are currently suported:
@@ -78,8 +78,8 @@ Example Configuration
     # finished_querying_sticky = False
     # task_crud_sticky = True
     # only_on_new_tasks = True
-    
-    
+
+
     # This is a github example.  It says, "scrape every issue from every repository
     # on http://github.com/ralphbean.  It doesn't matter if ralphbean owns the issue
     # or not."
@@ -87,21 +87,21 @@ Example Configuration
     service = github
     default_priority = H
     add_tags = open_source
-    
+
     # This specifies that we should pull issues from repositories belonging
     # to the 'ralphbean' github account.  See the note below about
     # 'github.username' and 'github.login'.  They are different, and you need
     # both.
     github.username = ralphbean
-    
+
     # I want taskwarrior to include issues from all my repos, except these
     # two because they're spammy or something.
     github.exclude_repos = project_bar,project_baz
-    
+
     # Working with a large number of projects, instead of excluding most of them I
     # can also simply include just a limited set.
     github.include_repos = project_foo,project_foz
-    
+
     # Note that login and username can be different:  I can login as me, but
     # scrape issues from an organization's repos.
     #
@@ -111,30 +111,30 @@ Example Configuration
     #   issues for.  It could be you, or some other user entirely.
     github.login = ralphbean
     github.password = OMG_LULZ
-    
-    
+
+
     # Here's an example of a trac target.
     [moksha_trac]
     service = trac
-    
+
     trac.base_uri = fedorahosted.org/moksha
     trac.username = ralph
     trac.password = OMG_LULZ
-    
+
     only_if_assigned = ralph
     also_unassigned = True
     default_priority = H
     add_tags = work
-    
+
     # Here's an example of a megaplan target.
     [my_megaplan]
     service = megaplan
-    
+
     megaplan.hostname = example.megaplan.ru
     megaplan.login = alice
     megaplan.password = secret
     megaplan.project_name = example
-    
+
     # Here's an example of a jira project. The ``jira-python`` module is
     # a bit particular, and jira deployments, like Bugzilla, tend to be
     # reasonably customized. So YMMV. The ``base_uri`` must not have a
@@ -152,21 +152,21 @@ Example Configuration
     # the dashboard.
     jira.version = 5
     add_tags = enterprisey work
-    
+
     # Here's an example of a phabricator target
     [my_phabricator]
     service = phabricator
     # No need to specify credentials.  They are gathered from ~/.arcrc
-    
+
     # Here's an example of a teamlab target.
     [my_teamlab]
     service = teamlab
-    
+
     teamlab.hostname = teamlab.example.com
     teamlab.login = alice
     teamlab.password = secret
     teamlab.project_name = example_teamlab
-    
+
     # Here's an example of a redmine target.
     [my_redmine]
     service = redmine
@@ -175,14 +175,14 @@ Example Configuration
     redmine.user_id = 7
     redmine.project_name = redmine
     add_tags = chiliproject
-    
+
     [activecollab]
     service = activecollab
     activecollab.url = https://ac.example.org/api.php
     activecollab.key = your-api-key
     activecollab.user_id = 15
     add_tags = php
-    
+
     [activecollab2]
     service = activecollab2
     activecollab2.url = http://ac.example.org/api.php

--- a/bugwarrior/docs/configuration.rst
+++ b/bugwarrior/docs/configuration.rst
@@ -28,6 +28,10 @@ Example Configuration
     # Setting this to True will include a link to the ticket as an annotation
     annotation_links = True
 
+    # Setting this to True will include issue comments and author name in task
+    # annotations
+    annotation_comments = True
+
     # Defines whether or not issues should be matched based upon their description.
     # For historical reasons, and by default, we will attempt to match issues
     # based upon the presence of the '(bw)' marker in the task description.

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -75,6 +75,12 @@ class IssueService(object):
                 config.get(self.main_section, 'annotation_links')
             )
 
+        self.annotation_comments = True
+        if config.has_option(self.main_section, 'annotation_comments'):
+            self.annotation_comments = asbool(
+                config.get(self.main_section, 'annotation_comments')
+            )
+
         self.shorten = False
         if config.has_option(self.main_section, 'shorten'):
             self.shorten = asbool(config.get(self.main_section, 'shorten'))
@@ -165,6 +171,8 @@ class IssueService(object):
         final = []
         if self.annotation_links:
             final.append(url)
+        if not self.annotation_comments:
+            return final
         for author, message in annotations:
             message = message.strip()
             if not message or not author:

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -171,20 +171,19 @@ class IssueService(object):
         final = []
         if self.annotation_links:
             final.append(url)
-        if not self.annotation_comments:
-            return final
-        for author, message in annotations:
-            message = message.strip()
-            if not message or not author:
-                continue
-            message = message.replace('\n', '').replace('\r', '')
-            final.append(
-                '@%s - %s%s' % (
-                    author,
-                    message[0:self.anno_len],
-                    '...' if len(message) > self.anno_len else ''
+        if self.annotation_comments:
+            for author, message in annotations:
+                message = message.strip()
+                if not message or not author:
+                    continue
+                message = message.replace('\n', '').replace('\r', '')
+                final.append(
+                    '@%s - %s%s' % (
+                        author,
+                        message[0:self.anno_len],
+                        '...' if len(message) > self.anno_len else ''
+                    )
                 )
-            )
         return final
 
     @classmethod


### PR DESCRIPTION
This patch adds a general config option `annotation_comments` that defaults to True (current behavior) and lets users turn off annotations for issue comments. This is super handy if you're on large github issue threads.