### PR TITLE
Turn legacy_matching off by default.

### DIFF
--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -127,7 +127,7 @@ def get_managed_task_uuids(tw, key_list, legacy_matching):
     return expected_task_ids
 
 
-def find_local_uuid(tw, keys, issue, legacy_matching=True):
+def find_local_uuid(tw, keys, issue, legacy_matching=False):
     """ For a given issue issue, find its local UUID.
 
     Assembles a list of task IDs existing in taskwarrior
@@ -150,9 +150,10 @@ def find_local_uuid(tw, keys, issue, legacy_matching=True):
         ]
 
     * `issue`: A instance of a subclass of `bugwarrior.services.Issue`.
-    * `legacy_matching`: By default, this is enabled, and it allows
+    * `legacy_matching`: By default, this is disabled, and it allows
       the matching algorithm to -- in addition to searching by stored
       issue keys -- search using the task's description for a match.
+      It is prone to error and should avoided if possible.
 
     :returns:
     * A single string UUID.
@@ -323,7 +324,7 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
         marshal=True,
     )
 
-    legacy_matching = _bool_option(main_section, 'legacy_matching', 'True')
+    legacy_matching = _bool_option(main_section, 'legacy_matching', 'False')
     merge_annotations = _bool_option(main_section, 'merge_annotations', 'True')
     merge_tags = _bool_option(main_section, 'merge_tags', 'True')
 

--- a/bugwarrior/docs/configuration.rst
+++ b/bugwarrior/docs/configuration.rst
@@ -33,11 +33,11 @@ Example Configuration
     annotation_comments = True
 
     # Defines whether or not issues should be matched based upon their description.
-    # For historical reasons, and by default, we will attempt to match issues
-    # based upon the presence of the '(bw)' marker in the task description.
+    # In legacy mode, we will attempt to match issues to bugs based upon the
+    # presence of the '(bw)' marker in the task description.
     # If this is false, we will only select issues having the appropriate UDA
-    # fields defined
-    #legacy_matching=False
+    # fields defined (which is smarter, better, newer, etc..)
+    legacy_matching = False
 
     # log.level specifices the verbosity.  The default is DEBUG.
     # log.level can be one of DEBUG, INFO, WARNING, ERROR, CRITICAL, DISABLED


### PR DESCRIPTION
We get weird bug reports for it all the time.

We've had the new code in place long enough that many users have
hopefully migrated to the new UDA scheme.  This should turn it off for
new users by default, hopefully providing a better experience.