### PR TITLE
Comment out this section header.

### DIFF
--- a/bugwarrior/docs/configuration.rst
+++ b/bugwarrior/docs/configuration.rst
@@ -72,7 +72,7 @@ Example Configuration
     # To configure, adjust the settings below.  Note that neither of the
     # "sticky" options have any effect on Linux with pynotify.  They only work
     # for growlnotify.
-    [notifications]
+    #[notifications]
     # notifications = True
     # backend = growlnotify
     # finished_querying_sticky = False


### PR DESCRIPTION
New users get an error when the section header is present, but no
options.  Let's set them up for success.