### PR TITLE
Ignore microseconds for gitlab

### DIFF
--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -120,9 +120,9 @@ class GitlabIssue(Issue):
         if milestone:
             milestone = milestone['title']
         if created:
-            created = self.parse_date(created)
+            created = self.parse_date(created).replace(microsecond=0)
         if updated:
-            updated = self.parse_date(updated)
+            updated = self.parse_date(updated).replace(microsecond=0)
         if author:
             author = author['username']
         if assignee:


### PR DESCRIPTION
To prevent issue updates on every bugwarrior-pull.  See #259.