### PR TITLE
Add missing test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,8 @@ setup(name='bugwarrior',
           "nose",
           "jira>=0.22",
           "megaplan>=1.4",
+          "pypandoc",
+          "pyac"
       ],
       test_suite='nose.collector',
       entry_points="""


### PR DESCRIPTION
I had to install pypandoc and pyac for all the tests to pass.  Note that
pypandoc probably requires pandoc to be installed as well.