### PR TITLE
Minimal CI and documentation fixes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
- - "2.6"
  - "2.7"
 before_install:
   - sudo apt-get update -qq

--- a/bugwarrior/docs/common_configuration.rst
+++ b/bugwarrior/docs/common_configuration.rst
@@ -17,7 +17,7 @@ Optional options include:
   Defaults to ``True``.
 * ``annotation_links``: When ``True`` will include a link to the ticket as an
   annotation. Defaults to ``False``.
-* ``annotation_comments``: When ``True`` skips putting issue comments into
+* ``annotation_comments``: When ``False`` skips putting issue comments into
   annotations. Defaults to ``True``.
 * ``legacy_matching``: Set to ``False`` to instruct Bugwarrior to match
   issues using only the issue's unique identifiers (rather than matching

--- a/bugwarrior/docs/common_configuration.rst
+++ b/bugwarrior/docs/common_configuration.rst
@@ -29,6 +29,8 @@ Optional options include:
   written.  By default, logging messages will be written to stderr.
 * ``annotation_length``: Import maximally this number of characters
   of incoming annotations.  Default: 45.
+* ``description_length``: Use maximally this number of characters in the
+  description. Default: 35.
 * ``merge_annotations``: If ``False``, bugwarrior won't bother with adding
   annotations to your tasks at all.  Default: ``True``.
 * ``merge_tags``: If ``False``, bugwarrior won't bother with adding

--- a/bugwarrior/docs/contributing.rst
+++ b/bugwarrior/docs/contributing.rst
@@ -42,5 +42,4 @@ This will actually run it.. be careful and back up your task directory!
 
 If you're developing, it can be helpful to run the test suite::
 
-    (bugwarrior)$ pip install nose
-    (bugwarrior)$ nosetests
+    (bugwarrior)$ python setup.py nosetests


### PR DESCRIPTION
Simply running `nosetests` wont work because dependencies aren't installed
in the virtualenv. You'd have to manually `pip install` each dependency
like travis currently does.

Nose recommends this as "the easiest way to run tests with nose".
http://nose.readthedocs.org/en/latest/api/commands.html