### PR TITLE
bitbucket: More v2 API. Progress on #129.

### DIFF
--- a/tests/test_bitbucket.py
+++ b/tests/test_bitbucket.py
@@ -15,7 +15,7 @@ class TestBitbucketIssue(ServiceTest):
     def test_to_taskwarrior(self):
         arbitrary_issue = {
             'priority': 'trivial',
-            'local_id': '100',
+            'id': '100',
             'title': 'Some Title',
         }
         arbitrary_extra = {
@@ -36,7 +36,7 @@ class TestBitbucketIssue(ServiceTest):
             'annotations': arbitrary_extra['annotations'],
 
             issue.URL: arbitrary_extra['url'],
-            issue.FOREIGN_ID: arbitrary_issue['local_id'],
+            issue.FOREIGN_ID: arbitrary_issue['id'],
             issue.TITLE: arbitrary_issue['title'],
         }
         actual_output = issue.to_taskwarrior()


### PR DESCRIPTION
- Moving most things to the v2 API makes some things cleaner.
- One DRY get_data function that takes an optional api kwarg.
- Still no way to get detailed comment data without making an extra api
  call, so let's put that off for now.