### PR TITLE
Bitbucket OAuth. Resolve #201.

### DIFF
--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -9,9 +9,7 @@ import getpass
 import keyring
 import click
 
-from taskw.warrior import TaskWarriorBase
-
-from bugwarrior.config import get_taskrc_path, load_config
+from bugwarrior.config import get_data_path, load_config
 from bugwarrior.services import aggregate_issues, get_service
 from bugwarrior.db import (
     get_defined_udas_as_strings,
@@ -45,14 +43,7 @@ def pull(dry_run, flavor, interactive):
         # Load our config file
         config = load_config(main_section, interactive)
 
-        tw_config = TaskWarriorBase.load_config(get_taskrc_path(config, main_section))
-        lockfile_path = os.path.join(
-            os.path.expanduser(
-                tw_config['data']['location']
-            ),
-            'bugwarrior.lockfile'
-        )
-
+        lockfile_path = os.path.join(get_data_path(), 'bugwarrior.lockfile')
         lockfile = PIDLockFile(lockfile_path)
         lockfile.acquire(timeout=10)
         try:

--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -174,5 +174,9 @@ def get_taskrc_path(conf, main_section):
     )
 
 
+def get_data_path():
+    return os.path.expanduser(os.getenv('TASKDATA', '~/.task'))
+
+
 # This needs to be imported here and not above to avoid a circular-import.
 from bugwarrior.services import get_service

--- a/bugwarrior/data.py
+++ b/bugwarrior/data.py
@@ -1,0 +1,26 @@
+import os
+import json
+
+
+DATAFILE = os.path.expanduser(
+    os.path.join(os.getenv('TASKDATA', '~/.task'), 'bugwarrior.data'))
+
+
+def get(key):
+    try:
+        with open(DATAFILE, 'r') as jsondata:
+            data = json.load(jsondata)
+            return data[key]
+    except IOError:  # File does not exist.
+        return None
+
+
+def set(key, value):
+    try:
+        with open(DATAFILE, 'rw') as jsondata:
+            data = json.load(jsondata)
+            data[key] = value
+            json.dump(data, jsondata)
+    except IOError:  # File does not exist.
+        with open(DATAFILE, 'w+') as jsondata:
+            json.dump({key: value}, jsondata)

--- a/bugwarrior/data.py
+++ b/bugwarrior/data.py
@@ -1,26 +1,35 @@
 import os
 import json
 
+from lockfile.pidlockfile import PIDLockFile
 
-DATAFILE = os.path.expanduser(
-    os.path.join(os.getenv('TASKDATA', '~/.task'), 'bugwarrior.data'))
+from bugwarrior.config import get_data_path
+
+
+DATAFILE = os.path.join(get_data_path(), 'bugwarrior.data')
+LOCKFILE = os.path.join(get_data_path(), 'bugwarrior-data.lockfile')
 
 
 def get(key):
     try:
         with open(DATAFILE, 'r') as jsondata:
-            data = json.load(jsondata)
-            return data[key]
+            try:
+                data = json.load(jsondata)
+            except ValueError:  # File does not contain JSON.
+                return None
+            else:
+                return data[key]
     except IOError:  # File does not exist.
         return None
 
 
 def set(key, value):
-    try:
-        with open(DATAFILE, 'rw') as jsondata:
-            data = json.load(jsondata)
-            data[key] = value
-            json.dump(data, jsondata)
-    except IOError:  # File does not exist.
-        with open(DATAFILE, 'w+') as jsondata:
-            json.dump({key: value}, jsondata)
+    with PIDLockFile(LOCKFILE):
+        try:
+            with open(DATAFILE, 'r+') as jsondata:
+                data = json.load(jsondata)
+                data[key] = value
+                json.dump(data, jsondata)
+        except IOError:  # File does not exist.
+            with open(DATAFILE, 'w+') as jsondata:
+                json.dump({key: value}, jsondata)

--- a/bugwarrior/docs/services/bitbucket.rst
+++ b/bugwarrior/docs/services/bitbucket.rst
@@ -27,6 +27,14 @@ set to ralphbean (my account).  But I have some targets with
 ``bitbucket.username`` pointed at organizations or other users to watch issues
 there.
 
+As an alternative to password authentication, there is OAuth. To get a key and secret,
+go to the "OAuth" section of your profile settings and click "Add consumer". Set the
+"Callback URL" to ``https://localhost/`` and set the appropriate permissions. Then
+assign your consumer's credentials to ``bitbucket.key`` and ``bitbucket.secret``. Note
+that you will have to provide a password (only) the first time you pull, so you may
+want to set ``bitbucket.password = @oracle:ask_password`` and run
+``bugwarrior-pull --interactive`` on your next pull.
+
 Service Features
 ----------------
 


### PR DESCRIPTION
- Implement OAuth2. Thanks to @ibuchanan for helping me navigate
  bitbucket's idiosyncratic implementation.
- Add a bugwarrior.data file to the ~/.task directory, per [taskwarrior's
  third-party guidelines](https://taskwarrior.org/docs/3rd-party.html#guidelines).