### PR TITLE
Password oracle improvements

### DIFF
--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -71,6 +71,8 @@ def pull(dry_run, flavor, interactive):
                 lockfile_path
             )
         )
+    except RuntimeError as e:
+        log.name('command').critical("Aborted (%s)" % e)
     except:
         log.name('command').trace('error').critical('oh noes')
 

--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -56,18 +56,25 @@ def get_service_password(service, username, oracle=None, interactive=False):
         password = getpass.getpass(prompt)
     elif oracle.startswith('@oracle:eval:'):
         command = oracle[13:]
-        p = subprocess.Popen(
-            command,
-            shell=True,
-            stdout=subprocess.PIPE,
-            #stderr=subprocess.STDOUT
-        )
-        password = p.stdout.read()[:-1]
+        return oracle_eval(command)
 
     if password is None:
         die("MISSING PASSWORD: oracle='%s', interactive=%s for service=%s" %
             (oracle, interactive, service))
     return password
+
+
+def oracle_eval(command):
+    """ Retrieve password from the given command """
+    p = subprocess.Popen(
+        command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p.wait()
+    if p.returncode == 0:
+        return p.stdout.readline().strip()
+    else:
+        die(
+            "Error retrieving password: `{command}` returned '{error}'".format(
+                command=command, error=p.stderr.read().strip()))
 
 
 def load_example_rc():

--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -26,10 +26,6 @@ CACHE_REGION = dogpile.cache.make_region().configure(
 )
 
 
-# Sentinel value used for aborting processing of tasks
-ABORT_PROCESSING = 2
-
-
 class URLShortener(object):
     _instance = None
 
@@ -335,8 +331,6 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
     }
 
     for issue in issue_generator:
-        if isinstance(issue, tuple) and issue[0] == ABORT_PROCESSING:
-            raise RuntimeError(issue[1])
         try:
             existing_uuid = find_local_uuid(
                 tw, key_list, issue, legacy_matching=legacy_matching

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -139,8 +139,9 @@ class IssueService(object):
             return to_type(value)
         return value
 
-    def config_get_password(self, key, keyring_service, login):
+    def config_get_password(self, key, login):
         password = self.config_get_default(key)
+        keyring_service = self.get_keyring_service(self.config, self.target),
         if not password or password.startswith("@oracle:"):
             password = get_service_password(
                 keyring_service, login, oracle=password,

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -501,6 +501,9 @@ def _aggregate_issues(conf, main_section, target, queue, service_name):
         for issue in service.issues():
             queue.put(issue)
             issue_count += 1
+    except SystemExit as e:
+        log.name(target).critical(str(e))
+        queue.put((SERVICE_FINISHED_ERROR, (target, e)))
     except BaseException as e:
         log.name(target).trace('error').critical(
             "Worker for [%s] failed: %s" % (target, e)

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -14,7 +14,7 @@ from twiggy import log
 from taskw.task import Task
 
 from bugwarrior.config import asbool, get_service_password
-from bugwarrior.db import MARKUP, URLShortener, ABORT_PROCESSING
+from bugwarrior.db import MARKUP, URLShortener
 
 
 # Sentinels for process completion status
@@ -563,9 +563,11 @@ def aggregate_issues(conf, main_section):
             completion_type, args = issue
             if completion_type == SERVICE_FINISHED_ERROR:
                 target, e = args
+                log.name('bugwarrior').info("Terminating workers")
                 for process in processes:
                     process.terminate()
-                yield ABORT_PROCESSING, e
+                raise RuntimeError(
+                    "critical error in target '{}'".format(target))
             currently_running -= 1
             continue
         yield issue

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -501,7 +501,7 @@ def _aggregate_issues(conf, main_section, target, queue, service_name):
         for issue in service.issues():
             queue.put(issue)
             issue_count += 1
-    except Exception as e:
+    except BaseException as e:
         log.name(target).trace('error').critical(
             "Worker for [%s] failed: %s" % (target, e)
         )

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -13,7 +13,7 @@ from twiggy import log
 
 from taskw.task import Task
 
-from bugwarrior.config import asbool
+from bugwarrior.config import asbool, get_service_password
 from bugwarrior.db import MARKUP, URLShortener, ABORT_PROCESSING
 
 
@@ -124,6 +124,9 @@ class IssueService(object):
                 templates[key] = self.config.get(self.target, template_key)
         return templates
 
+    def config_has(self, key):
+        return self.config.has_option(self.target, self._get_key(key))
+
     def config_get_default(self, key, default=None, to_type=None):
         try:
             return self.config_get(key, to_type=to_type)
@@ -135,6 +138,14 @@ class IssueService(object):
         if to_type:
             return to_type(value)
         return value
+
+    def config_get_password(self, key, keyring_service, login):
+        password = self.config_get_default(key)
+        if not password or password.startswith("@oracle:"):
+            password = get_service_password(
+                keyring_service, login, oracle=password,
+                interactive=self.config.interactive)
+        return password
 
     @classmethod
     def _get_key(cls, key):

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -67,10 +67,7 @@ class BitbucketService(IssueService):
 
         self.auth = None
         login = self.config_get('login')
-        password = self.config_get_password(
-            'password',
-            self.get_keyring_service(self.config, self.target),
-            login)
+        password = self.config_get_password('password', login)
 
         self.auth = (login, password)
 

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -66,14 +66,13 @@ class BitbucketService(IssueService):
         super(BitbucketService, self).__init__(*args, **kw)
 
         self.auth = None
-        if self.config_get_default('login'):
-            login = self.config_get('login')
-            password = self.config_get_password(
-                'password',
-                self.get_keyring_service(self.config, self.target),
-                login)
+        login = self.config_get('login')
+        password = self.config_get_password(
+            'password',
+            self.get_keyring_service(self.config, self.target),
+            login)
 
-            self.auth = (login, password)
+        self.auth = (login, password)
 
         self.exclude_repos = []
         if self.config_get_default('exclude_repos', None):
@@ -136,6 +135,8 @@ class BitbucketService(IssueService):
     def validate_config(cls, config, target):
         if not config.has_option(target, 'bitbucket.username'):
             die("[%s] has no 'username'" % target)
+        if not config.has_option(target, 'bitbucket.login'):
+            die("[%s] has no 'login'" % target)
 
         IssueService.validate_config(config, target)
 

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -2,7 +2,7 @@ import requests
 from twiggy import log
 
 from bugwarrior.services import IssueService, Issue
-from bugwarrior.config import asbool, die, get_service_password
+from bugwarrior.config import asbool, die
 
 
 class BitbucketIssue(Issue):
@@ -68,13 +68,10 @@ class BitbucketService(IssueService):
         self.auth = None
         if self.config_get_default('login'):
             login = self.config_get('login')
-            password = self.config_get_default('password')
-            if not password or password.startswith('@oracle:'):
-                username = self.config_get('username')
-                password = get_service_password(
-                    self.get_keyring_service(self.config, self.target),
-                    login, oracle=password,
-                    interactive=self.config.interactive)
+            password = self.config_get_password(
+                'password',
+                self.get_keyring_service(self.config, self.target),
+                login)
 
             self.auth = (login, password)
 

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -6,7 +6,7 @@ import pytz
 import datetime
 import six
 
-from bugwarrior.config import die, asbool, get_service_password
+from bugwarrior.config import die, asbool
 from bugwarrior.services import IssueService, Issue
 
 
@@ -124,12 +124,10 @@ class BugzillaService(IssueService):
         # to pass that argument or not.
         self.advanced = asbool(self.config_get_default('advanced', 'no'))
 
-        if not self.password or self.password.startswith("@oracle:"):
-            self.password = get_service_password(
-                self.get_keyring_service(self.config, self.target),
-                self.username, oracle=self.password,
-                interactive=self.config.interactive
-            )
+        self.password = self.config_get_password(
+            'password',
+            self.get_keyring_service(self.config, self.target),
+            self.username)
 
         url = 'https://%s/xmlrpc.cgi' % self.base_uri
         self.bz = bugzilla.Bugzilla(url=url)

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -106,7 +106,6 @@ class BugzillaService(IssueService):
         super(BugzillaService, self).__init__(*args, **kw)
         self.base_uri = self.config_get('base_uri')
         self.username = self.config_get('username')
-        self.password = self.config_get('password')
         self.ignore_cc = self.config_get_default('ignore_cc', default=False,
                                                  to_type=lambda x: x == "True")
         self.query_url = self.config_get_default('query_url', default=None)
@@ -124,10 +123,7 @@ class BugzillaService(IssueService):
         # to pass that argument or not.
         self.advanced = asbool(self.config_get_default('advanced', 'no'))
 
-        self.password = self.config_get_password(
-            'password',
-            self.get_keyring_service(self.config, self.target),
-            self.username)
+        self.password = self.config_get_password('password', self.username)
 
         url = 'https://%s/xmlrpc.cgi' % self.base_uri
         self.bz = bugzilla.Bugzilla(url=url)

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -4,7 +4,7 @@ import six
 from jinja2 import Template
 from twiggy import log
 
-from bugwarrior.config import asbool, die, get_service_password
+from bugwarrior.config import asbool, die
 from bugwarrior.services import IssueService, Issue
 
 from . import githubutils
@@ -134,24 +134,17 @@ class GithubService(IssueService):
 
         login = self.config_get('login')
         token = self.config_get_default('token')
-        if token:
-            if token.startswith('@oracle:'):
-                username = self.config_get('username')
-                token = get_service_password(
-                    self.get_keyring_service(self.config, self.target),
-                    login, oracle=token,
-                    interactive=self.config.interactive
-                )
+        if self.config_has('token'):
+            token = self.config_get_password(
+                'token',
+                self.get_keyring_service(self.config, self.target),
+                login)
             self.auth['token'] = token
         else:
-            password = self.config_get_default('password')
-            if not password or password.startswith('@oracle:'):
-                username = self.config_get('username')
-                password = get_service_password(
-                    self.get_keyring_service(self.config, self.target),
-                    login, oracle=password,
-                    interactive=self.config.interactive
-                )
+            password = self.config_get_password(
+                'password',
+                self.get_keyring_service(self.config, self.target),
+                login)
             self.auth['basic'] = (login, password)
 
         self.exclude_repos = []

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -135,16 +135,10 @@ class GithubService(IssueService):
         login = self.config_get('login')
         token = self.config_get_default('token')
         if self.config_has('token'):
-            token = self.config_get_password(
-                'token',
-                self.get_keyring_service(self.config, self.target),
-                login)
+            token = self.config_get_password('token', login)
             self.auth['token'] = token
         else:
-            password = self.config_get_password(
-                'password',
-                self.get_keyring_service(self.config, self.target),
-                login)
+            password = self.config_get_password('password', login)
             self.auth['basic'] = (login, password)
 
         self.exclude_repos = []

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -1,3 +1,4 @@
+from ConfigParser import NoOptionError
 import re
 import requests
 import six
@@ -226,8 +227,13 @@ class GitlabService(IssueService):
             'filter_merge_requests', default=False, to_type=asbool
         )
 
-    @staticmethod
-    def get_keyring_service(login, host):
+    @classmethod
+    def get_keyring_service(cls, config, section):
+        login = config.get(section, cls._get_key('login'))
+        try:
+            host = config.get(section, cls._get_key('host'))
+        except NoOptionError:
+            host = 'gitlab.com'
         return "gitlab://%s@%s" % (login, host)
 
     def get_service_metadata(self):

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -5,7 +5,7 @@ import six
 from jinja2 import Template
 from twiggy import log
 
-from bugwarrior.config import asbool, die, get_service_password
+from bugwarrior.config import asbool, die
 from bugwarrior.services import IssueService, Issue
 
 
@@ -189,13 +189,8 @@ class GitlabService(IssueService):
         host = self.config_get_default(
             'host', default='gitlab.com', to_type=six.text_type)
         login = self.config_get('login')
-        token = self.config_get('token')
-        if token.startswith('@oracle:'):
-            token = get_service_password(
-                self.get_keyring_service(login, host),
-                login, oracle=token,
-                interactive=self.config.interactive
-            )
+        token = self.config_get_password(
+            'token', self.get_keyring_service(login, host), login)
         self.auth = (host, token)
 
         if self.config_get_default('use_https', default=True, to_type=asbool):

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -188,12 +188,12 @@ class GitlabService(IssueService):
 
         host = self.config_get_default(
             'host', default='gitlab.com', to_type=six.text_type)
-        self.login = self.config_get('login')
+        login = self.config_get('login')
         token = self.config_get('token')
-        if not token or token.startswith('@oracle:'):
+        if token.startswith('@oracle:'):
             token = get_service_password(
-                self.get_keyring_service(self.config, self.target),
-                self.login, oracle=password,
+                self.get_keyring_service(login, host),
+                login, oracle=token,
                 interactive=self.config.interactive
             )
         self.auth = (host, token)
@@ -231,9 +231,8 @@ class GitlabService(IssueService):
             'filter_merge_requests', default=False, to_type=asbool
         )
 
-    @classmethod
-    def get_keyring_service(cls, config, section):
-        login = config.get(section, cls._get_key('login'))
+    @staticmethod
+    def get_keyring_service(login, host):
         return "gitlab://%s@%s" % (login, host)
 
     def get_service_metadata(self):

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -190,8 +190,7 @@ class GitlabService(IssueService):
         host = self.config_get_default(
             'host', default='gitlab.com', to_type=six.text_type)
         login = self.config_get('login')
-        token = self.config_get_password(
-            'token', self.get_keyring_service(login, host), login)
+        token = self.config_get_password('token', login)
         self.auth = (host, token)
 
         if self.config_get_default('use_https', default=True, to_type=asbool):

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -131,10 +131,7 @@ class JiraService(IssueService):
         super(JiraService, self).__init__(*args, **kw)
         self.username = self.config_get('username')
         self.url = self.config_get('base_uri')
-        password = self.config_get_password(
-            'password',
-            self.get_keyring_service(self.config, self.target),
-            self.username)
+        password = self.config_get_password('password', self.username)
 
         default_query = 'assignee=' + self.username + \
             ' AND resolution is null'

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -4,7 +4,7 @@ from jinja2 import Template
 from jira.client import JIRA
 import six
 
-from bugwarrior.config import asbool, die, get_service_password
+from bugwarrior.config import asbool, die
 from bugwarrior.services import IssueService, Issue
 
 
@@ -131,13 +131,10 @@ class JiraService(IssueService):
         super(JiraService, self).__init__(*args, **kw)
         self.username = self.config_get('username')
         self.url = self.config_get('base_uri')
-        password = self.config_get('password')
-        if not password or password.startswith("@oracle:"):
-            password = get_service_password(
-                self.get_keyring_service(self.config, self.target),
-                self.username, oracle=password,
-                interactive=self.config.interactive
-            )
+        password = self.config_get_password(
+            'password',
+            self.get_keyring_service(self.config, self.target),
+            self.username)
 
         default_query = 'assignee=' + self.username + \
             ' AND resolution is null'

--- a/bugwarrior/services/mplan.py
+++ b/bugwarrior/services/mplan.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import megaplan
 from twiggy import log
 
-from bugwarrior.config import die, get_service_password
+from bugwarrior.config import die
 from bugwarrior.services import IssueService, Issue
 
 
@@ -73,13 +73,10 @@ class MegaplanService(IssueService):
 
         self.hostname = self.config_get('hostname')
         _login = self.config_get('login')
-        _password = self.config_get('password')
-        if not _password or _password.startswith("@oracle:"):
-            _password = get_service_password(
-                self.get_keyring_service(self.config, self.target),
-                _login, oracle=_password,
-                interactive=self.config.interactive
-            )
+        _password = self.config_get_password(
+            'password',
+            self.get_keyring_service(self.config, self.target),
+            _login)
 
         self.client = megaplan.Client(self.hostname)
         self.client.authenticate(_login, _password)

--- a/bugwarrior/services/mplan.py
+++ b/bugwarrior/services/mplan.py
@@ -73,10 +73,7 @@ class MegaplanService(IssueService):
 
         self.hostname = self.config_get('hostname')
         _login = self.config_get('login')
-        _password = self.config_get_password(
-            'password',
-            self.get_keyring_service(self.config, self.target),
-            _login)
+        _password = self.config_get_password('password', _login)
 
         self.client = megaplan.Client(self.hostname)
         self.client.authenticate(_login, _password)

--- a/bugwarrior/services/teamlab.py
+++ b/bugwarrior/services/teamlab.py
@@ -122,10 +122,7 @@ class TeamLabService(IssueService):
 
         self.hostname = self.config_get('hostname')
         _login = self.config_get('login')
-        _password = self.config_get_password(
-            'password',
-            self.get_keyring_service(self.config, self.target),
-            _login)
+        _password = self.config_get_password('password', _login)
 
         self.client = TeamLabClient(self.hostname)
         self.client.authenticate(_login, _password)

--- a/bugwarrior/services/teamlab.py
+++ b/bugwarrior/services/teamlab.py
@@ -5,7 +5,7 @@ import urllib2
 import six
 from twiggy import log
 
-from bugwarrior.config import die, get_service_password
+from bugwarrior.config import die
 from bugwarrior.services import Issue, IssueService
 
 
@@ -122,13 +122,10 @@ class TeamLabService(IssueService):
 
         self.hostname = self.config_get('hostname')
         _login = self.config_get('login')
-        _password = self.config_get('password')
-        if not _password or _password.startswith("@oracle:"):
-            _password = get_service_password(
-                self.get_keyring_service(self.config, self.target),
-                _login, oracle=_password,
-                interactive=self.config.interactive
-            )
+        _password = self.config_get_password(
+            'password',
+            self.get_keyring_service(self.config, self.target),
+            _login)
 
         self.client = TeamLabClient(self.hostname)
         self.client.authenticate(_login, _password)

--- a/bugwarrior/services/trac.py
+++ b/bugwarrior/services/trac.py
@@ -80,10 +80,7 @@ class TracService(IssueService):
         scheme = self.config_get_default('scheme', default='https')
         username = self.config_get_default('username', default=None)
         if username:
-            password = self.config_get_password(
-                'password',
-                self.get_keyring_service(self.config, self.target),
-                username)
+            password = self.config_get_password('password', username)
 
             auth = urllib.quote_plus('%s:%s' % (username, password)) + '@'
         else:

--- a/bugwarrior/services/trac.py
+++ b/bugwarrior/services/trac.py
@@ -5,7 +5,7 @@ import requests
 from twiggy import log
 import urllib
 
-from bugwarrior.config import die, get_service_password
+from bugwarrior.config import die
 from bugwarrior.services import Issue, IssueService
 
 
@@ -80,13 +80,10 @@ class TracService(IssueService):
         scheme = self.config_get_default('scheme', default='https')
         username = self.config_get_default('username', default=None)
         if username:
-            password = self.config_get('password')
-            if not password or password.startswith('@oracle:'):
-                password = get_service_password(
-                    self.get_keyring_service(self.config, self.target),
-                    username, oracle=password,
-                    interactive=self.config.interactive
-                )
+            password = self.config_get_password(
+                'password',
+                self.get_keyring_service(self.config, self.target),
+                username)
 
             auth = urllib.quote_plus('%s:%s' % (username, password)) + '@'
         else:

--- a/bugwarrior/services/versionone.py
+++ b/bugwarrior/services/versionone.py
@@ -3,7 +3,7 @@ from v1pysdk.none_deref import NoneDeref
 from six.moves.urllib import parse
 
 from bugwarrior.services import IssueService, Issue, LOCAL_TIMEZONE
-from bugwarrior.config import die, get_service_password
+from bugwarrior.config import die
 
 
 class VersionOneIssue(Issue):
@@ -186,13 +186,10 @@ class VersionOneService(IssueService):
         self.address = parsed_address.netloc
         self.instance = parsed_address.path.strip('/')
         self.username = self.config_get('username')
-        self.password = self.config_get_default('password')
-        if not self.password or self.password.startswith('@oracle:'):
-            self.password = get_service_password(
-                self.get_keyring_service(self.config, self.target),
-                self.username, oracle=self.password,
-                interactive=self.config.interactive
-            )
+        self.password = self.config_get_password(
+            'password',
+            self.get_keyring_service(self.config, self.target),
+            self.username)
 
         self.timezone = self.config_get_default(
             'timezone',

--- a/bugwarrior/services/versionone.py
+++ b/bugwarrior/services/versionone.py
@@ -186,10 +186,7 @@ class VersionOneService(IssueService):
         self.address = parsed_address.netloc
         self.instance = parsed_address.path.strip('/')
         self.username = self.config_get('username')
-        self.password = self.config_get_password(
-            'password',
-            self.get_keyring_service(self.config, self.target),
-            self.username)
+        self.password = self.config_get_password('password', self.username)
 
         self.timezone = self.config_get_default(
             'timezone',

--- a/tests/test_bitbucket.py
+++ b/tests/test_bitbucket.py
@@ -6,6 +6,7 @@ from .base import ServiceTest
 class TestBitbucketIssue(ServiceTest):
     SERVICE_CONFIG = {
         'bitbucket.login': 'something',
+        'bitbucket.username': 'somename',
         'bitbucket.password': 'something else',
     }
 

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -1,10 +1,31 @@
+import ConfigParser
 import datetime
+from unittest2 import TestCase
 
 import pytz
 
 from bugwarrior.services.gitlab import GitlabService
 
 from .base import ServiceTest
+
+
+class TestGitlabService(TestCase):
+
+    def setUp(self):
+        self.config = ConfigParser.RawConfigParser()
+        self.config.add_section('myservice')
+        self.config.set('myservice', 'gitlab.login', 'foobar')
+
+    def test_get_keyring_service_default_host(self):
+        self.assertEqual(
+            GitlabService.get_keyring_service(self.config, 'myservice'),
+            'gitlab://foobar@gitlab.com')
+
+    def test_get_keyring_service_custom_host(self):
+        self.config.set('myservice', 'gitlab.host', 'gitlab.example.com')
+        self.assertEqual(
+            GitlabService.get_keyring_service(self.config, 'myservice'),
+            'gitlab://foobar@gitlab.example.com')
 
 
 class TestGitlabIssue(ServiceTest):


### PR DESCRIPTION
* Fix a bug that prevented using an `@oracle:` token in gitlab
* improve error reporting in case a `@oracle:eval:` commands fails
* fix a bug that made bugwarrior hang when the oracle failed