### PR TITLE
Replace development config with --debug flag.

### DIFF
--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -31,7 +31,8 @@ def _get_section_name(flavor):
 @click.option('--dry-run', is_flag=True)
 @click.option('--flavor', default=None, help='The flavor to use')
 @click.option('--interactive', is_flag=True)
-def pull(dry_run, flavor, interactive):
+@click.option('--debug', is_flag=True)
+def pull(dry_run, flavor, interactive, debug):
     """ Pull down tasks from forges and add them to your taskwarrior tasks.
 
     Relies on configuration in bugwarriorrc
@@ -48,7 +49,7 @@ def pull(dry_run, flavor, interactive):
         lockfile.acquire(timeout=10)
         try:
             # Get all the issues.  This can take a while.
-            issue_generator = aggregate_issues(config, main_section)
+            issue_generator = aggregate_issues(config, main_section, debug)
 
             # Stuff them in the taskwarrior db as necessary
             synchronize(issue_generator, config, main_section, dry_run)

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -521,7 +521,7 @@ def _aggregate_issues(conf, main_section, target, queue, service_name):
         log.name(target).info("Done with [%s] in %fs" % (target, duration))
 
 
-def aggregate_issues(conf, main_section):
+def aggregate_issues(conf, main_section, debug):
     """ Return all issues from every target. """
     log.name('bugwarrior').info("Starting to aggregate remote issues.")
 
@@ -533,10 +533,7 @@ def aggregate_issues(conf, main_section):
     log.name('bugwarrior').info("Spawning %i workers." % len(targets))
     processes = []
 
-    if (
-        conf.has_option(main_section, 'development')
-        and asbool(conf.get(main_section, 'development'))
-    ):
+    if debug:
         for target in targets:
             _aggregate_issues(
                 conf,


### PR DESCRIPTION
The 'development' configuration option is not currently documented. Rather than document
it, I suggest using a flag because it's more convenient (doesn't require
constantly editing a file) and self-documenting.