### PR TITLE
Fetch github comments only when they will be used

### DIFF
--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -220,12 +220,16 @@ class GithubService(IssueService):
 
     def annotations(self, tag, issue, issue_obj):
         url = issue['html_url']
-        comments = self._comments(tag, issue['number'])
-        return self.build_annotations(
-            ((
+        annotations = []
+        if self.annotation_comments:
+            comments = self._comments(tag, issue['number'])
+            log.name(self.target).debug(" got comments for {0}", issue['html_url'])
+            annotations = ((
                 c['user']['login'],
                 c['body'],
             ) for c in comments),
+        return self.build_annotations(
+            annotations,
             issue_obj.get_processed_url(url)
         )
 


### PR DESCRIPTION
Prior to this change, comments on Github issues were fetched
(generating their own API request) whether or not they were saved in
taskwarrior per the `annotation_comments` config option. This change
only fetches them if `annotation_comments` is True, saving requests &
time.