### PR TITLE
Complain when users specify old config values.

### DIFF
--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -196,7 +196,7 @@ class IssueService(object):
     def include(self, issue):
         """ Return true if the issue in question should be included """
         only_if_assigned = self.config_get_default(
-            'only_if_assigned', None, asbool)
+            'only_if_assigned', None)
 
         if only_if_assigned:
             owner = self.get_owner(issue)

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -191,7 +191,12 @@ class IssueService(object):
     @classmethod
     def validate_config(cls, config, target):
         """ Validate generic options for a particular target """
-        pass
+        if config.has_option(target, 'only_if_assigned'):
+            die("[%s] has a 'only_if_assigned' option.  Should be "
+                "'%s.only_if_assigned'." % (target, cls.CONFIG_PREFIX))
+        if config.has_option(target, 'also_unassigned'):
+            die("[%s] has a 'also_unassigned' option.  Should be "
+                "'%s.also_unassigned'." % (target, cls.CONFIG_PREFIX))
 
     def include(self, issue):
         """ Return true if the issue in question should be included """


### PR DESCRIPTION
In 81e8d74d0, we accidentally changed the config value from
``only_if_assigned`` to ``$SERVICE.only_if_assigned``.  That's okay by me,
just because it makes things consistent.  But, it breaks people's existing
configs (it broke mine).

This change adds some warnings which will halt bugwarrior and prompt you to
update your config.