### PR TITLE
Simplify SerivceClient.json_response interface.

### DIFF
--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -481,12 +481,12 @@ class Issue(object):
 
 class ServiceClient(object):
     @staticmethod
-    def json_response(response, url):
+    def json_response(response):
         # If we didn't get good results, just bail.
         if response.status_code != 200:
             raise IOError(
                 "Non-200 status code %r; %r; %r" % (
-                    response.status_code, url, response.text,
+                    response.status_code, response.url, response.text,
                 ))
         if callable(response.json):
             # Newer python-requests

--- a/bugwarrior/services/activecollab2.py
+++ b/bugwarrior/services/activecollab2.py
@@ -72,7 +72,7 @@ class ActiveCollab2Client(ServiceClient):
             'path_info': uri,
             'format': 'json'}
 
-        return self.json_response(requests.get(url, params=params), url)
+        return self.json_response(requests.get(url, params=params))
 
 
 class ActiveCollab2Issue(Issue):

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -145,7 +145,7 @@ class BitbucketService(IssueService, ServiceClient):
         elif 'basic' in self.auth:
             kwargs['auth'] = self.auth['basic']
 
-        return self.json_response(requests.get(api + url, **kwargs), url)
+        return self.json_response(requests.get(api + url, **kwargs))
 
     @classmethod
     def validate_config(cls, config, target):

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -281,7 +281,7 @@ class GitlabService(IssueService, ServiceClient):
             requests.packages.urllib3.disable_warnings()
         response = requests.get(url, headers=headers, verify=self.verify_ssl, **kwargs)
 
-        return self.json_response(response, url)
+        return self.json_response(response)
 
     def _fetch_paged(self, tmpl):
         params = {

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -27,7 +27,7 @@ class RedMineClient(ServiceClient):
         if self.auth:
             kwargs['auth'] = self.auth
 
-        return self.json_response(requests.get(url, **kwargs), url)
+        return self.json_response(requests.get(url, **kwargs))
 
 
 class RedMineIssue(Issue):

--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -108,7 +108,7 @@ class TaigaService(IssueService, ServiceClient):
     @cache.cache_on_arguments()
     def get_project(self, project_id):
         url = '%s/api/v1/projects/%i' % (self.url, project_id)
-        return self.json_response(self.session.get(url), url)
+        return self.json_response(self.session.get(url))
 
     def build_url(self, story, project):
         return '%s/project/%s/us/%i' % (self.url, project['slug'], story['ref'])

--- a/bugwarrior/services/teamlab.py
+++ b/bugwarrior/services/teamlab.py
@@ -34,7 +34,7 @@ class TeamLabClient(ServiceClient):
         response = (requests.post(uri, data=post, **kwargs) if post
                     else requests.get(uri, **kwargs))
 
-        return self.json_response(response, uri)
+        return self.json_response(response)
 
 
 class TeamLabIssue(Issue):


### PR DESCRIPTION
The only difference is that errors will include the full url (i.e,
inluding params), which is probably a good thing anyway.

This also fixes the regression I introduced into taiga in which I forgot
to include the url.