### PR TITLE
Documentation improvements

### DIFF
--- a/bugwarrior/docs/common_configuration.rst
+++ b/bugwarrior/docs/common_configuration.rst
@@ -13,7 +13,7 @@ Optional options include:
 * ``taskrc``: Specify which TaskRC configuration file to use.  By default,
   will use the system default (usually ``~/.taskrc``).
 * ``shorten``: Set to ``True`` to shorten links.
-* ``inline_link``: When ``False``, links are appended as an annotation.
+* ``inline_links``: When ``False``, links are appended as an annotation.
   Defaults to ``True``.
 * ``annotation_links``: When ``True`` will include a link to the ticket as an
   annotation. Defaults to ``False``.

--- a/bugwarrior/docs/conf.py
+++ b/bugwarrior/docs/conf.py
@@ -90,6 +90,9 @@ exclude_patterns = []
 # output. They are ignored by default.
 #show_authors = False
 
+# The default language to highlight source code in.
+highlight_language = 'ini'
+
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 

--- a/bugwarrior/docs/contributing.rst
+++ b/bugwarrior/docs/contributing.rst
@@ -1,6 +1,8 @@
 How to Contribute
 =================
 
+.. highlight:: console
+
 Setting up your development environment
 ---------------------------------------
 


### PR DESCRIPTION
* Fix typo in option name 'inline_links' in docs
* Enable syntax coloring for configuration examples