### PR TITLE
Github: add an option to skip user issues

### DIFF
--- a/bugwarrior/docs/services/github.rst
+++ b/bugwarrior/docs/services/github.rst
@@ -97,6 +97,12 @@ by adding the following configuration option::
 Get involved issues
 +++++++++++++++++++
 
+By default, bugwarrior pulls all issues across owned and member repositories
+assigned to the authenticated user.  To disable this behavior, use::
+
+    github.include_user_issues = False
+
+
 Instead of fetching issues and pull requests based on ``{{username}}``'s owned
 repositories, you may instead get those that ``{{username}}`` is involved in.
 This includes all issues and pull requests where the user is the author, the

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -364,7 +364,8 @@ class GithubService(IssueService):
                 issues.update(
                     self.get_owned_repo_issues(user + "/" + repo['name'])
                 )
-        issues.update(self.get_directly_assigned_issues())
+        if self.config_get_default('include_user_issues', True, asbool):
+            issues.update(self.get_directly_assigned_issues())
         log.name(self.target).debug(" Found {0} issues.", len(issues))
         issues = filter(self.include, issues.values())
         log.name(self.target).debug(" Pruned down to {0} issues.", len(issues))


### PR DESCRIPTION
This is a new option to fix #314. I set the default to be backward compatible so it shouldn't change bugwarrior's behavior for existing users.
