### PR TITLE
Update docs link to readthedocs.io.

### DIFF
--- a/bugwarrior/README.rst
+++ b/bugwarrior/README.rst
@@ -27,7 +27,7 @@ Documentation
 -------------
 
 For information on how to install and use bugwarrior, read `the docs
-<https://bugwarrior.readthedocs.org>`_ on RTFD.
+<https://bugwarrior.readthedocs.io>`_ on RTFD.
 
 Build Status
 ------------


### PR DESCRIPTION
See <https://blog.readthedocs.com/securing-subdomains/>:

> Projects will automatically be redirected, and this redirect will remain in place for the foreseeable future. Still, you should plan on updating links to your documentation after the new domain goes live.