### PR TITLE
Include github private repos (take 2). Fix #282.

### DIFF
--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -78,8 +78,18 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
     @responses.activate
     def test_issues(self):
         self.add_response(
+            'https://api.github.com/user/repos?per_page=100',
+            json=[{
+                'name': 'some_repo',
+                'owner': {'login': 'some_username'}
+            }])
+
+        self.add_response(
             'https://api.github.com/users/arbitrary_username/repos?per_page=100',
-            json=[{'name': 'arbitrary_repo'}])
+            json=[{
+                'name': 'arbitrary_repo',
+                'owner': {'login': 'arbitrary_username'}
+            }])
 
         self.add_response(
             'https://api.github.com/repos/arbitrary_username/arbitrary_repo/issues?per_page=100',


### PR DESCRIPTION
It seems that the distinction was not properly documented for some time,
but it now is. `/user/repos` includes all repos the authorized user has
access to, but `/users/:username/repos` only includes public repos.
http://stackoverflow.com/questions/21907278/github-api-using-repo-scope-but-still-cant-see-private-repos

**Note**: This doesn't break anything for me but I'm not super familiar with the configuration options and am not sure if this might accidentally change their behavior.