### PR TITLE
Add missing import

### DIFF
--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -15,7 +15,7 @@ from twiggy import log
 
 from taskw.task import Task
 
-from bugwarrior.config import asbool, get_service_password
+from bugwarrior.config import asbool, die, get_service_password
 from bugwarrior.db import MARKUP, URLShortener
 
 


### PR DESCRIPTION
The `die()` function was used in `IssueService.validate_config()`, but it was never imported.

This bug was found using [pyflakes](https://github.com/pyflakes/pyflakes).