### PR TITLE
Kill twiggy.

### DIFF
--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -1,10 +1,8 @@
 import os
 
-from twiggy import log
 from lockfile import LockTimeout
 from lockfile.pidlockfile import PIDLockFile
 
-import twiggy
 import getpass
 import keyring
 import click
@@ -15,6 +13,9 @@ from bugwarrior.db import (
     get_defined_udas_as_strings,
     synchronize,
 )
+
+import logging
+log = logging.getLogger(__name__)
 
 
 # We overwrite 'list' further down.
@@ -37,7 +38,7 @@ def pull(dry_run, flavor, interactive, debug):
 
     Relies on configuration in bugwarriorrc
     """
-    twiggy.quickSetup()
+
     try:
         main_section = _get_section_name(flavor)
 
@@ -56,7 +57,7 @@ def pull(dry_run, flavor, interactive, debug):
         finally:
             lockfile.release()
     except LockTimeout:
-        log.name('command').critical(
+        log.critical(
             'Your taskrc repository is currently locked. '
             'Remove the file at %s if you are sure no other '
             'bugwarrior processes are currently running.' % (
@@ -64,9 +65,9 @@ def pull(dry_run, flavor, interactive, debug):
             )
         )
     except RuntimeError as e:
-        log.name('command').critical("Aborted (%s)" % e)
+        log.critical("Aborted (%s)" % e)
     except:
-        log.name('command').trace('error').critical('oh noes')
+        log.exception('oh noes')
 
 
 @click.group()

--- a/bugwarrior/services/activecollab.py
+++ b/bugwarrior/services/activecollab.py
@@ -1,10 +1,12 @@
 import re
 
 import pypandoc
-from twiggy import log
 from pyac.library import activeCollab
 from bugwarrior.services import IssueService, Issue
 from bugwarrior.config import die
+
+import logging
+log = logging.getLogger(__name__)
 
 
 class ActiveCollabClient(object):
@@ -242,8 +244,8 @@ class ActiveCollabService(IssueService):
                             subtask['task_id'] = task['task_id']
                             subtask['milestone'] = task['milestone']
                             issues.append(subtask)
-        log.name(self.target).debug(" Found {0} total", task_count)
-        log.name(self.target).debug(" Pruned down to {0}", len(issues))
+        log.debug(" Found %i total", task_count)
+        log.debug(" Pruned down to %i", len(issues))
         for issue in issues:
             issue_obj = self.get_issue_for_record(issue)
             extra = {

--- a/bugwarrior/services/activecollab2.py
+++ b/bugwarrior/services/activecollab2.py
@@ -3,10 +3,12 @@ import time
 
 import six
 import requests
-from twiggy import log
 
 from bugwarrior.services import IssueService, Issue, ServiceClient
 from bugwarrior.config import die
+
+import logging
+log = logging.getLogger(__name__)
 
 
 class ActiveCollab2Client(ServiceClient):
@@ -60,7 +62,7 @@ class ActiveCollab2Client(ServiceClient):
             assigned_task = self.get_task_dict(project_id, key, task)
 
             if assigned_task:
-                log.name(self.target).debug(
+                log.debug(
                     " Adding '" + assigned_task['description'] +
                     "' to task list.")
                 yield assigned_task
@@ -207,7 +209,7 @@ class ActiveCollab2Service(IssueService):
         projects = self.projects
         for project in projects:
             for project_id, project_name in project.iteritems():
-                log.name(self.target).debug(
+                log.debug(
                     " Getting tasks for #" + project_id +
                     " " + project_name + '"')
                 issue_generators.append(
@@ -216,8 +218,7 @@ class ActiveCollab2Service(IssueService):
                     )
                 )
 
-        log.name(self.target).debug(
-            " Elapsed Time: %s" % (time.time() - start))
+        log.debug(" Elapsed Time: %s" % (time.time() - start))
 
         for record in itertools.chain(*issue_generators):
             yield self.get_issue_for_record(record)

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -1,12 +1,13 @@
 from __future__ import unicode_literals
 
 import requests
-from twiggy import log
 
 from bugwarrior import data
 from bugwarrior.services import IssueService, Issue, ServiceClient
 from bugwarrior.config import asbool, die
 
+import logging
+log = logging.getLogger(__name__)
 
 class BitbucketIssue(Issue):
     TITLE = 'bitbuckettitle'
@@ -215,7 +216,7 @@ class BitbucketService(IssueService, ServiceClient):
         ])
 
         issues = sum([self.fetch_issues(repo) for repo in repo_tags], [])
-        log.name(self.target).debug(" Found {0} total.", len(issues))
+        log.debug(" Found %i total.", len(issues))
 
         closed = ['resolved', 'duplicate', 'wontfix', 'invalid', 'closed']
         try:
@@ -223,7 +224,7 @@ class BitbucketService(IssueService, ServiceClient):
         except KeyError:  # Undocumented API change.
             issues = filter(lambda tup: tup[1]['state'] not in closed, issues)
         issues = filter(self.include, issues)
-        log.name(self.target).debug(" Pruned down to {0}", len(issues))
+        log.debug(" Pruned down to %i", len(issues))
 
         for tag, issue in issues:
             issue_obj = self.get_issue_for_record(issue)
@@ -239,13 +240,13 @@ class BitbucketService(IssueService, ServiceClient):
         if not self.filter_merge_requests:
             pull_requests = sum(
                 [self.fetch_pull_requests(repo) for repo in repo_tags], [])
-            log.name(self.target).debug(" Found {0} total.", len(pull_requests))
+            log.debug(" Found %i total.", len(pull_requests))
 
             closed = ['rejected', 'fulfilled']
             not_resolved = lambda tup: tup[1]['state'] not in closed
             pull_requests = filter(not_resolved, pull_requests)
             pull_requests = filter(self.include, pull_requests)
-            log.name(self.target).debug(" Pruned down to {0}", len(pull_requests))
+            log.debug(" Pruned down to %i", len(pull_requests))
 
             for tag, issue in pull_requests:
                 issue_obj = self.get_issue_for_record(issue)

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -1,5 +1,4 @@
 import bugzilla
-from twiggy import log
 
 import time
 import pytz
@@ -8,6 +7,9 @@ import six
 
 from bugwarrior.config import die, asbool
 from bugwarrior.services import IssueService, Issue
+
+import logging
+log = logging.getLogger(__name__)
 
 
 class BugzillaIssue(Issue):
@@ -113,7 +115,7 @@ class BugzillaService(IssueService):
             'include_needinfos', False, to_type=lambda x: x == "True")
         self.open_statuses = self.config_get_default(
             'open_statuses', _open_statuses, to_type=lambda x: x.split(','))
-        log.name(self.target).debug(" filtering on statuses: {0}", self.open_statuses)
+        log.debug(" filtering on statuses: %r", self.open_statuses)
 
         # So more modern bugzilla's require that we specify
         # query_format=advanced along with the xmlrpc request.
@@ -235,7 +237,7 @@ class BugzillaService(IssueService):
         ]
 
         issues = [(self.target, bug) for bug in bugs]
-        log.name(self.target).debug(" Found {0} total.", len(issues))
+        log.debug(" Found %i total.", len(issues))
 
         # Build a url for each issue
         base_url = "https://%s/show_bug.cgi?id=" % (self.base_uri)

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -3,10 +3,12 @@ import six
 
 import requests
 from jinja2 import Template
-from twiggy import log
 
 from bugwarrior.config import asbool, die
 from bugwarrior.services import IssueService, Issue, ServiceClient
+
+import logging
+log = logging.getLogger(__name__)
 
 
 class GithubClient(ServiceClient):
@@ -284,7 +286,7 @@ class GithubService(IssueService):
             url = issue['html_url']
             tag = re.match('.*github\\.com/(.*)/(issues|pull)/[^/]*$', url)
             if tag is None:
-                log.name(self.target).critical(" Unrecognized issue URL: {0}.", url)
+                log.critical(" Unrecognized issue URL: %s.", url)
                 continue
             issues[url] = (tag.group(1), issue)
         return issues
@@ -313,7 +315,7 @@ class GithubService(IssueService):
         annotations = []
         if self.annotation_comments:
             comments = self._comments(tag, issue['number'])
-            log.name(self.target).debug(" got comments for {0}", issue['html_url'])
+            log.debug(" got comments for %s", issue['html_url'])
             annotations = ((
                 c['user']['login'],
                 c['body'],
@@ -373,9 +375,9 @@ class GithubService(IssueService):
                 )
         if self.config_get_default('include_user_issues', True, asbool):
             issues.update(self.get_directly_assigned_issues())
-        log.name(self.target).debug(" Found {0} issues.", len(issues))
+        log.debug(" Found %i issues.", len(issues))
         issues = filter(self.include, issues.values())
-        log.name(self.target).debug(" Pruned down to {0} issues.", len(issues))
+        log.debug(" Pruned down to %i issues.", len(issues))
 
         for tag, issue in issues:
             # Stuff this value into the upstream dict for:

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -4,10 +4,12 @@ import requests
 import six
 
 from jinja2 import Template
-from twiggy import log
 
 from bugwarrior.config import asbool, die
 from bugwarrior.services import IssueService, Issue, ServiceClient
+
+import logging
+log = logging.getLogger(__name__)
 
 
 class GitlabIssue(Issue):
@@ -354,9 +356,9 @@ class GitlabService(IssueService, ServiceClient):
             issues.update(
                 self.get_repo_issues(rid)
             )
-        log.name(self.target).debug(" Found {0} issues.", len(issues))
+        log.debug(" Found %i issues.", len(issues))
         issues = filter(self.include, issues.values())
-        log.name(self.target).debug(" Pruned down to {0} issues.", len(issues))
+        log.debug(" Pruned down to %i issues.", len(issues))
 
         for rid, issue in issues:
             repo = repo_map[rid]
@@ -380,9 +382,9 @@ class GitlabService(IssueService, ServiceClient):
                 merge_requests.update(
                     self.get_repo_merge_requests(rid)
                 )
-            log.name(self.target).debug(" Found {0} merge requests.", len(merge_requests))
+            log.debug(" Found %i merge requests.", len(merge_requests))
             merge_requests = filter(self.include, merge_requests.values())
-            log.name(self.target).debug(" Pruned down to {0} merge requests.", len(merge_requests))
+            log.debug(" Pruned down to %i merge requests.", len(merge_requests))
 
             for rid, issue in merge_requests:
                 repo = repo_map[rid]

--- a/bugwarrior/services/mplan.py
+++ b/bugwarrior/services/mplan.py
@@ -1,10 +1,12 @@
 from __future__ import absolute_import
 
 import megaplan
-from twiggy import log
 
 from bugwarrior.config import die
 from bugwarrior.services import IssueService, Issue
+
+import logging
+log = logging.getLogger(__name__)
 
 
 class MegaplanIssue(Issue):
@@ -104,7 +106,7 @@ class MegaplanService(IssueService):
 
     def issues(self):
         issues = self.client.get_actual_tasks()
-        log.name(self.target).debug(" Found {0} total.", len(issues))
+        log.debug(" Found %i total.", len(issues))
 
         for issue in issues:
             yield self.get_issue_for_record(issue)

--- a/bugwarrior/services/pagure.py
+++ b/bugwarrior/services/pagure.py
@@ -6,10 +6,13 @@ import pytz
 import requests
 
 from jinja2 import Template
-from twiggy import log
 
 from bugwarrior.config import asbool, die
 from bugwarrior.services import IssueService, Issue
+
+import logging
+log = logging.getLogger(__name__)
+
 
 class PagureIssue(Issue):
     TITLE = 'paguretitle'
@@ -204,9 +207,9 @@ class PagureService(IssueService):
             issues.extend(self.get_issues(repo, ('issues', 'issues')))
             issues.extend(self.get_issues(repo, ('pull-requests', 'requests')))
 
-        log.name(self.target).debug(" Found {0} issues.", len(issues))
+        log.debug(" Found %i issues.", len(issues))
         issues = filter(self.include, issues)
-        log.name(self.target).debug(" Pruned down to {0} issues.", len(issues))
+        log.debug(" Pruned down to %i issues.", len(issues))
 
         for repo, issue in issues:
             # Stuff this value into the upstream dict for:

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -1,10 +1,13 @@
 import six
-from twiggy import log
 
 from bugwarrior.services import IssueService, Issue
 
 # This comes from PyPI
 import phabricator
+
+import logging
+log = logging.getLogger(__name__)
+
 
 class PhabricatorIssue(Issue):
     TITLE = 'phabricatortitle'
@@ -92,7 +95,7 @@ class PhabricatorService(IssueService):
             issues = self.api.maniphest.query(status='status-open')
             issues = list(issues.iteritems())
 
-        log.name(self.target).info("Found %i issues" % len(issues))
+        log.info("Found %i issues" % len(issues))
 
         for phid, issue in issues:
 
@@ -135,7 +138,7 @@ class PhabricatorService(IssueService):
         diffs = self.api.differential.query(status='status-open')
         diffs = list(diffs)
 
-        log.name(self.target).info("Found %i differentials" % len(diffs))
+        log.info("Found %i differentials" % len(diffs))
 
         for diff in list(diffs):
 

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -1,9 +1,11 @@
 import six
 import requests
-from twiggy import log
 
 from bugwarrior.config import die
 from bugwarrior.services import Issue, IssueService, ServiceClient
+
+import logging
+log = logging.getLogger(__name__)
 
 
 class RedMineClient(ServiceClient):
@@ -136,7 +138,7 @@ class RedMineService(IssueService):
 
     def issues(self):
         issues = self.client.find_issues(self.user_id)
-        log.name(self.target).debug(" Found {0} total.", len(issues))
+        log.debug(" Found %i total.", len(issues))
 
         for issue in issues:
             yield self.get_issue_for_record(issue)

--- a/bugwarrior/services/teamlab.py
+++ b/bugwarrior/services/teamlab.py
@@ -1,9 +1,11 @@
 import six
 import requests
-from twiggy import log
 
 from bugwarrior.config import die
 from bugwarrior.services import Issue, IssueService, ServiceClient
+
+import logging
+log = logging.getLogger(__name__)
 
 
 class TeamLabClient(ServiceClient):
@@ -138,13 +140,11 @@ class TeamLabService(IssueService):
 
     def issues(self):
         issues = self.client.get_task_list()
-        log.name(self.target).debug(
-            " Remote has {0} total issues.", len(issues))
+        log.debug(" Remote has %i total issues.", len(issues))
 
         # Filter out closed tasks.
         issues = filter(lambda i: i["status"] == 1, issues)
-        log.name(self.target).debug(
-            " Remote has {0} active issues.", len(issues))
+        log.debug(" Remote has %i active issues.", len(issues))
 
         for issue in issues:
             yield self.get_issue_for_record(issue)

--- a/bugwarrior/services/trac.py
+++ b/bugwarrior/services/trac.py
@@ -2,11 +2,13 @@ import offtrac
 import csv
 import cStringIO as StringIO
 import requests
-from twiggy import log
 import urllib
 
 from bugwarrior.config import die
 from bugwarrior.services import Issue, IssueService
+
+import logging
+log = logging.getLogger(__name__)
 
 
 class TracIssue(Issue):
@@ -153,10 +155,10 @@ class TracService(IssueService):
                 issues[i][1]['url'] = "%s/ticket/%s" % (base_url, tickets[i]['id'])
                 issues[i][1]['number'] = int(tickets[i]['id'])
 
-        log.name(self.target).debug(" Found {0} total.", len(issues))
+        log.debug(" Found %i total.", len(issues))
 
         issues = filter(self.include, issues)
-        log.name(self.target).debug(" Pruned down to {0}", len(issues))
+        log.debug(" Pruned down to %i", len(issues))
 
         for project, issue in issues:
             issue_obj = self.get_issue_for_record(issue)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(name='bugwarrior',
       include_package_data=True,
       zip_safe=False,
       install_requires=[
-          "twiggy",
           "requests",
           "offtrac",
           "python-bugzilla",


### PR DESCRIPTION
I used it on a whim when I first started writing bugwarrior, but it has
proved to be annoying.  It has problems interpolating strings when we
don't want it to and it has all kinds of weird encoding handling that
keeps raising new bugs.

The stdlib logging is sufficient.