### PR TITLE
Modify headers instead of overwriting.

### DIFF
--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -17,7 +17,7 @@ class GithubClient(ServiceClient):
         self.session = requests.Session()
         if 'token' in self.auth:
             authorization = 'token ' + self.auth['token']
-            self.session.headers = {'Authorization': authorization}
+            self.session.headers['Authorization'] = authorization
 
     def get_repos(self, username):
         user_repos = self._getter(


### PR DESCRIPTION
There are some default headers attached to requests sessions:

```python
>>> import requests
>>> s = requests.session()
>>> print(s.headers)
{
    'Connection': 'keep-alive',
    'Accept-Encoding': 'gzip, deflate',
    'Accept': '*/*',
    'User-Agent': 'python-requests/2.10.0',
}
```

In #332 we accidentally started overwriting all of those defaults.
This change brings them back into play and should fix #345.