### PR TITLE
Debian BTS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - pip install responses
   - cd $TRAVIS_BUILD_DIR
 install:
-  - pip install .[jira,megaplan,activecollab]
+  - pip install .[jira,megaplan,activecollab,bts]
   - pip install coveralls
   - pip install coverage
 script: nosetests -w tests --with-coverage --cover-package=bugwarrior

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
   - pip install taskw
   - pip install mock
   - pip install responses
+  - pip install PySimpleSOAP
   - cd $TRAVIS_BUILD_DIR
 install:
   - pip install .[jira,megaplan,activecollab,bts]

--- a/bugwarrior/README.rst
+++ b/bugwarrior/README.rst
@@ -62,3 +62,5 @@ Contributors
 - Luke Macken (contributed some code cleaning)
 - James Rowe (contributed to the docs)
 - Adam Coddington (anti-entropy crusader)
+- Iain R. Learmonth (contributed support for the Debian BTS and maintains the
+  Debian package)

--- a/bugwarrior/docs/services/bts.rst
+++ b/bugwarrior/docs/services/bts.rst
@@ -58,6 +58,20 @@ feature, you can add this line to your service configuration::
 
     bts.udd = True
 
+Excluding bugs marked pending
++++++++++++++++++++++++++++++
+
+Debian bugs are not considered closed until the fixed package is present in the
+Debian archive. Bugs do cease to be outstanding tasks however as soon as you have
+completed the work, and so it can be useful to exclude bugs that you have marked
+with the pending tag in the BTS.
+
+This is the default behaviour, but if you feel you would like to include bugs that
+are marked as pending in the BTS, you can disable this by adding this line to your
+service configuration::
+
+    bts.ignore_pending = False
+
 Excluding sponsored and NMU'd packages
 ++++++++++++++++++++++++++++++++++++++
 
@@ -106,5 +120,7 @@ Provided UDA Fields
 | ``btspackage``      | Binary Package      | Text (string)       |
 +---------------------+---------------------+---------------------+
 | ``btsforwarded``    | Forwarded URL       | Text (string)       |
++---------------------+---------------------+---------------------+
+| ``btsstatus``       | Status              | Text (string)       |
 +---------------------+---------------------+---------------------+
 

--- a/bugwarrior/docs/services/bts.rst
+++ b/bugwarrior/docs/services/bts.rst
@@ -1,11 +1,20 @@
 Debian Bug Tracking System (BTS)
 ================================
 
-You can import tasks from your {{ service_name_humane }} instance using
-the ``{{ service_name }}`` service name.
+You can import tasks from the Debian Bug Tracking System (BTS) using
+the ``bts`` service name. Debian's bugs are public and no authentication
+information is required by bugwarrior for this service.
 
-Instructions
-------------
+Additional Requirements
+-----------------------
+
+You will need to install the following additional packages via ``pip``:
+
+ * ``PySimpleSOAP``
+ * ``python-debianbts``
+
+.. note:: If you have installed the Debian package for bugwarrior, this
+          dependency will already be satisfied.
 
 Example Service
 ---------------
@@ -28,14 +37,12 @@ Include all bugs for packages
 +++++++++++++++++++++++++++++
 
 If you would like more bugs than just those you are the owner of, you can specify
-the ```bts.packages``` option.
+the ``bts.packages`` option.
 
-For example if you wanted to include bugs on the ```hello``` package, you can add
-this line to your service configuration:
+For example if you wanted to include bugs on the ``hello`` package, you can add
+this line to your service configuration::
 
-```
-bts.packages = hello
-```
+    bts.packages = hello
 
 More packages can be specified seperated by commas.
 
@@ -47,11 +54,9 @@ packages where you are listed as a Maintainer or an Uploader in the Debian archi
 you can enable the use of the `UDD Bugs Search <https://udd.debian.org/bugs/>`_.
 
 This will peform a search and include the bugs from the result. To enable this
-feature, you can add this line to your service configuration:
+feature, you can add this line to your service configuration::
 
-```
-bts.udd = True
-```
+    bts.udd = True
 
 Excluding sponsored and NMU'd packages
 ++++++++++++++++++++++++++++++++++++++
@@ -61,11 +66,9 @@ packages.
 
 You can exclude packages that you have sponsored or have uploaded as a
 non-maintainer upload or team upload by adding the following line to your
-service configuration:
+service configuration::
 
-```
-bts.udd_ignore_sponsor = True
-```
+    bts.udd_ignore_sponsor = True
 
 .. note:: This will only affect the bugs returned by the UDD bugs search service
           and will not exclude bugs that are discovered due to ownership or due
@@ -78,14 +81,12 @@ If you would like to exclude a particularly noisy package, that is perhaps team
 maintained, or a package that you have orphaned and no longer have interest in but
 are still listed as Maintainer or Uploader in stable suites, you can explicitly
 ignore bugs based on their binary or source package names. To do this add one
-of the following lines to your service configuration:
+of the following lines to your service configuration::
 
-```
-bts.ignore_pkg = hello,anarchism
-bts.ignore_src = linux
-```
+    bts.ignore_pkg = hello,anarchism
+    bts.ignore_src = linux
 
-.. note:: The ```src:``` prefix that is commonly seen in the Debian BTS interface
+.. note:: The ``src:`` prefix that is commonly seen in the Debian BTS interface
           is not required when specifying source packages to exclude.
 
 Provided UDA Fields

--- a/bugwarrior/docs/services/bts.rst
+++ b/bugwarrior/docs/services/bts.rst
@@ -23,7 +23,7 @@ Here's an example of a Debian BTS target::
 
     [debian_bts]
     service = bts
-    email = username@debian.org
+    bts.email = username@debian.org
 
 The above example is the minimum required to import issues from
 the Debian BTS.  You can also feel free to use any of the configuration options

--- a/bugwarrior/docs/services/bts.rst
+++ b/bugwarrior/docs/services/bts.rst
@@ -1,0 +1,109 @@
+Debian Bug Tracking System (BTS)
+================================
+
+You can import tasks from your {{ service_name_humane }} instance using
+the ``{{ service_name }}`` service name.
+
+Instructions
+------------
+
+Example Service
+---------------
+
+Here's an example of a Debian BTS target::
+
+    [debian_bts]
+    service = bts
+    email = username@debian.org
+
+The above example is the minimum required to import issues from
+the Debian BTS.  You can also feel free to use any of the configuration options
+described in :ref:`common_configuration_options` or described in `Service
+Features`_ below.
+
+Service Features
+----------------
+
+Include all bugs for packages
++++++++++++++++++++++++++++++
+
+If you would like more bugs than just those you are the owner of, you can specify
+the ```bts.packages``` option.
+
+For example if you wanted to include bugs on the ```hello``` package, you can add
+this line to your service configuration:
+
+```
+bts.packages = hello
+```
+
+More packages can be specified seperated by commas.
+
+Ultimate Debian Database (UDD) Bugs Search
+++++++++++++++++++++++++++++++++++++++++++
+
+If you maintain a large number of packages and you wish to include bugs from all
+packages where you are listed as a Maintainer or an Uploader in the Debian archive,
+you can enable the use of the `UDD Bugs Search <https://udd.debian.org/bugs/>`_.
+
+This will peform a search and include the bugs from the result. To enable this
+feature, you can add this line to your service configuration:
+
+```
+bts.udd = True
+```
+
+Excluding sponsored and NMU'd packages
+++++++++++++++++++++++++++++++++++++++
+
+If you maintain an even larger number of packages, you may wish to exclude some
+packages.
+
+You can exclude packages that you have sponsored or have uploaded as a
+non-maintainer upload or team upload by adding the following line to your
+service configuration:
+
+```
+bts.udd_ignore_sponsor = True
+```
+
+.. note:: This will only affect the bugs returned by the UDD bugs search service
+          and will not exclude bugs that are discovered due to ownership or due
+          to packages explicitly specified in the service configuration.
+
+Excluding packages explicitly
++++++++++++++++++++++++++++++
+
+If you would like to exclude a particularly noisy package, that is perhaps team
+maintained, or a package that you have orphaned and no longer have interest in but
+are still listed as Maintainer or Uploader in stable suites, you can explicitly
+ignore bugs based on their binary or source package names. To do this add one
+of the following lines to your service configuration:
+
+```
+bts.ignore_pkg = hello,anarchism
+bts.ignore_src = linux
+```
+
+.. note:: The ```src:``` prefix that is commonly seen in the Debian BTS interface
+          is not required when specifying source packages to exclude.
+
+Provided UDA Fields
+-------------------
+
++---------------------+---------------------+---------------------+
+| Field Name          | Description         | Type                |
++=====================+=====================+=====================+
+| ``btsnumber``       | Bug Number          | Text (string)       |
++---------------------+---------------------+---------------------+
+| ``btsurl``          | bugs.d.o URL        | Text (string)       |
++---------------------+---------------------+---------------------+
+| ``btssubject``      | Subject             | Text (string)       |
++---------------------+---------------------+---------------------+
+| ``btssource``       | Source Package      | Text (string)       |
++---------------------+---------------------+---------------------+
+| ``btspackage``      | Binary Package      | Text (string)       |
++---------------------+---------------------+---------------------+
+| ``btsforwarded``    | Forwarded URL       | Text (string)       |
++---------------------+---------------------+---------------------+
+

--- a/bugwarrior/services/bts.py
+++ b/bugwarrior/services/bts.py
@@ -1,7 +1,7 @@
 import debianbts
 import requests
 
-from bugwarrior.config import die
+from bugwarrior.config import die, asbool
 from bugwarrior.services import Issue, IssueService, ServiceClient
 
 import logging
@@ -91,8 +91,8 @@ class BTSService(IssueService, ServiceClient):
         super(BTSService, self).__init__(*args, **kw)
         self.email = self.config_get_default('email', default=None)
         self.packages = self.config_get_default('packages', default=None)
-        self.udd = self.config_get_default('udd', default=False).lower() in ['true', 'yes', 'enabled']
-        self.udd_ignore_sponsor = self.config_get_default('udd_ignore_sponsor', default="True").lower() in ['true', 'yes', 'enabled']
+        self.udd = self.config_get_default('udd', default=False, to_type=asbool)
+        self.udd_ignore_sponsor = self.config_get_default('udd_ignore_sponsor', default=True, to_type=asbool)
         self.ignore_pkg = self.config_get_default('ignore_pkg', default=None)
         self.ignore_src = self.config_get_default('ignore_src', default=None)
 

--- a/bugwarrior/services/bts.py
+++ b/bugwarrior/services/bts.py
@@ -98,10 +98,14 @@ class BTSService(IssueService, ServiceClient):
 
     @classmethod
     def validate_config(cls, config, target):
-#        if not config.has_option(target, 'trac.base_uri'):
-#            die("[%s] has no 'base_uri'" % target)
-#        elif '://' in config.get(target, 'trac.base_uri'):
-#            die("[%s] do not include scheme in 'base_uri'" % target)
+	if ( config.has_option(target, 'bts.udd') and
+                asbool(config.get(target, 'bts.udd')) == True and
+                not config.has_option(target, 'bts.email') ):
+            die("[%s] has no 'bts.email' but UDD search was requested" % target)
+
+	if ( not config.has_option(target, 'bts.packages') and
+                not config.has_option(target, 'bts.email') ):
+            die("[%s] has neither 'bts.email' or 'bts.packages'" % target)
 
         IssueService.validate_config(config, target)
 

--- a/bugwarrior/services/bts.py
+++ b/bugwarrior/services/bts.py
@@ -89,7 +89,6 @@ class BTSService(IssueService, ServiceClient):
 
     def __init__(self, *args, **kw):
         super(BTSService, self).__init__(*args, **kw)
-        self.bts = debianbts
         self.email = self.config_get_default('email', default=None)
         self.packages = self.config_get_default('packages', default=None)
         self.udd = self.config_get_default('udd', default=False, to_type=asbool)
@@ -133,14 +132,14 @@ class BTSService(IssueService, ServiceClient):
 
         # Search BTS for bugs owned by email address
         if self.email:
-            owned_bugs = self.bts.get_bugs("owner", self.email, "status", "open")
+            owned_bugs = debianbts.get_bugs("owner", self.email, "status", "open")
             collected_bugs.extend(owned_bugs)
 
         # Search BTS for bugs related to specified packages
         if self.packages:
             packages = self.packages.split(",")
             for pkg in packages:
-                pkg_bugs = self.bts.get_bugs("package", pkg, "status", "open")
+                pkg_bugs = debianbts.get_bugs("package", pkg, "status", "open")
                 for bug in pkg_bugs:
                     if bug not in collected_bugs:
                         collected_bugs.append(bug)
@@ -153,7 +152,7 @@ class BTSService(IssueService, ServiceClient):
                 if bug not in collected_bugs:
                     collected_bugs.append(bug['id'])
 
-        issues = [self._record_for_bug(bug) for bug in self.bts.get_status(collected_bugs)]
+        issues = [self._record_for_bug(bug) for bug in debianbts.get_status(collected_bugs)]
 
         log.debug(" Found %i total.", len(issues))
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(name='bugwarrior',
       extras_require=dict(
           jira=["jira>=0.22"],
           megaplan=["megaplan>=1.4"],
-          activecollab=["pypandoc", "pyac"]
+          activecollab=["pypandoc", "pyac"],
+          bts=["PySimpleSOAP","python-debianbts"],
       ),
       tests_require=[
           "Mock",
@@ -54,6 +55,7 @@ setup(name='bugwarrior',
           "bugwarrior[jira]",
           "bugwarrior[megaplan]",
           "bugwarrior[activecollab]",
+          "bugwarrior[bts]",
       ],
       test_suite='nose.collector',
       entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(name='bugwarrior',
       gitlab=bugwarrior.services.gitlab:GitlabService
       bitbucket=bugwarrior.services.bitbucket:BitbucketService
       trac=bugwarrior.services.trac:TracService
+      bts=bugwarrior.services.bts:BTSService
       bugzilla=bugwarrior.services.bz:BugzillaService
       teamlab=bugwarrior.services.teamlab:TeamLabService
       redmine=bugwarrior.services.redmine:RedMineService

--- a/tests/test_bts.py
+++ b/tests/test_bts.py
@@ -9,6 +9,7 @@ class FakeBTSBug(object):
     severity = "wishlist"
     source = ""
     forwarded = ""
+    pending = "pending"
 
 class FakeBTSLib(object):
     def get_bugs(self, *args, **kwargs):
@@ -50,6 +51,7 @@ class TestBTSService(AbstractServiceTest, ServiceTest):
             issue.PACKAGE: FakeBTSBug.package,
             issue.SOURCE: FakeBTSBug.source,
             issue.FORWARDED: FakeBTSBug.forwarded,
+            issue.STATUS: FakeBTSBug.pending,
         }
         actual_output = issue.to_taskwarrior()
 
@@ -67,6 +69,7 @@ class TestBTSService(AbstractServiceTest, ServiceTest):
             'btssource': '',
             'description': u'(bw)Is#810629 - ITP: bugwarrior -- Pull tickets from github, bitbucket, bugzilla, jira, trac, and others into taskwa .. https://bugs.debian.org/810629',
             'priority': 'L',
+            'btsstatus': 'pending',
             u'tags': []}
 
         self.assertEqual(issue.get_taskwarrior_record(), expected)

--- a/tests/test_bts.py
+++ b/tests/test_bts.py
@@ -1,4 +1,4 @@
-from bugwarrior.services.bts import BTSService
+import bugwarrior.services.bts as bts
 
 from .base import ServiceTest, AbstractServiceTest
 
@@ -18,7 +18,6 @@ class FakeBTSLib(object):
         if bug_num == [810629]:
             return [FakeBTSBug]
 
-
 class TestBTSService(AbstractServiceTest, ServiceTest):
 
     maxDiff = None
@@ -29,12 +28,12 @@ class TestBTSService(AbstractServiceTest, ServiceTest):
     }
 
     def setUp(self):
-        self.service = self.get_mock_service(BTSService)
+        self.service = self.get_mock_service(bts.BTSService)
 
     def get_mock_service(self, *args, **kwargs):
+        bts.debianbts = FakeBTSLib()
         service = super(TestBTSService, self).get_mock_service(
             *args, **kwargs)
-        service.bts = FakeBTSLib()
         return service
 
     def test_to_taskwarrior(self):

--- a/tests/test_bts.py
+++ b/tests/test_bts.py
@@ -1,0 +1,73 @@
+from bugwarrior.services.bts import BTSService
+
+from .base import ServiceTest, AbstractServiceTest
+
+class FakeBTSBug(object):
+    bug_num = 810629
+    package = "wnpp"
+    subject = "ITP: bugwarrior -- Pull tickets from github, bitbucket, bugzilla, jira, trac, and others into taskwarrior"
+    severity = "wishlist"
+    source = ""
+    forwarded = ""
+
+class FakeBTSLib(object):
+    def get_bugs(self, *args, **kwargs):
+        return [810629]
+
+    def get_status(self, bug_num):
+        if bug_num == [810629]:
+            return [FakeBTSBug]
+
+
+class TestBTSService(AbstractServiceTest, ServiceTest):
+
+    maxDiff = None
+
+    SERVICE_CONFIG = {
+        'bts.email': 'irl@debian.org',
+        'bts.packages': 'bugwarrior',
+    }
+
+    def setUp(self):
+        self.service = self.get_mock_service(BTSService)
+
+    def get_mock_service(self, *args, **kwargs):
+        service = super(TestBTSService, self).get_mock_service(
+            *args, **kwargs)
+        service.bts = FakeBTSLib()
+        return service
+
+    def test_to_taskwarrior(self):
+        issue = self.service.get_issue_for_record(
+            self.service._record_for_bug(FakeBTSBug)
+        )
+
+        expected_output = {
+            'priority': issue.PRIORITY_MAP[FakeBTSBug.severity],
+
+            issue.URL: "https://bugs.debian.org/" + str(FakeBTSBug.bug_num),
+            issue.SUBJECT: FakeBTSBug.subject,
+            issue.NUMBER: FakeBTSBug.bug_num,
+            issue.PACKAGE: FakeBTSBug.package,
+            issue.SOURCE: FakeBTSBug.source,
+            issue.FORWARDED: FakeBTSBug.forwarded,
+        }
+        actual_output = issue.to_taskwarrior()
+
+        self.assertEqual(actual_output, expected_output)
+
+    def test_issues(self):
+        issue = next(self.service.issues())
+
+        expected = {
+            'btsnumber': 810629,
+            'btsforwarded': '',
+            'btspackage': 'wnpp',
+            'btssubject': 'ITP: bugwarrior -- Pull tickets from github, bitbucket, bugzilla, jira, trac, and others into taskwarrior',
+            'btsurl': 'https://bugs.debian.org/810629',
+            'btssource': '',
+            'description': u'(bw)Is#810629 - ITP: bugwarrior -- Pull tickets from github, bitbucket, bugzilla, jira, trac, and others into taskwa .. https://bugs.debian.org/810629',
+            'priority': 'L',
+            u'tags': []}
+
+        self.assertEqual(issue.get_taskwarrior_record(), expected)

--- a/tests/test_bts.py
+++ b/tests/test_bts.py
@@ -2,14 +2,18 @@ import bugwarrior.services.bts as bts
 
 from .base import ServiceTest, AbstractServiceTest
 
+
 class FakeBTSBug(object):
     bug_num = 810629
     package = "wnpp"
-    subject = "ITP: bugwarrior -- Pull tickets from github, bitbucket, bugzilla, jira, trac, and others into taskwarrior"
+    subject = ("ITP: bugwarrior -- Pull tickets from github, "
+               "bitbucket, bugzilla, jira, trac, and others into "
+               "taskwarrior")
     severity = "wishlist"
     source = ""
     forwarded = ""
     pending = "pending"
+
 
 class FakeBTSLib(object):
     def get_bugs(self, *args, **kwargs):
@@ -18,6 +22,7 @@ class FakeBTSLib(object):
     def get_status(self, bug_num):
         if bug_num == [810629]:
             return [FakeBTSBug]
+
 
 class TestBTSService(AbstractServiceTest, ServiceTest):
 
@@ -64,10 +69,15 @@ class TestBTSService(AbstractServiceTest, ServiceTest):
             'btsnumber': 810629,
             'btsforwarded': '',
             'btspackage': 'wnpp',
-            'btssubject': 'ITP: bugwarrior -- Pull tickets from github, bitbucket, bugzilla, jira, trac, and others into taskwarrior',
+            'btssubject': ('ITP: bugwarrior -- Pull tickets from github, '
+                           'bitbucket, bugzilla, jira, trac, and others into '
+                           'taskwarrior'),
             'btsurl': 'https://bugs.debian.org/810629',
             'btssource': '',
-            'description': u'(bw)Is#810629 - ITP: bugwarrior -- Pull tickets from github, bitbucket, bugzilla, jira, trac, and others into taskwa .. https://bugs.debian.org/810629',
+            'description': (u'(bw)Is#810629 - ITP: bugwarrior -- Pull tickets'
+                            u' from github, bitbucket, bugzilla, jira, trac, '
+                            u'and others into taskwa .. https://bugs.debian.o'
+                            u'rg/810629'),
             'priority': 'L',
             'btsstatus': 'pending',
             u'tags': []}


### PR DESCRIPTION
This pull request adds a service ```bts``` for the Debian Bug Tracking System (BTS) that is used to track bugs on packages distributed as part of the Debian Operating System.

This pull request closes #327.