### PR TITLE
Make Jira installation example in docs ZSH compatible

### DIFF
--- a/bugwarrior/docs/getting.rst
+++ b/bugwarrior/docs/getting.rst
@@ -20,10 +20,6 @@ and Active Collab but those require extra dependencies that are installed by
 specifying ``bugwarrior[service]`` in the commands above. For example, if you
 want to use bugwarrior with Jira::
 
-    $ pip install bugwarrior[jira]
-
-If you are using the z-shell (ZSH) you need to add quotation marks:
-
     $ pip install "bugwarrior[jira]"
 
 

--- a/bugwarrior/docs/getting.rst
+++ b/bugwarrior/docs/getting.rst
@@ -22,6 +22,10 @@ want to use bugwarrior with Jira::
 
     $ pip install bugwarrior[jira]
 
+If you are using the z-shell (ZSH) you need to add quotation marks:
+
+    $ pip install "bugwarrior[jira]"
+
 
 Installing from Source
 ----------------------


### PR DESCRIPTION
In ZSH running `pip install bugwarrior[jira] doesn't work as the shell will try to interpret bugwarrior[jira] as a command. Therefore I've added a hint on how to install the Jira plugin on ZSH which requires adding quotation marks around the installation target.