### PR TITLE
Add help text to bugwarrior-pull's --debug flag.

### DIFF
--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -32,7 +32,8 @@ def _get_section_name(flavor):
 @click.option('--dry-run', is_flag=True)
 @click.option('--flavor', default=None, help='The flavor to use')
 @click.option('--interactive', is_flag=True)
-@click.option('--debug', is_flag=True)
+@click.option('--debug', is_flag=True,
+              help='Do not use multiprocessing (which breaks pdb).')
 def pull(dry_run, flavor, interactive, debug):
     """ Pull down tasks from forges and add them to your taskwarrior tasks.
 


### PR DESCRIPTION
This should protect it from cold-blooded killers like @ralphbean.
(See #333.)