### PR TITLE
Make bitbucketid numeric.

### DIFF
--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -24,7 +24,7 @@ class BitbucketIssue(Issue):
             'label': 'Bitbucket URL',
         },
         FOREIGN_ID: {
-            'type': 'string',
+            'type': 'numeric',
             'label': 'Bitbucket Issue ID',
         }
     }


### PR DESCRIPTION
This silences all the warnings from taskw that a number is being coerced
into a string.

I'm not sure what the ramifications of this might be. Looking at the json files, this doesn't appear to have caused an automatic migration or duplication among existing tasks. Any thoughts on how to proceed would be appreciated.