### PR TITLE
Get data location from taskwarrior.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ python:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install uuid-dev
-  - wget http://taskwarrior.org/download/task-2.3.0.tar.gz
-  - gunzip task-2.3.0.tar.gz
-  - tar xf task-2.3.0.tar
-  - cd task-2.3.0
+  - wget http://taskwarrior.org/download/task-2.4.4.tar.gz
+  - gunzip task-2.4.4.tar.gz
+  - tar xf task-2.4.4.tar
+  - cd task-2.4.4
   - cmake .
   - make
   - sudo make install

--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -60,7 +60,8 @@ def pull(dry_run, flavor, interactive, debug):
         main_section = _get_section_name(flavor)
         config = _try_load_config(main_section, interactive)
 
-        lockfile_path = os.path.join(get_data_path(), 'bugwarrior.lockfile')
+        lockfile_path = os.path.join(get_data_path(config, main_section),
+                                     'bugwarrior.lockfile')
         lockfile = PIDLockFile(lockfile_path)
         lockfile.acquire(timeout=10)
         try:

--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -220,10 +220,7 @@ def get_data_path(config, main_section):
     data_path = data_location[len(line_prefix):].rstrip()
 
     if not data_path:
-        data_path = os.getenv('TASKDATA', '~/.task')
-        log.warning(
-            'Unable to determine the data location. Falling back to %s.' %
-            data_path)
+        raise RuntimeError('Unable to determine the data location.')
 
     return os.path.normpath(os.path.expanduser(data_path))
 

--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -213,7 +213,9 @@ def get_data_path(config, main_section):
     # the `_` subcommands properly (`rc:` can't be used for them).
     line_prefix = 'data.location='
     tw_show = subprocess.Popen(
-        ('task', '_show'), stdout=subprocess.PIPE, env={'TASKRC': taskrc})
+        ('task', '_show'),
+        stdout=subprocess.PIPE,
+        env={'PATH': os.getenv('PATH'), 'TASKRC': taskrc})
     data_location = subprocess.check_output(
         ('grep', '-e', '^' + line_prefix), stdin=tw_show.stdout)
     tw_show.wait()

--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -215,7 +215,7 @@ def get_data_path(config, main_section):
     tw_show = subprocess.Popen(
         ('task', '_show'), stdout=subprocess.PIPE, env={'TASKRC': taskrc})
     data_location = subprocess.check_output(
-        ('grep', line_prefix), stdin=tw_show.stdout)
+        ('grep', '-e', '^' + line_prefix), stdin=tw_show.stdout)
     tw_show.wait()
     data_path = data_location[len(line_prefix):].rstrip()
 

--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -212,10 +212,18 @@ def get_data_path(config, main_section):
     # We cannot use the taskw module here because it doesn't really support
     # the `_` subcommands properly (`rc:` can't be used for them).
     line_prefix = 'data.location='
+
+    env={
+        'PATH': os.getenv('PATH'),
+        'TASKRC': taskrc,
+    }
+    # If TASKDATA is set but empty, taskwarrior's data.location is empty.
+    taskdata = os.getenv('TASKDATA')
+    if taskdata:
+        env['TASKDATA'] = taskdata
+
     tw_show = subprocess.Popen(
-        ('task', '_show'),
-        stdout=subprocess.PIPE,
-        env={'PATH': os.getenv('PATH'), 'TASKRC': taskrc})
+        ('task', '_show'), stdout=subprocess.PIPE, env=env)
     data_location = subprocess.check_output(
         ('grep', '-e', '^' + line_prefix), stdin=tw_show.stdout)
     tw_show.wait()

--- a/bugwarrior/data.py
+++ b/bugwarrior/data.py
@@ -6,30 +6,31 @@ from lockfile.pidlockfile import PIDLockFile
 from bugwarrior.config import get_data_path
 
 
-DATAFILE = os.path.join(get_data_path(), 'bugwarrior.data')
-LOCKFILE = os.path.join(get_data_path(), 'bugwarrior-data.lockfile')
+class BugwarriorData(object):
+    def __init__(self, config, main_section):
+        data_path = get_data_path(config, main_section)
+        self.datafile = os.path.join(data_path, 'bugwarrior.data')
+        self.lockfile = os.path.join(data_path, 'bugwarrior-data.lockfile')
 
-
-def get(key):
-    try:
-        with open(DATAFILE, 'r') as jsondata:
-            try:
-                data = json.load(jsondata)
-            except ValueError:  # File does not contain JSON.
-                return None
-            else:
-                return data[key]
-    except IOError:  # File does not exist.
-        return None
-
-
-def set(key, value):
-    with PIDLockFile(LOCKFILE):
+    def get(self, key):
         try:
-            with open(DATAFILE, 'r+') as jsondata:
-                data = json.load(jsondata)
-                data[key] = value
-                json.dump(data, jsondata)
+            with open(self.datafile, 'r') as jsondata:
+                try:
+                    data = json.load(jsondata)
+                except ValueError:  # File does not contain JSON.
+                    return None
+                else:
+                    return data[key]
         except IOError:  # File does not exist.
-            with open(DATAFILE, 'w+') as jsondata:
-                json.dump({key: value}, jsondata)
+            return None
+
+    def set(self, key, value):
+        with PIDLockFile(self.lockfile):
+            try:
+                with open(self.datafile, 'r+') as jsondata:
+                    data = json.load(jsondata)
+                    data[key] = value
+                    json.dump(data, jsondata)
+            except IOError:  # File does not exist.
+                with open(self.datafile, 'w+') as jsondata:
+                    json.dump({key: value}, jsondata)

--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -287,7 +287,7 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
         log.info(
             'Service-defined UDAs exist: you can optionally use the '
             '`bugwarrior-uda` command to export a list of UDAs you can '
-            'add to your ~/.taskrc file.'
+            'add to your taskrc file.'
         )
 
     static_fields = static_fields_default = ['priority']

--- a/bugwarrior/docs/using.rst
+++ b/bugwarrior/docs/using.rst
@@ -24,18 +24,18 @@ of the ticket and its URL, but some services provide an extensive amount of
 metadata.  See each service's documentation for more information.
 
 For using this data in reports, it is recommended that you add these UDA
-definitions to your ``~/.taskrc`` file.  You can generate your list of
+definitions to your ``taskrc`` file.  You can generate your list of
 UDA definitions by running the following command::
 
     bugwarrior-uda
 
-You can add those lines verbatim to your ``~/.taskrc`` file if you would like
+You can add those lines verbatim to your ``taskrc`` file if you would like
 Taskwarrior to know the human-readable name and data type for the defined
 UDAs.
 
 .. note::
 
-   Not adding those lines to your ``~/.taskrc`` file will have no negative
+   Not adding those lines to your ``taskrc`` file will have no negative
    effects aside from Taskwarrior not knowing the human-readable name for the
    field, but depending on what version of Taskwarrior you are using, it
    may prevent you from changing the values of those fields or using them

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -15,6 +15,7 @@ import six
 from taskw.task import Task
 
 from bugwarrior.config import asbool, die, get_service_password
+from bugwarrior.data import BugwarriorData
 from bugwarrior.db import MARKUP, URLShortener
 
 import logging
@@ -49,6 +50,7 @@ class IssueService(object):
     def __init__(self, config, main_section, target):
         self.config = config
         self.main_section = main_section
+        self.data = BugwarriorData(config, main_section)
         self.target = target
 
         self.desc_len = 35

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import requests
 
-from bugwarrior import data
 from bugwarrior.services import IssueService, Issue, ServiceClient
 from bugwarrior.config import asbool, aslist, die
 
@@ -73,7 +72,7 @@ class BitbucketService(IssueService, ServiceClient):
         secret = self.config_get_default('secret')
         auth = {'oauth': (key, secret)}
 
-        refresh_token = data.get('bitbucket_refresh_token')
+        refresh_token = self.data.get('bitbucket_refresh_token')
 
         if not refresh_token:
             login = self.config_get('login')
@@ -95,7 +94,8 @@ class BitbucketService(IssueService, ServiceClient):
                           'password': password},
                     auth=auth['oauth']).json()
 
-                data.set('bitbucket_refresh_token', response['refresh_token'])
+                self.data.set('bitbucket_refresh_token',
+                              response['refresh_token'])
 
             auth['token'] = response['access_token']
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(name='bugwarrior',
           "dogpile.cache>=0.5.3",
           "lockfile>=0.9.1",
           "click",
+          "functools32",
       ],
       extras_require=dict(
           jira=["jira>=0.22"],

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,4 +1,8 @@
 import mock
+import shutil
+import os
+import os.path
+import tempfile
 import unittest
 
 import responses
@@ -38,6 +42,8 @@ class ServiceTest(unittest.TestCase):
             'general': self.GENERAL_CONFIG.copy(),
             section: self.SERVICE_CONFIG.copy(),
         }
+        options['general']['taskrc'] = self.taskrc
+
         if config_overrides:
             options[section].update(config_overrides)
         if general_overrides:
@@ -63,6 +69,22 @@ class ServiceTest(unittest.TestCase):
         service = service(config, 'general', section)
 
         return service
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = tempfile.mkdtemp(prefix='bugwarrior')
+        cls.taskrc = os.path.join(cls.tempdir, 'taskrc')
+        lists = os.mkdir(os.path.join(cls.tempdir, 'lists'))
+        with open(cls.taskrc, 'w+') as fout:
+            fout.write('data.location=%s\n' % lists)
+
+        # Clear the environment of external settings.
+        os.environ['TASKRC'] = cls.taskrc
+        os.environ.pop('TASKDATA', None)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tempdir, ignore_errors=True)
 
     @staticmethod
     def add_response(url, **kwargs):

--- a/tests/base.py
+++ b/tests/base.py
@@ -36,11 +36,11 @@ class ConfigTest(unittest.TestCase):
         self.tempdir = tempfile.mkdtemp(prefix='bugwarrior')
 
         # Create temporary config files.
-        taskrc = os.path.join(self.tempdir, '.taskrc')
-        lists_path = os.path.join(self.tempdir, 'lists')
-        os.mkdir(lists_path)
-        with open(taskrc, 'w+') as fout:
-            fout.write('data.location=%s\n' % lists_path)
+        self.taskrc = os.path.join(self.tempdir, '.taskrc')
+        self.lists_path = os.path.join(self.tempdir, 'lists')
+        os.mkdir(self.lists_path)
+        with open(self.taskrc, 'w+') as fout:
+            fout.write('data.location=%s\n' % self.lists_path)
 
         # Configure environment.
         os.environ['HOME'] = self.tempdir

--- a/tests/base.py
+++ b/tests/base.py
@@ -74,9 +74,10 @@ class ServiceTest(unittest.TestCase):
     def setUpClass(cls):
         cls.tempdir = tempfile.mkdtemp(prefix='bugwarrior')
         cls.taskrc = os.path.join(cls.tempdir, 'taskrc')
-        lists = os.mkdir(os.path.join(cls.tempdir, 'lists'))
+        lists_path = os.path.join(cls.tempdir, 'lists')
+        os.mkdir(lists_path)
         with open(cls.taskrc, 'w+') as fout:
-            fout.write('data.location=%s\n' % lists)
+            fout.write('data.location=%s\n' % lists_path)
 
         # Clear the environment of external settings.
         os.environ['TASKRC'] = cls.taskrc

--- a/tests/test_activecollab.py
+++ b/tests/test_activecollab.py
@@ -73,6 +73,7 @@ class TestActiveCollabIssues(AbstractServiceTest, ServiceTest):
     }
 
     def setUp(self):
+        super(TestActiveCollabIssues, self).setUp()
         self.maxDiff = None
         with mock.patch('pyac.library.activeCollab.call_api'):
             self.service = self.get_mock_service(ActiveCollabService)

--- a/tests/test_activecollab2.py
+++ b/tests/test_activecollab2.py
@@ -43,6 +43,7 @@ class TestActiveCollab2Issue(AbstractServiceTest, ServiceTest):
     }
 
     def setUp(self):
+        super(TestActiveCollab2Issue, self).setUp()
         self.service = self.get_mock_service(ActiveCollab2Service)
 
     def test_to_taskwarrior(self):

--- a/tests/test_bitbucket.py
+++ b/tests/test_bitbucket.py
@@ -15,6 +15,7 @@ class TestBitbucketIssue(AbstractServiceTest, ServiceTest):
     }
 
     def setUp(self):
+        super(TestBitbucketIssue, self).setUp()
         self.service = self.get_mock_service(BitbucketService)
 
     def test_to_taskwarrior(self):

--- a/tests/test_bts.py
+++ b/tests/test_bts.py
@@ -36,6 +36,7 @@ class TestBTSService(AbstractServiceTest, ServiceTest):
     }
 
     def setUp(self):
+        super(TestBTSService, self).setUp()
         self.service = self.get_mock_service(bts.BTSService)
 
     def test_to_taskwarrior(self):

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -32,6 +32,7 @@ class TestBugzillaService(AbstractServiceTest, ServiceTest):
     }
 
     def setUp(self):
+        super(TestBugzillaService, self).setUp()
         with mock.patch('bugzilla.Bugzilla'):
             self.service = self.get_mock_service(BugzillaService)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,30 +2,25 @@ from __future__ import unicode_literals
 
 import unittest
 import os
-from tempfile import mkdtemp
-from shutil import rmtree
 
 import bugwarrior.config as config
+
+from .base import set_up_config, tear_down_config
 
 
 class TestGetConfigPath(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = mkdtemp()
-        self.old_environ = os.environ.copy()
-        os.environ['HOME'] = self.tmpdir
-        if config.BUGWARRIORRC in os.environ:
-            del os.environ[config.BUGWARRIORRC]
+        set_up_config(self)
 
     def tearDown(self):
-        rmtree(self.tmpdir)
-        os.environ = self.old_environ
+        tear_down_config(self)
 
     def create(self, path):
         """
         Create an empty file in the temporary directory, return the full path.
         """
-        fpath = os.path.join(self.tmpdir, path)
+        fpath = os.path.join(self.tempdir, path)
         if not os.path.exists(os.path.dirname(fpath)):
             os.makedirs(os.path.dirname(fpath))
         open(fpath, 'a').close()
@@ -60,14 +55,14 @@ class TestGetConfigPath(unittest.TestCase):
         """
         self.assertEquals(
             config.get_config_path(),
-            os.path.join(self.tmpdir, '.config/bugwarrior/bugwarriorrc'))
+            os.path.join(self.tempdir, '.config/bugwarrior/bugwarriorrc'))
 
     def test_BUGWARRIORRC(self):
         """
         If $BUGWARRIORRC is set, it takes precedence over everything else (even
         if the file doesn't exist).
         """
-        rc = os.path.join(self.tmpdir, 'my-bugwarriorc')
+        rc = os.path.join(self.tempdir, 'my-bugwarriorc')
         os.environ['BUGWARRIORRC'] = rc
         self.create('.bugwarriorrc')
         self.create('.config/bugwarrior/bugwarriorrc')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,20 +1,13 @@
 from __future__ import unicode_literals
 
-import unittest
 import os
 
 import bugwarrior.config as config
 
-from .base import set_up_config, tear_down_config
+from .base import ConfigTest
 
 
-class TestGetConfigPath(unittest.TestCase):
-
-    def setUp(self):
-        set_up_config(self)
-
-    def tearDown(self):
-        tear_down_config(self)
+class TestGetConfigPath(ConfigTest):
 
     def create(self, path):
         """

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,35 @@
+import os
+import json
+import ConfigParser
+
+from bugwarrior import data
+
+from .base import ConfigTest
+
+
+class TestData(ConfigTest):
+    def setUp(self):
+        super(TestData, self).setUp()
+        config = ConfigParser.RawConfigParser()
+        config.add_section('general')
+        self.data = data.BugwarriorData(config, 'general')
+
+    def test_get_set(self):
+        # "touch" data file.
+        with open(self.data.datafile, 'w+') as handle:
+            json.dump({'old': 'stuff'}, handle)
+
+        self.data.set('key', 'value')
+
+        self.assertEqual(self.data.get('key'), 'value')
+        self.assertEqual(
+            self.data.get_data(), {'old': 'stuff', 'key': 'value'})
+        self.assertEqual(
+            oct(os.stat(self.data.datafile).st_mode & 0777), '0600')
+
+    def test_set_first_time(self):
+        self.data.set('key', 'value')
+
+        self.assertEqual(self.data.get('key'), 'value')
+        self.assertEqual(
+            oct(os.stat(self.data.datafile).st_mode & 0777), '0600')

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -23,6 +23,7 @@ class TestGerritIssue(AbstractServiceTest, ServiceTest):
     }
 
     def setUp(self):
+        super(TestGerritIssue, self).setUp()
         self.service = self.get_mock_service(GerritService)
 
     def test_to_taskwarrior(self):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -39,6 +39,7 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
     }
 
     def setUp(self):
+        super(TestGithubIssue, self).setUp()
         self.service = self.get_mock_service(GithubService)
 
     def test_normalize_label_to_tag(self):

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -1,18 +1,18 @@
 import ConfigParser
 import datetime
-from unittest import TestCase
 
 import pytz
 import responses
 
 from bugwarrior.services.gitlab import GitlabService
 
-from .base import ServiceTest, AbstractServiceTest
+from .base import ConfigTest, ServiceTest, AbstractServiceTest
 
 
-class TestGitlabService(TestCase):
+class TestGitlabService(ConfigTest):
 
     def setUp(self):
+        super(TestGitlabService, self).setUp()
         self.config = ConfigParser.RawConfigParser()
         self.config.add_section('general')
         self.config.add_section('myservice')

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -103,6 +103,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
     }
 
     def setUp(self):
+        super(TestGitlabIssue, self).setUp()
         self.service = self.get_mock_service(GitlabService)
 
     def test_normalize_label_to_tag(self):

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -42,6 +42,7 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
     }
 
     def setUp(self):
+        super(TestJiraIssue, self).setUp()
         with mock.patch('jira.client.JIRA._get_json'):
             self.service = self.get_mock_service(JiraService)
 

--- a/tests/test_megaplan.py
+++ b/tests/test_megaplan.py
@@ -25,6 +25,7 @@ class TestMegaplanIssue(AbstractServiceTest, ServiceTest):
     }
 
     def setUp(self):
+        super(TestMegaplanIssue, self).setUp()
         with mock.patch('megaplan.Client'):
             self.service = self.get_mock_service(MegaplanService)
 

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -46,6 +46,7 @@ class TestRedmineIssue(AbstractServiceTest, ServiceTest):
     }
 
     def setUp(self):
+        super(TestRedmineIssue, self).setUp()
         self.service = self.get_mock_service(RedMineService)
 
     def test_to_taskwarrior(self):

--- a/tests/test_taiga.py
+++ b/tests/test_taiga.py
@@ -21,6 +21,7 @@ class TestTaigaIssue(AbstractServiceTest, ServiceTest):
     }
 
     def setUp(self):
+        super(TestTaigaIssue, self).setUp()
         self.service = self.get_mock_service(TaigaService)
 
     def test_to_taskwarrior(self):

--- a/tests/test_teamlab.py
+++ b/tests/test_teamlab.py
@@ -23,6 +23,7 @@ class TestTeamlabIssue(AbstractServiceTest, ServiceTest):
     }
 
     def setUp(self):
+        super(TestTeamlabIssue, self).setUp()
         with mock.patch(
             'bugwarrior.services.teamlab.TeamLabClient.authenticate'
         ):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -5,6 +5,7 @@ from .base import ServiceTest
 
 class TestTemplates(ServiceTest):
     def setUp(self):
+        super(TestTemplates, self).setUp()
         self.arbitrary_default_description = 'Construct Library on Terminus'
         self.arbitrary_issue = {
             'project': 'end_of_empire',

--- a/tests/test_trac.py
+++ b/tests/test_trac.py
@@ -42,6 +42,7 @@ class TestTracIssue(AbstractServiceTest, ServiceTest):
     }
 
     def setUp(self):
+        super(TestTracIssue, self).setUp()
         self.service = self.get_mock_service(TracService)
 
     def get_mock_service(self, *args, **kwargs):

--- a/tests/test_trello.py
+++ b/tests/test_trello.py
@@ -20,6 +20,7 @@ class TestTrelloIssue(ServiceTest):
         }
 
     def setUp(self):
+        super(TestTrelloIssue, self).setUp()
         origin = dict(inline_links=True, description_length=31,
                       import_labels_as_tags=True)
         extra = {'boardname': 'Hyperspatial express route',

--- a/tests/test_trello.py
+++ b/tests/test_trello.py
@@ -1,12 +1,11 @@
 from __future__ import unicode_literals, print_function
 
 import ConfigParser
-from unittest import TestCase
 from mock import patch
 import responses
 
 from bugwarrior.services.trello import TrelloService, TrelloIssue
-from .base import ServiceTest
+from .base import ConfigTest, ServiceTest
 
 
 class TestTrelloIssue(ServiceTest):
@@ -40,7 +39,7 @@ class TestTrelloIssue(ServiceTest):
                          self.issue.to_taskwarrior().get('project', None))
 
 
-class TestTrelloService(TestCase):
+class TestTrelloService(ConfigTest):
     BOARD = {'id': 'B04RD', 'name': 'My Board'}
     CARD1 = {'id': 'C4RD', 'name': 'Card 1', 'members': [{'username': 'tintin'}],
              'idShort': 1,
@@ -59,6 +58,7 @@ class TestTrelloService(TestCase):
                  "memberCreator": { "username": "mario" } }
 
     def setUp(self):
+        super(TestTrelloService, self).setUp()
         self.config = ConfigParser.RawConfigParser()
         self.config.add_section('general')
         self.config.add_section('mytrello')


### PR DESCRIPTION
Since we support multiple config flavors, we need to ask taskwarrior
(given the current flavor's taskrc) what the data location is.

Thanks to @mathstuf for taking the lead on this. I copied some of the
code from #363 and tried for a cleaner implementation of his idea.

# TODO

- [x] Move `task _show` calling/parsing to taskw.
- [x] Change data file mode to 0600.
- [x] Test using `TASKDATA`.