### PR TITLE
Add support for environment variable $BUGWARRIORRC

### DIFF
--- a/bugwarrior/docs/common_configuration.rst
+++ b/bugwarrior/docs/common_configuration.rst
@@ -1,9 +1,9 @@
 How to Configure
 ================
 
-First, add a file named ``.bugwarriorrc`` to your home folder.
-This file must include at least a ``[general]`` section including
-the following option:
+First, add a file named ``.config/bugwarrior/bugwarriorrc`` to your home
+folder.  This file must include at least a ``[general]`` section including the
+following option:
 
 * ``targets``: A comma-separated list of *other* section names to use
   as task sources.
@@ -41,7 +41,9 @@ In addition to the ``[general]`` section, sections may be named
 ``bugwarrior-pull``. This section will then be used rather than the
 ``[general]`` section.
 
-A more-detailed example configuration can be found at :ref:`example_configuration`.
+A more-detailed example configuration can be found at
+:ref:`example_configuration`.
+
 
 .. _common_configuration_options:
 
@@ -183,3 +185,43 @@ Backend options:
    The ``finished_querying_sticky`` and ``task_crud_sticky`` options
    have no effect if you are using a notification backend other than
    ``growlnotify``.
+
+
+Configuration files
+-------------------
+
+bugwarrior will look at the following paths and read its configuration from the
+first existing file in this order:
+
+* :file:`~/.config/bugwarrior/bugwarriorrc`
+* :file:`~/.bugwarriorrc`
+* :file:`/etc/xdg/bugwarrior/bugwarriorrc`
+
+The default paths can be altered using the environment variables
+:envvar:`BUGWARRIORRC`, :envvar:`XDG_CONFIG_HOME` and
+:envvar:`XDG_CONFIG_DIRS`.
+
+
+Environment Variables
+---------------------
+
+.. envvar:: BUGWARRIORRC
+
+This overrides the default RC file.
+
+.. envvar:: XDG_CONFIG_HOME
+
+By default, :program:`bugwarrior` looks for a configuration file named
+``$XDG_CONFIG_HOME/bugwarrior/bugwarriorrc``.  If ``$XDG_CONFIG_HOME`` is
+either not set or empty, a default equal to ``$HOME/.config`` is used.
+
+.. envvar:: XDG_CONFIG_DIRS
+
+If it can't find a user-specific configuration file (either
+``$XDG_CONFIG_HOME/bugwarrior/bugwarriorrc`` or ``$HOME/.bugwarriorrc``),
+:program:`bugwarrior` looks through the directories in
+``$XDG_CONFIG_DIRS`` for a configuration file named
+``bugwarrior/bugwarriorrc``.
+The directories in ``$XDG_CONFIG_DIRS`` should be separated with a colon ':'.
+If ``$XDG_CONFIG_DIRS`` is either not set or empty, a value equal to
+``/etc/xdg`` is used.

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(name='bugwarrior',
           "dogpile.cache>=0.5.3",
           "lockfile>=0.9.1",
           "click",
-          "pyxdg",
       ],
       extras_require=dict(
           jira=["jira>=0.22"],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,7 +15,7 @@ class TestGetConfigPath(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = mkdtemp()
-        self.old_HOME = os.environ.get('HOME', None)
+        self.old_environ = os.environ.copy()
         self.old_xdg_config_home = xdg.BaseDirectory.xdg_config_home
         self.old_xdg_config_dirs = xdg.BaseDirectory.xdg_config_dirs
         os.environ['HOME'] = self.tmpdir
@@ -26,7 +26,7 @@ class TestGetConfigPath(unittest.TestCase):
 
     def tearDown(self):
         rmtree(self.tmpdir)
-        os.environ['HOME'] = self.old_HOME
+        os.environ = self.old_environ
         xdg.BaseDirectory.xdg_config_home = self.old_xdg_config_home
         xdg.BaseDirectory.xdg_config_dirs = self.old_xdg_config_dirs
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,31 +4,22 @@ import unittest
 import os
 from tempfile import mkdtemp
 from shutil import rmtree
-from mock import patch
 
 import bugwarrior.config as config
 
-
-import xdg
 
 class TestGetConfigPath(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = mkdtemp()
         self.old_environ = os.environ.copy()
-        self.old_xdg_config_home = xdg.BaseDirectory.xdg_config_home
-        self.old_xdg_config_dirs = xdg.BaseDirectory.xdg_config_dirs
         os.environ['HOME'] = self.tmpdir
         if config.BUGWARRIORRC in os.environ:
             del os.environ[config.BUGWARRIORRC]
-        xdg.BaseDirectory.xdg_config_home = os.path.join(self.tmpdir, '.config')
-        xdg.BaseDirectory.xdg_config_dirs = [xdg.BaseDirectory.xdg_config_home]
 
     def tearDown(self):
         rmtree(self.tmpdir)
         os.environ = self.old_environ
-        xdg.BaseDirectory.xdg_config_home = self.old_xdg_config_home
-        xdg.BaseDirectory.xdg_config_dirs = self.old_xdg_config_dirs
 
     def create(self, path):
         """
@@ -71,7 +62,7 @@ class TestGetConfigPath(unittest.TestCase):
             config.get_config_path(),
             os.path.join(self.tmpdir, '.config/bugwarrior/bugwarriorrc'))
 
-    def test_env(self):
+    def test_BUGWARRIORRC(self):
         """
         If $BUGWARRIORRC is set, it takes precedence over everything else (even
         if the file doesn't exist).
@@ -82,4 +73,11 @@ class TestGetConfigPath(unittest.TestCase):
         self.create('.config/bugwarrior/bugwarriorrc')
         self.assertEquals(config.get_config_path(), rc)
 
-
+    def test_BUGWARRIORRC_empty(self):
+        """
+        If $BUGWARRIORRC is set but emty, it is not used and the default file
+        is used instead.
+        """
+        os.environ['BUGWARRIORRC'] = ''
+        rc = self.create('.config/bugwarrior/bugwarriorrc')
+        self.assertEquals(config.get_config_path(), rc)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,85 @@
+from __future__ import unicode_literals
+
+import unittest
+import os
+from tempfile import mkdtemp
+from shutil import rmtree
+from mock import patch
+
+import bugwarrior.config as config
+
+
+import xdg
+
+class TestGetConfigPath(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = mkdtemp()
+        self.old_HOME = os.environ.get('HOME', None)
+        self.old_xdg_config_home = xdg.BaseDirectory.xdg_config_home
+        self.old_xdg_config_dirs = xdg.BaseDirectory.xdg_config_dirs
+        os.environ['HOME'] = self.tmpdir
+        if config.BUGWARRIORRC in os.environ:
+            del os.environ[config.BUGWARRIORRC]
+        xdg.BaseDirectory.xdg_config_home = os.path.join(self.tmpdir, '.config')
+        xdg.BaseDirectory.xdg_config_dirs = [xdg.BaseDirectory.xdg_config_home]
+
+    def tearDown(self):
+        rmtree(self.tmpdir)
+        os.environ['HOME'] = self.old_HOME
+        xdg.BaseDirectory.xdg_config_home = self.old_xdg_config_home
+        xdg.BaseDirectory.xdg_config_dirs = self.old_xdg_config_dirs
+
+    def create(self, path):
+        """
+        Create an empty file in the temporary directory, return the full path.
+        """
+        fpath = os.path.join(self.tmpdir, path)
+        if not os.path.exists(os.path.dirname(fpath)):
+            os.makedirs(os.path.dirname(fpath))
+        open(fpath, 'a').close()
+        return fpath
+
+    def test_default(self):
+        """
+        If it exists, use the file at $XDG_CONFIG_HOME/bugwarrior/bugwarriorrc
+        """
+        rc = self.create('.config/bugwarrior/bugwarriorrc')
+        self.assertEquals(config.get_config_path(), rc)
+
+    def test_legacy(self):
+        """
+        Falls back on .bugwarriorrc if it exists
+        """
+        rc = self.create('.bugwarriorrc')
+        self.assertEquals(config.get_config_path(), rc)
+
+    def test_xdg_first(self):
+        """
+        If both files above exist, the one in $XDG_CONFIG_HOME takes precedence
+        """
+        self.create('.bugwarriorrc')
+        rc = self.create('.config/bugwarrior/bugwarriorrc')
+        self.assertEquals(config.get_config_path(), rc)
+
+    def test_no_file(self):
+        """
+        If no bugwarriorrc exist anywhere, the path to the prefered one is
+        returned.
+        """
+        self.assertEquals(
+            config.get_config_path(),
+            os.path.join(self.tmpdir, '.config/bugwarrior/bugwarriorrc'))
+
+    def test_env(self):
+        """
+        If $BUGWARRIORRC is set, it takes precedence over everything else (even
+        if the file doesn't exist).
+        """
+        rc = os.path.join(self.tmpdir, 'my-bugwarriorc')
+        os.environ['BUGWARRIORRC'] = rc
+        self.create('.bugwarriorrc')
+        self.create('.config/bugwarrior/bugwarriorrc')
+        self.assertEquals(config.get_config_path(), rc)
+
+


### PR DESCRIPTION
* If `$BUGWARRIORRC` is set, then bugwarrior will try to read its
  configuration file from its content
* Extract the code that guess the path to the configuration file in its
  own function.
* Add some unit tests

I got a bit tired of editing my own `.bugwarriorrc` to test bugwarrior. This is inspired by the similar variable `TASKRC` used by taskwarrior.