### PR TITLE
Fix gitlab include/exclude repos

### DIFF
--- a/bugwarrior/docs/services/gitlab.rst
+++ b/bugwarrior/docs/services/gitlab.rst
@@ -33,19 +33,32 @@ may want to pull issues from only a subset of your repositories.  To
 do that, you can use the ``gitlab.include_repos`` option.
 
 For example, if you would like to only pull-in issues from
-your ``project_foo`` and ``project_fox`` repositories, you could add
-this line to your service configuration::
+your own ``project_foo`` and team ``bar``'s ``project_fox`` repositories, you
+could add this line to your service configuration (replacing ``me`` by your own
+login)::
 
-    gitlab.include_repos = project_foo,project_fox
+    gitlab.include_repos = me/project_foo, bar/project_fox
 
 Alternatively, if you have a particularly noisy repository, you can
 instead choose to import all issues excepting it using the
 ``gitlab.exclude_repos`` configuration option.
 
-In this example, ``noisy_repository`` is the repository you would
+In this example, ``noisy/repository`` is the repository you would
 *not* like issues created for::
 
-    gitlab.exclude_repos = noisy_repository
+    gitlab.exclude_repos = noisy/repository
+
+.. hint::
+   If you omit the repository's namespace, bugwarrior will automatically add
+   your login as namespace. E.g. the following are equivalent::
+
+       gitlab.login = foo
+       gitlab.include_repos = bar
+
+   and::
+
+       gitlab.login = foo
+       gitlab.include_repos = foo/bar
 
 Import Labels as Tags
 +++++++++++++++++++++

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -14,8 +14,10 @@ class TestGitlabService(TestCase):
 
     def setUp(self):
         self.config = ConfigParser.RawConfigParser()
+        self.config.add_section('general')
         self.config.add_section('myservice')
         self.config.set('myservice', 'gitlab.login', 'foobar')
+        self.config.set('myservice', 'gitlab.token', 'XXXXXX')
 
     def test_get_keyring_service_default_host(self):
         self.assertEqual(
@@ -27,6 +29,16 @@ class TestGitlabService(TestCase):
         self.assertEqual(
             GitlabService.get_keyring_service(self.config, 'myservice'),
             'gitlab://foobar@gitlab.example.com')
+
+    def test_add_default_namespace_to_included_repos(self):
+        self.config.set('myservice', 'gitlab.include_repos', 'baz, banana/tree')
+        service = GitlabService(self.config, 'general', 'myservice')
+        self.assertEqual(service.include_repos, ['foobar/baz', 'banana/tree'])
+
+    def test_add_default_namespace_to_excluded_repos(self):
+        self.config.set('myservice', 'gitlab.exclude_repos', 'baz, banana/tree')
+        service = GitlabService(self.config, 'general', 'myservice')
+        self.assertEqual(service.exclude_repos, ['foobar/baz', 'banana/tree'])
 
 
 class TestGitlabIssue(AbstractServiceTest, ServiceTest):


### PR DESCRIPTION
The documentation said that to include/exclude a repository you should
simply write the project name, like `bar` but actually, the service
expects a namespace in the repository name, e.g. `foo/bar`.

This commit does two things:

* If the user writes a repository name without the namespace,
  automatically adds the value of `gitlab.login` as the namespace.
* Update the gitlab documentation accordingly