### PR TITLE
Use milestone title instead of id for githubmilestone

### DIFF
--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -127,7 +127,7 @@ class GithubIssue(Issue):
             'label': 'Github Updated',
         },
         MILESTONE: {
-            'type': 'numeric',
+            'type': 'string',
             'label': 'Github Milestone',
         },
         REPO: {
@@ -155,7 +155,7 @@ class GithubIssue(Issue):
     def to_taskwarrior(self):
         milestone = self.record['milestone']
         if milestone:
-            milestone = milestone['id']
+            milestone = milestone['title']
 
         body = self.record['body']
         if body:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -26,7 +26,7 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
         'url': 'https://api.github.com/repos/arbitrary_username/arbitrary_repo/issues/1',
         'number': 10,
         'body': 'Something',
-        'milestone': {'id': 'alpha'},
+        'milestone': {'title': 'alpha'},
         'labels': [{'name': 'bugfix'}],
         'created_at': arbitrary_created.isoformat(),
         'updated_at': arbitrary_updated.isoformat(),
@@ -69,7 +69,7 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
             issue.UPDATED_AT: self.arbitrary_updated,
             issue.CREATED_AT: self.arbitrary_created,
             issue.BODY: self.arbitrary_issue['body'],
-            issue.MILESTONE: self.arbitrary_issue['milestone']['id'],
+            issue.MILESTONE: self.arbitrary_issue['milestone']['title'],
         }
         actual_output = issue.to_taskwarrior()
 


### PR DESCRIPTION
Note that the milestone id that was used before is the intertal github
id for the row, not the sequencial milestone number included in the url.
As such I didn't keep it at all as I assumed that it was fairly useless
for everyone.

The milestone number may eventually be useful but I guess we should
wait until someone asks for it explicitely before adding it to avoid
some sort of "UDA creap".

Fix issue #365