### PR TITLE
Fix some problems with unicode

### DIFF
--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -359,7 +359,7 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
     log.info("Adding %i tasks", len(issue_updates['new']))
     for issue in issue_updates['new']:
         log.info("Adding task %s%s",
-            issue['description'].encode("utf-8"), notreally)
+            issue['description'], notreally)
         if dry_run:
             continue
         if notify:
@@ -382,8 +382,8 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
         ])
         log.info(
             "Updating task %s, %s; %s%s",
-            six.text_type(issue['uuid']).encode("utf-8"),
-            issue['description'].encode("utf-8"),
+            six.text_type(issue['uuid']),
+            issue['description'],
             changes,
             notreally
         )
@@ -401,7 +401,7 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
         log.info(
             "Completing task %s %s%s",
             issue,
-            task_info.get('description', '').encode('utf-8'),
+            task_info.get('description', ''),
             notreally
         )
         if dry_run:


### PR DESCRIPTION
Because of the import

    from __future__ import unicode_literals

We can pass all the arguments as unicode and let the logging library
take care of the encoding.