### PR TITLE
Only query for open github PRs (#377)

### DIFF
--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -28,7 +28,7 @@ class GithubClient(ServiceClient):
         return user_repos + public_repos
 
     def get_involved_issues(self, username):
-        tmpl = "https://api.github.com/search/issues?q=involves%3A{username}&per_page=100"
+        tmpl = "https://api.github.com/search/issues?q=involves%3A{username}%20state%3Aopen&per_page=100"
         url = tmpl.format(username=username)
         return self._getter(url, subkey='items')
 


### PR DESCRIPTION
Previously, setting `involved_issues = True` would pull in PRs that were in any
state, including merged PRs. This patch amends the involved issues query to
only search for open PRs.