### PR TITLE
redmine: import first 100 issues instead 25

### DIFF
--- a/bugwarrior/docs/services/redmine.rst
+++ b/bugwarrior/docs/services/redmine.rst
@@ -4,6 +4,8 @@ Redmine
 You can import tasks from your Redmine instance using
 the ``redmine`` service name.
 
+Only first 100 issues are imported at the moment.
+
 Example Service
 ---------------
 

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -15,7 +15,7 @@ class RedMineClient(ServiceClient):
         self.auth = auth
 
     def find_issues(self, user_id=None):
-        args = {}
+        args = {"limit": 100}
         if user_id is not None:
             args["assigned_to_id"] = user_id
         return self.call_api("/issues.json", args)["issues"]


### PR DESCRIPTION
This is quick and dirty patch to increase current limitation from 25 records
returned to 100 (hard coded maximum). Fore more, we'd need to implement
pagination. Since I have less then 100 bugs assigned, I am not interested in
that for the moment. But who knows :-)