### PR TITLE
Filter gitlab requests by author

### DIFF
--- a/bugwarrior/docs/services/gitlab.rst
+++ b/bugwarrior/docs/services/gitlab.rst
@@ -110,6 +110,13 @@ may set::
 
     gitlab.include_all_todos = False
 
+Include Only One Author
+++++++++++++++++++++++
+
+If you would like to only pull issues and MRs that you've authored, you may set::
+
+    gitlab.only_if_author = myusername
+
 Use HTTP
 ++++++++
 

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -218,9 +218,19 @@ class IssueService(object):
 
             return owner in include_owners
 
+        only_if_author = self.config_get_default(
+            'only_if_author', None)
+
+        if only_if_author:
+            return self.get_author(issue) == only_if_author
+
         return True
 
     def get_owner(self, issue):
+        """ Override this for filtering on tickets """
+        raise NotImplementedError()
+
+    def get_author(self, issue):
         """ Override this for filtering on tickets """
         raise NotImplementedError()
 

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -274,6 +274,10 @@ class GitlabService(IssueService, ServiceClient):
         if issue[1]['assignee'] != None and issue[1]['assignee']['username']:
             return issue[1]['assignee']['username']
 
+    def get_author(self, issue):
+        if issue[1]['author'] != None and issue[1]['author']['username']:
+            return issue[1]['author']['username']
+
     def filter_repos(self, repo):
         if self.exclude_repos:
             if repo['path_with_namespace'] in self.exclude_repos:


### PR DESCRIPTION
This adds a new option to the gitlab service for `only_if_author` which works
similarly to `only_if_assigned`. It is useful for making sure MRs and issues
that you put in stay on your radar until they are merged or closed out.

this is a workaround that fixes #402 , you can list all of your projects and it mimics the gitlab dashboard, but in TW.
