### PR TITLE
Fix gobject notifications with unicode characters

### DIFF
--- a/bugwarrior/notifications.py
+++ b/bugwarrior/notifications.py
@@ -115,7 +115,7 @@ def send_notification(issue, op, conf):
                 issue['description']
         else:
             message = "%s task: %s" % (
-                op, issue['description'].encode("utf-8"))
+                op.encode("utf-8"), issue['description'].encode("utf-8"))
             metadata = _get_metadata(issue)
             if metadata is not None:
                 message += metadata.encode("utf-8")


### PR DESCRIPTION
Fixes "UnicodeDecodeError: 'ascii' codec can't decode byte X in position N: ordinal not in range(128)", which occurs if Phabricator task titles contain unicode characters.