### PR TITLE
Fix @oracle:eval with Github and python 3

### DIFF
--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -11,6 +11,8 @@ import six
 import logging
 log = logging.getLogger(__name__)
 
+from bugwarrior.data import BugwarriorData
+
 
 # The name of the environment variable that can be used to ovewrite the path
 # to the bugwarriorrc file
@@ -193,6 +195,7 @@ def load_config(main_section, interactive=False):
     path = get_config_path()
     config.readfp(codecs.open(path, "r", "utf-8",))
     config.interactive = interactive
+    config.data = BugwarriorData(get_data_path(config, main_section))
     validate_config(config, main_section)
     return config
 

--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -81,7 +81,7 @@ def oracle_eval(command):
         command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     p.wait()
     if p.returncode == 0:
-        return p.stdout.readline().strip()
+        return p.stdout.readline().strip().decode('utf-8')
     else:
         die(
             "Error retrieving password: `{command}` returned '{error}'".format(

--- a/bugwarrior/data.py
+++ b/bugwarrior/data.py
@@ -3,12 +3,9 @@ import json
 
 from lockfile.pidlockfile import PIDLockFile
 
-from bugwarrior.config import get_data_path
-
 
 class BugwarriorData(object):
-    def __init__(self, config, main_section):
-        data_path = get_data_path(config, main_section)
+    def __init__(self, data_path):
         self.datafile = os.path.join(data_path, 'bugwarrior.data')
         self.lockfile = os.path.join(data_path, 'bugwarrior-data.lockfile')
 

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -17,7 +17,6 @@ import six
 from taskw.task import Task
 
 from bugwarrior.config import asbool, die, get_service_password
-from bugwarrior.data import BugwarriorData
 from bugwarrior.db import MARKUP, URLShortener
 
 import logging
@@ -52,7 +51,6 @@ class IssueService(object):
     def __init__(self, config, main_section, target):
         self.config = config
         self.main_section = main_section
-        self.data = BugwarriorData(config, main_section)
         self.target = target
 
         self.desc_len = 35

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -73,7 +73,7 @@ class BitbucketService(IssueService, ServiceClient):
         secret = self.config_get_default('secret')
         auth = {'oauth': (key, secret)}
 
-        refresh_token = self.data.get('bitbucket_refresh_token')
+        refresh_token = self.config.data.get('bitbucket_refresh_token')
 
         if not refresh_token:
             login = self.config_get('login')
@@ -95,8 +95,8 @@ class BitbucketService(IssueService, ServiceClient):
                           'password': password},
                     auth=auth['oauth']).json()
 
-                self.data.set('bitbucket_refresh_token',
-                              response['refresh_token'])
+                self.config.data.set('bitbucket_refresh_token',
+                                     response['refresh_token'])
 
             auth['token'] = response['access_token']
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -8,6 +8,7 @@ import unittest
 import responses
 
 from bugwarrior import config
+from bugwarrior.data import BugwarriorData
 
 
 class AbstractServiceTest(object):
@@ -92,6 +93,7 @@ class ServiceTest(ConfigTest):
         config.has_option = mock.Mock(side_effect=has_option)
         config.get = mock.Mock(side_effect=get_option)
         config.getint = mock.Mock(side_effect=get_int)
+        config.data = BugwarriorData(self.lists_path)
 
         service_instance = service_class(config, 'general', section)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,9 @@
+# coding: utf-8
 from __future__ import unicode_literals
 
 import os
 import configparser
+from unittest import TestCase
 
 import bugwarrior.config as config
 
@@ -108,3 +110,9 @@ class TestGetDataPath(ConfigTest):
         os.environ['TASKDATA'] = ''
 
         self.assertDataPath(os.path.expanduser('~/.task'))
+
+
+class TestOracleEval(TestCase):
+
+    def test_echo(self):
+        self.assertEqual(config.oracle_eval("echo fööbår"), "fööbår")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -12,7 +12,7 @@ class TestData(ConfigTest):
         super(TestData, self).setUp()
         config = configparser.RawConfigParser()
         config.add_section('general')
-        self.data = data.BugwarriorData(config, 'general')
+        self.data = data.BugwarriorData(self.lists_path)
 
     def assert0600(self):
         permissions = oct(os.stat(self.data.datafile).st_mode & 0o777)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,5 +1,7 @@
 from builtins import next
 import datetime
+from unittest import TestCase
+from configparser import RawConfigParser
 
 import pytz
 import responses
@@ -130,3 +132,20 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
             'tags': []}
 
         self.assertEqual(issue.get_taskwarrior_record(), expected)
+
+
+class TestGithubService(TestCase):
+
+    def test_token_authorization_header(self):
+        config = RawConfigParser()
+        config.interactive = False
+        config.add_section('general')
+        config.add_section('mygithub')
+        config.set('mygithub', 'service', 'github')
+        config.set('mygithub', 'github.login', 'tintin')
+        config.set('mygithub', 'github.username', 'tintin')
+        config.set('mygithub', 'github.token',
+                   '@oracle:eval:echo 1234567890ABCDEF')
+        service = GithubService(config, 'general', 'mygithub')
+        self.assertEqual(service.client.session.headers['Authorization'],
+                         "token 1234567890ABCDEF")


### PR DESCRIPTION
The oracle now returns the password as a unicode string.  The password
is decoded using the UTF-8 coding as this is the python 3 default.