### PR TITLE
Add kerberos authentication to JiraService

### DIFF
--- a/bugwarrior/docs/services/jira.rst
+++ b/bugwarrior/docs/services/jira.rst
@@ -98,6 +98,13 @@ to all fields on the Taskwarrior task if needed.
    See :ref:`field_templates` for more details regarding how templates
    are processed.
 
+Kerberos authentication
++++++++++++++++++++++++
+
+If the ``password`` is specified as ``@kerberos``, the service plugin will try
+to authenticate against server with kerberos. A ticket must be already present
+on the client (created by running ``kinit`` or any other method).
+
 Provided UDA Fields
 -------------------
 

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -231,13 +231,17 @@ class JiraService(IssueService):
         default_query = 'assignee=' + self.username + \
             ' AND resolution is null'
         self.query = self.config_get_default('query', default_query)
+        if password == '@kerberos':
+            auth = dict(kerberos=True)
+        else:
+            auth = dict(basic_auth=(self.username, password))
         self.jira = JIRA(
             options={
                 'server': self.config_get('base_uri'),
                 'rest_api_version': 'latest',
                 'verify': self.config_get_default('verify_ssl', default=None, to_type=asbool),
             },
-            basic_auth=(self.username, password)
+            **auth
         )
         self.import_labels_as_tags = self.config_get_default(
             'import_labels_as_tags', default=False, to_type=asbool


### PR DESCRIPTION
This will make it possible to authenticate to Jira server using Kerberos by specifying password as magic value `@kerberos`.

Currently released `jira` package does not work with servers that do not support mutual authentication, so this would not work for some people. See related issue https://github.com/pycontribs/jira/issues/274.