### PR TITLE
Remove unpickleable attributes from exception

### DIFF
--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -530,6 +530,12 @@ def _aggregate_issues(conf, main_section, target, queue, service_name):
         log.critical(str(e))
         queue.put((SERVICE_FINISHED_ERROR, (target, e)))
     except BaseException as e:
+        if hasattr(e, 'request'):
+            # Exceptions raised by requests library have the HTTP request
+            # object stored as attribute. The request can have hooks attached
+            # to it, and we need to remove them, as there can be unpickleable
+            # methods. There is no one left to call these hooks anyway.
+            e.request.hooks = {}
         log.exception("Worker for [%s] failed: %s" % (target, e))
         queue.put((SERVICE_FINISHED_ERROR, (target, e)))
     else:


### PR DESCRIPTION
Before passing an exception out of the service worker, we should remove attributes that could break pickling.

Turns out this is caused by using kerberos: it adds a hook to the request and that causes the break.