### PR TITLE
Make sure e.request is not None before removing hooks

### DIFF
--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -530,7 +530,7 @@ def _aggregate_issues(conf, main_section, target, queue, service_name):
         log.critical(str(e))
         queue.put((SERVICE_FINISHED_ERROR, (target, e)))
     except BaseException as e:
-        if hasattr(e, 'request'):
+        if hasattr(e, 'request') and e.request:
             # Exceptions raised by requests library have the HTTP request
             # object stored as attribute. The request can have hooks attached
             # to it, and we need to remove them, as there can be unpickleable


### PR DESCRIPTION
If the worker fails `bugwarrior-pull` may get stuck:
```
INFO:bugwarrior.services:Working on [jira.redhat]
ERROR:requests_kerberos.kerberos_:handle_other(): Mutual authentication failed
INFO:bugwarrior.services:Done with [jira.redhat] in 1.376839s
Traceback (most recent call last):
  File "/usr/bin/bugwarrior-pull", line 9, in <module>
    load_entry_point('bugwarrior==1.4.0', 'console_scripts', 'bugwarrior-pull')()
  File "/usr/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/bugwarrior-1.4.0-py2.7.egg/bugwarrior/command.py", line 72, in pull
    synchronize(issue_generator, config, main_section, dry_run)
  File "/usr/lib/python2.7/site-packages/bugwarrior-1.4.0-py2.7.egg/bugwarrior/db.py", line 327, in synchronize
    for issue in issue_generator:
  File "/usr/lib/python2.7/site-packages/bugwarrior-1.4.0-py2.7.egg/bugwarrior/services/__init__.py", line 567, in aggregate_issues
    conf.get(target, 'service')
  File "/usr/lib/python2.7/site-packages/bugwarrior-1.4.0-py2.7.egg/bugwarrior/services/__init__.py", line 538, in _aggregate_issues
    e.request.hooks = {}
AttributeError: 'NoneType' object has no attribute 'hooks'
```