### PR TITLE
gerrit: Track the branch and topic used by each change

### DIFF
--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -13,6 +13,8 @@ class GerritIssue(Issue):
     SUMMARY = 'gerritsummary'
     URL = 'gerriturl'
     FOREIGN_ID = 'gerritid'
+    BRANCH = 'gerritbranch'
+    TOPIC = 'gerrittopic'
 
     UDAS = {
         SUMMARY: {
@@ -27,6 +29,14 @@ class GerritIssue(Issue):
             'type': 'numeric',
             'label': 'Gerrit Change ID'
         },
+        BRANCH: {
+            'type': 'string',
+            'label': 'Gerrit Branch',
+        },
+        TOPIC: {
+            'type': 'string',
+            'label': 'Gerrit Topic',
+        },
     }
     UNIQUE_KEY = (URL, )
 
@@ -40,6 +50,8 @@ class GerritIssue(Issue):
             'tags': [],
             self.FOREIGN_ID: self.record['_number'],
             self.SUMMARY: self.record['subject'],
+            self.BRANCH: self.record['branch'],
+            self.TOPIC: self.record['topic'],
         }
 
     def get_default_description(self):

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -17,6 +17,8 @@ class TestGerritIssue(AbstractServiceTest, ServiceTest):
     record = {
         'project': 'nova',
         '_number': 1,
+        'branch': 'master',
+        'topic': 'test-topic',
         'subject': 'this is a title',
         'messages': [{'author': {'username': 'Iam Author'},
                       'message': 'this is a message',
@@ -44,6 +46,8 @@ class TestGerritIssue(AbstractServiceTest, ServiceTest):
             'gerritid': 1,
             'gerritsummary': 'this is a title',
             'gerriturl': 'this is a url',
+            'gerritbranch': 'master',
+            'gerrittopic': 'test-topic',
             'tags': [],
         }
 
@@ -64,6 +68,8 @@ class TestGerritIssue(AbstractServiceTest, ServiceTest):
             'gerritid': 1,
             'gerritsummary': u'this is a title',
             'gerriturl': 'https://one/#/c/1/',
+            'gerritbranch': 'master',
+            'gerrittopic': 'test-topic',
             'priority': 'M',
             'project': u'nova',
             'tags': []}


### PR DESCRIPTION
Useful when tracking work in projects that use multiple branches for
development and maintenance, such as Openstack.