### PR TITLE
Allow unlimited description and annotation lengths. Resolve #441.

### DIFF
--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -202,7 +202,7 @@ def get_config_path():
 
 
 def load_config(main_section, interactive=False):
-    config = ConfigParser({'log.level': "INFO", 'log.file': None})
+    config = BugwarriorConfigParser({'log.level': "INFO", 'log.file': None})
     path = get_config_path()
     config.readfp(codecs.open(path, "r", "utf-8",))
     config.interactive = interactive
@@ -247,6 +247,22 @@ def get_data_path(config, main_section):
         raise RuntimeError('Unable to determine the data location.')
 
     return os.path.normpath(os.path.expanduser(data_path))
+
+
+# ConfigParser is not a new-style class, so inherit from object to fix super().
+class BugwarriorConfigParser(ConfigParser, object):
+    def getint(self, section, option):
+        """ Accepts both integers and empty values. """
+        try:
+            return super(BugwarriorConfigParser, self).getint(section, option)
+        except ValueError:
+            if self.get(section, option) is u'':
+                return None
+            else:
+                raise ValueError(
+                    "{section}.{option} must be an integer or empty.".format(
+                        section=section, option=option))
+
 
 # This needs to be imported here and not above to avoid a circular-import.
 from bugwarrior.services import get_service

--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -256,7 +256,7 @@ class BugwarriorConfigParser(ConfigParser, object):
         try:
             return super(BugwarriorConfigParser, self).getint(section, option)
         except ValueError:
-            if self.get(section, option) is u'':
+            if self.get(section, option) == u'':
                 return None
             else:
                 raise ValueError(

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -185,13 +185,12 @@ class IssueService(object):
                 if not message or not author:
                     continue
                 message = message.replace('\n', '').replace('\r', '')
-                final.append(
-                    '@%s - %s%s' % (
-                        author,
-                        message[0:self.anno_len],
+                if self.anno_len:
+                    message = '%s%s' % (
+                        message[:self.anno_len],
                         '...' if len(message) > self.anno_len else ''
                     )
-                )
+                final.append('@%s - %s' % (author, message))
         return final
 
     @classmethod
@@ -393,11 +392,12 @@ class Issue(object):
         }
         url_separator = ' .. '
         url = url if self.origin['inline_links'] else ''
+        desc_len = self.origin['description_length']
         return u"%s%s#%s - %s%s%s" % (
             MARKUP,
             cls_markup[cls],
             number,
-            title[:self.origin['description_length']],
+            title[:desc_len] if desc_len else title,
             url_separator if url else '',
             url,
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -116,3 +116,23 @@ class TestOracleEval(TestCase):
 
     def test_echo(self):
         self.assertEqual(config.oracle_eval("echo fööbår"), "fööbår")
+
+
+class TestBugwarriorConfigParser(TestCase):
+    def setUp(self):
+        self.config = config.BugwarriorConfigParser()
+        self.config.add_section('general')
+        self.config.set('general', 'someint', '4')
+        self.config.set('general', 'somenone', '')
+        self.config.set('general', 'somechar', 'somestring')
+
+
+    def test_getint(self):
+        self.assertEqual(self.config.getint('general', 'someint'), 4)
+
+    def test_getint_none(self):
+        self.assertEqual(self.config.getint('general', 'somenone'), None)
+
+    def test_getint_valueerror(self):
+        with self.assertRaises(ValueError):
+            self.config.getint('general', 'somechar')

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,77 @@
+import unittest
+
+from bugwarrior import config, services
+
+LONG_MESSAGE = """\
+Some message that is over 100 characters. This message is so long it's
+going to fill up your floppy disk taskwarrior backup. Actually it's not
+that long.""".replace('\n', ' ')
+
+
+class TestIssueService(unittest.TestCase):
+    def setUp(self):
+        super(TestIssueService, self).setUp()
+        self.config = config.BugwarriorConfigParser()
+        self.config.add_section('general')
+
+    def test_build_annotations_default(self):
+        service = services.IssueService(self.config, 'general', 'test')
+
+        annotations = service.build_annotations(
+            (('some_author', LONG_MESSAGE),), 'example.com')
+        self.assertEqual(annotations, [
+            u'@some_author - Some message that is over 100 characters. Thi...'
+        ])
+
+    def test_build_annotations_limited(self):
+        self.config.set('general', 'annotation_length', '20')
+        service = services.IssueService(self.config, 'general', 'test')
+
+        annotations = service.build_annotations(
+            (('some_author', LONG_MESSAGE),), 'example.com')
+        self.assertEqual(
+            annotations, [u'@some_author - Some message that is...'])
+
+    def test_build_annotations_limitless(self):
+        self.config.set('general', 'annotation_length', '')
+        service = services.IssueService(self.config, 'general', 'test')
+
+        annotations = service.build_annotations(
+            (('some_author', LONG_MESSAGE),), 'example.com')
+        self.assertEqual(annotations, [
+            u'@some_author - {message}'.format(message=LONG_MESSAGE)])
+
+
+class TestIssue(unittest.TestCase):
+    def setUp(self):
+        super(TestIssue, self).setUp()
+        self.config = config.BugwarriorConfigParser()
+        self.config.add_section('general')
+
+    def makeIssue(self):
+        service = services.IssueService(self.config, 'general', 'test')
+        service.ISSUE_CLASS = services.Issue
+        return service.get_issue_for_record(None)
+
+    def test_build_default_description_default(self):
+        issue = self.makeIssue()
+
+        description = issue.build_default_description(LONG_MESSAGE)
+        self.assertEqual(
+            description, u'(bw)Is# - Some message that is over 100 chara')
+
+    def test_build_default_description_limited(self):
+        self.config.set('general', 'description_length', '20')
+        issue = self.makeIssue()
+
+        description = issue.build_default_description(LONG_MESSAGE)
+        self.assertEqual(
+            description, u'(bw)Is# - Some message that is')
+
+    def test_build_default_description_limitless(self):
+        self.config.set('general', 'description_length', '')
+        issue = self.makeIssue()
+
+        description = issue.build_default_description(LONG_MESSAGE)
+        self.assertEqual(
+            description, u'(bw)Is# - {message}'.format(message=LONG_MESSAGE))


### PR DESCRIPTION
<s>This is alternative proposal to #436.

The advantage to subclassing ConfigParser rather than using
allow_no_value is that we don't have to worry about handling None for
other value types.</s>