### PR TITLE
[WIP] Allow limitless description and annotation lengths (option B) Resolve #441.

### DIFF
--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -202,7 +202,7 @@ def get_config_path():
 
 
 def load_config(main_section, interactive=False):
-    config = ConfigParser({'log.level': "INFO", 'log.file': None}, allow_no_value=True)
+    config = ConfigParser({'log.level': "INFO", 'log.file': None})
     path = get_config_path()
     config.readfp(codecs.open(path, "r", "utf-8",))
     config.interactive = interactive

--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -202,7 +202,7 @@ def get_config_path():
 
 
 def load_config(main_section, interactive=False):
-    config = ConfigParser({'log.level': "INFO", 'log.file': None})
+    config = ConfigParser({'log.level': "INFO", 'log.file': None}, allow_no_value=True)
     path = get_config_path()
     config.readfp(codecs.open(path, "r", "utf-8",))
     config.interactive = interactive

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -185,13 +185,12 @@ class IssueService(object):
                 if not message or not author:
                     continue
                 message = message.replace('\n', '').replace('\r', '')
-                final.append(
-                    '@%s - %s%s' % (
-                        author,
-                        message[0:self.anno_len],
+                if self.anno_len:
+                    message = '%s%s' % (
+                        message[:self.anno_len],
                         '...' if len(message) > self.anno_len else ''
                     )
-                )
+                final.append('@%s - %s' % (author, message))
         return final
 
     @classmethod
@@ -393,11 +392,12 @@ class Issue(object):
         }
         url_separator = ' .. '
         url = url if self.origin['inline_links'] else ''
+        desc_len = self.origin['description_length']
         return u"%s%s#%s - %s%s%s" % (
             MARKUP,
             cls_markup[cls],
             number,
-            title[:self.origin['description_length']],
+            title[:desc_len] if desc_len else title,
             url_separator if url else '',
             url,
         )


### PR DESCRIPTION
This is presented as another alternative to #436.

<s>This could lead to more-difficult-to-debug errors if people pass no
value to other configuration options, because the error will likely be
in bugwarrior failing to handle None rather than ConfigParser raising a
validation error on their config file. However, I don't see a clear
alternative. I did play around with subclassing ConfigParser to just
allow no value for integers, but the extra complication might not be
worth it.</s> See second commit.

- [ ] Tests