### PR TITLE
Test and fix our usage of different python-jira versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,11 @@ before_install:
   - pip install responses
   - pip install PySimpleSOAP
   - cd $TRAVIS_BUILD_DIR
+env:
+  - JIRAVERSION=1.0.7
+  - JIRAVERSION=1.0.10
 install:
+  - pip install jira==$JIRAVERSION
   - pip install .[jira,megaplan,activecollab,bts]
   - pip install codecov
   - pip install coverage

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -29,8 +29,8 @@ class ObliviousCookieJar(RequestsCookieJar):
 
 
 class JIRA(BaseJIRA):
-    def _create_http_basic_session(self, username, password):
-        super(JIRA, self)._create_http_basic_session(username, password)
+    def _create_http_basic_session(self, *args, **kwargs):
+        super(JIRA, self)._create_http_basic_session(*args, **kwargs)
 
         # XXX: JIRA logs the web user out if we send the session cookies we get
         # back from the first request in any subsequent requests. As we don't

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,15 @@
 [tox]
-envlist = py27,py34,py35
+envlist = py{27,35}-jira{107,1010}
 
 [testenv]
 commands = python setup.py test
 setenv =
        XDG_CACHE_HOME={envtmpdir}/
+
 # NOTE:
 # * as of 2016-10-05 python-megaplan does not support python3, so a
 #   github repository with the needed fixes has been created
 deps = pysimplesoap
-     py34: git+https://github.com/wfranzini/python-megaplan.git
      py35: git+https://github.com/wfranzini/python-megaplan.git
+     jira107: jira==1.0.7
+     jira1010: jira==1.0.10


### PR DESCRIPTION
The issue is that they added a new keyword argument to a method that we override.  Our method signature didn't match.

I dropped the details to try and immunize ourself against any future changes.