### PR TITLE
Support Bugzilla API keys (pending support in python-bugzilla)

### DIFF
--- a/bugwarrior/docs/services/bugzilla.rst
+++ b/bugwarrior/docs/services/bugzilla.rst
@@ -33,6 +33,14 @@ make bugwarrior support more robust!
     bugzilla.username = rbean@redhat.com
     bugzilla.password = OMG_LULZ
 
+Alternately, if you are using a version of python-bugzilla newer than 2.0.0,
+you can specify an API key instead of a password. Note that the username is
+still required in this case, in order to identify bugs belonging to you.
+
+::
+
+    bugzilla.api_key = 4f4d475f4c554c5a4f4d475f4c554c5a
+
 The above example is the minimum required to import issues from
 Bugzilla.  You can also feel free to use any of the
 configuration options described in :ref:`common_configuration_options`.


### PR DESCRIPTION
python-bugzilla refers to these as [tokens](https://github.com/python-bugzilla/python-bugzilla/commit/e1af7160b3162d423fdfeb04e230067a75e9b584).  It would be nice to be able to create an API key and provide it as

```
[bugzilla_mozilla]
bugzilla.username = dustin@mozilla.com
bugzilla.token = e1af7160b3162d423fdfeb04e230067a75e9b584
```
