### PR TITLE
Check for duplicated new issues. Fix #447

### DIFF
--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -366,6 +366,20 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
     # Add new issues
     log.info("Adding %i tasks", len(issue_updates['new']))
     for issue in issue_updates['new']:
+        # Check for duplicated new issues
+        try:
+            existing_uuid = find_local_uuid(
+                tw, key_list, issue, legacy_matching=legacy_matching
+            )
+        except NotFound:
+            pass
+        except MultipleMatches:
+            pass
+        else:
+            log.info("Task %s was already adedd, skipping",
+                     issue['description'])
+            continue
+
         log.info("Adding task %s%s",
             issue['description'], notreally)
         if dry_run:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -126,9 +126,28 @@ class TestSynchronize(ConfigTest):
              'pending': []})
 
         # TEST DUPLICATED NEW ISSUE.
+
+        issue = {
+            'description': 'Twice!',
+            'githubtype': 'issue',
+            'githuburl': 'https://foo.bar',
+            'priority': 'M',
+        }
+
         db.synchronize(iter((issue, issue)), config, 'general')
 
-        self.assertEqual(get_tasks(tw), {
+        tasks = tw.load_tasks()
+
+        # Remove non-deterministic keys.
+        del tasks['pending'][0]['modified']
+        del tasks['pending'][0]['entry']
+        del tasks['pending'][0]['uuid']
+        del tasks['completed'][0]['modified']
+        del tasks['completed'][0]['entry']
+        del tasks['completed'][0]['end']
+        del tasks['completed'][0]['uuid']
+
+        self.assertEqual(tasks, {
             'completed': [{
                 u'description': u'Yada yada yada.',
                 u'githubtype': u'issue',
@@ -141,8 +160,8 @@ class TestSynchronize(ConfigTest):
             'pending': [{
                 u'priority': u'M',
                 u'status': u'pending',
-                u'description': u'Blah blah blah.',
-                u'githuburl': u'https://example.com',
+                u'description': u'Twice!',
+                u'githuburl': u'https://foo.bar',
                 u'githubtype': u'issue',
                 u'id': 1,
                 u'urgency': 3.9,

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -125,6 +125,31 @@ class TestSynchronize(ConfigTest):
             }],
              'pending': []})
 
+        # TEST DUPLICATED NEW ISSUE.
+        db.synchronize(iter((issue, issue)), config, 'general')
+
+        self.assertEqual(get_tasks(tw), {
+            'completed': [{
+                u'description': u'Yada yada yada.',
+                u'githubtype': u'issue',
+                u'githuburl': u'https://example.com',
+                u'id': 0,
+                u'priority': u'M',
+                u'status': u'completed',
+                u'urgency': 3.9,
+            }],
+            'pending': [{
+                u'priority': u'M',
+                u'status': u'pending',
+                u'description': u'Blah blah blah.',
+                u'githuburl': u'https://example.com',
+                u'githubtype': u'issue',
+                u'id': 1,
+                u'urgency': 3.9,
+            }],
+        })
+
+
 class TestUDAs(ConfigTest):
     def test_udas(self):
         config = ConfigParser.RawConfigParser()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -128,7 +128,7 @@ class TestSynchronize(ConfigTest):
         # TEST DUPLICATED NEW ISSUE.
 
         issue = {
-            'description': 'Twice!',
+            'description': 'Twice',
             'githubtype': 'issue',
             'githuburl': 'https://foo.bar',
             'priority': 'M',
@@ -160,7 +160,7 @@ class TestSynchronize(ConfigTest):
             'pending': [{
                 u'priority': u'M',
                 u'status': u'pending',
-                u'description': u'Twice!',
+                u'description': u'Twice',
                 u'githuburl': u'https://foo.bar',
                 u'githubtype': u'issue',
                 u'id': 1,


### PR DESCRIPTION
The task list is checked before adding the new issue, because two or more
services could have retrieved the same issue.

Fix #447 