### PR TITLE
Github: Add 'githubshorttype' UDA (PR/Is)

### DIFF
--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -108,6 +108,7 @@ class GithubIssue(Issue):
     URL = 'githuburl'
     REPO = 'githubrepo'
     TYPE = 'githubtype'
+    SHORT_TYPE = 'githubshorttype'
     NUMBER = 'githubnumber'
     USER = 'githubuser'
 
@@ -144,6 +145,10 @@ class GithubIssue(Issue):
             'type': 'string',
             'label': 'Github Type',
         },
+        SHORT_TYPE: {
+            'type': 'string',
+            'label': 'Short Github Type (Is/PR)',
+        },
         NUMBER: {
             'type': 'numeric',
             'label': 'Github Issue/PR #',
@@ -167,7 +172,10 @@ class GithubIssue(Issue):
         if body:
             body = body.replace('\r\n', '\n')
 
+        short_type = 'Is'
+
         if self.extra['type'] == 'pull_request':
+            short_type = 'PR'
             priority = 'H'
         else:
             priority = self.origin['default_priority']
@@ -181,6 +189,7 @@ class GithubIssue(Issue):
             self.URL: self.record['html_url'],
             self.REPO: self.record['repo'],
             self.TYPE: self.extra['type'],
+            self.SHORT_TYPE: short_type,
             self.USER: self.record['user']['login'],
             self.TITLE: self.record['title'],
             self.BODY: body,


### PR DESCRIPTION
The default strings generated by BugWarrior for github use a short 'PR'
or 'Is' string to indicate if something is a pull-request or issue
respectively. However no UDA exists allowing the user to use these when
specifying their own description_templates in their `.bugwarriorrc`.

This change adds a `githubshorttype` UDA.

Sample config:

    description_template = {{githubrepo}}#{{githubnumber}} ({{githubshorttype}}) {{githubtitle}}

Snippet of resulting output (dry-run):

    INFO:bugwarrior.db:Adding task pjf/exobrain#50 (Is) Personal log classifying agent (not really)
    INFO:bugwarrior.db:Adding task pjf/masterwork-dwarf-fortress#122 (Is) Wild orc traders keep bringing barrels of fire (not really)
    INFO:bugwarrior.db:Adding task pjf/exobrain#55 (PR) Logging (not really)
    INFO:bugwarrior.db:Adding task pjf/masterwork-dwarf-fortress#125 (Is) Simple wood option doesn't apply to orcs. (not really)
    INFO:bugwarrior.db:Adding task pjf/autodie#51 (PR) POD update (not really)