### PR TITLE
Implement `github.query` for the github service

### DIFF
--- a/bugwarrior/docs/services/github.rst
+++ b/bugwarrior/docs/services/github.rst
@@ -111,7 +111,6 @@ assigned to the authenticated user.  To disable this behavior, use::
 
     github.include_user_issues = False
 
-
 Instead of fetching issues and pull requests based on ``{{username}}``'s owned
 repositories, you may instead get those that ``{{username}}`` is involved in.
 This includes all issues and pull requests where the user is the author, the
@@ -123,16 +122,18 @@ configuration option::
 Queries
 +++++++
 
-if you want to write your own github query, as described at https://help.github.com/articles/searching-issues/
+If you want to write your own github query, as described at https://help.github.com/articles/searching-issues/::
 
     github.query = assignee:octocat is:open
 
 Note that this search covers both issues and pull requests, which github treats
 as a special kind of issue.
 
-This will override all other filtering including
-:ref:`common_configuration_options`, ``github.username``,
-``github.involved_issues``, and ``github.filter_pull_requests``.
+To disable the pre-defined queries described above and synchronize only the
+issues matched by the query, set::
+
+    github.include_user_issues = False
+    github.include_user_repos = False
 
 Provided UDA Fields
 -------------------

--- a/bugwarrior/docs/services/github.rst
+++ b/bugwarrior/docs/services/github.rst
@@ -11,22 +11,17 @@ Here's an example of a Github target::
 
     [my_issue_tracker]
     service = github
-    github.username = ralphbean
     github.login = ralphbean
     github.password = OMG_LULZ
+    github.username = ralphbean
 
 The above example is the minimum required to import issues from
 Github.  You can also feel free to use any of the
 configuration options described in :ref:`common_configuration_options`
 or described in `Service Features`_ below.
 
-Note that both ``github.username`` and ``github.login`` are required and can be
-set to different values.  ``github.login`` is used to specify what account
-bugwarrior should use to login to github.  ``github.username`` indicates which
-repositories should be scraped.  For instance, I always have ``github.login``
-set to ralphbean (my account).  But I have some targets with
-``github.username`` pointed at organizations or other users to watch issues
-there.
+``github.login`` is used to specify what account bugwarrior should use to login
+to github, combined with ``github.password``.
 
 If two-factor authentication is used, ``github.token`` must be given rather
 than ``github.password``. To get a token, go to the "Personal access tokens" section of
@@ -35,6 +30,15 @@ to private repos can be gained with ``repo`` as well.
 
 Service Features
 ----------------
+
+Repo Owner
+++++++++++
+
+``github.username`` indicates which repositories should be scraped.  For
+instance, I always have ``github.login`` set to ralphbean (my account).  But I
+have some targets with ``github.username`` pointed at organizations or other
+users to watch issues there.  This parameter is required unless
+``github.query`` is provided.
 
 Include and Exclude Certain Repositories
 ++++++++++++++++++++++++++++++++++++++++
@@ -110,6 +114,20 @@ assignee, mentioned in, or has commented on.  To do so, add the following
 configuration option::
 
     github.involved_issues = True
+
+Queries
++++++++
+
+if you want to write your own github query, as described at https://help.github.com/articles/searching-issues/
+
+    github.query = assignee:octocat is:open
+
+Note that this search covers both issues and pull requests, which github treats
+as a special kind of issue.
+
+This will override all other filtering including
+:ref:`common_configuration_options`, ``github.username``,
+``github.involved_issues``, and ``github.filter_pull_requests``.
 
 Provided UDA Fields
 -------------------

--- a/bugwarrior/docs/services/github.rst
+++ b/bugwarrior/docs/services/github.rst
@@ -43,6 +43,11 @@ users to watch issues there.  This parameter is required unless
 Include and Exclude Certain Repositories
 ++++++++++++++++++++++++++++++++++++++++
 
+By default, issues from all repos belonging to ``github.username`` are
+included. To turn this off, set::
+
+    github.include_user_repos = False
+
 If you happen to be working with a large number of projects, you
 may want to pull issues from only a subset of your repositories.  To 
 do that, you can use the ``github.include_repos`` option.

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -373,15 +373,16 @@ class GithubService(IssueService):
         if self.query:
             issues.update(self.get_query(self.query))
 
-        all_repos = self.client.get_repos(self.username)
-        assert(type(all_repos) == list)
-        repos = filter(self.filter_repos, all_repos)
+        if self.config_get_default('include_user_repos', True, asbool):
+            all_repos = self.client.get_repos(self.username)
+            assert(type(all_repos) == list)
+            repos = filter(self.filter_repos, all_repos)
 
-        for repo in repos:
-            issues.update(
-                self.get_owned_repo_issues(
-                    self.username + "/" + repo['name'])
-            )
+            for repo in repos:
+                issues.update(
+                    self.get_owned_repo_issues(
+                        self.username + "/" + repo['name'])
+                )
         if self.config_get_default('include_user_issues', True, asbool):
             issues.update(
                 filter(self.filter_issues,
@@ -415,8 +416,7 @@ class GithubService(IssueService):
            not config.has_option(target, 'github.password'):
             die("[%s] has no 'github.token' or 'github.password'" % target)
 
-        if not (config.has_option(target, 'github.username') or
-                config.has_option(target, 'github.query')):
-            die("[%s] must have one of 'github.username' or 'github.query'" % target)
+        if not config.has_option(target, 'github.username'):
+            die("[%s] has no 'github.username'" % target)
 
         super(GithubService, cls).validate_config(config, target)

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -3,7 +3,7 @@ import re
 import six
 
 import requests
-import urllib
+from six.moves.urllib.parse import quote_plus
 from jinja2 import Template
 
 from bugwarrior.config import asbool, aslist, die
@@ -32,7 +32,7 @@ class GithubClient(ServiceClient):
     def get_query(self, query):
         """Run a generic issue/PR query"""
         tmpl = "https://api.github.com/search/issues?q={query}&per_page=100"
-        url = tmpl.format(query=urllib.quote_plus(query.encode('utf-8')))
+        url = tmpl.format(query=quote_plus(query.encode('utf-8')))
         return self._getter(url, subkey='items')
 
     def get_issues(self, username, repo):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -143,6 +143,8 @@ class TestGithubIssueQuery(AbstractServiceTest, ServiceTest):
         'github.password': 'arbitrary_password',
         'github.username': 'arbitrary_username',
         'github.query': 'is:open reviewer:octocat',
+        'github.include_user_repos': 'False',
+        'github.include_user_issues': 'False',
     }
 
     def setUp(self):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -11,35 +11,37 @@ from bugwarrior.services.github import GithubService
 from .base import ServiceTest, AbstractServiceTest
 
 
+ARBITRARY_CREATED = (
+    datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+).replace(tzinfo=pytz.UTC, microsecond=0)
+ARBITRARY_UPDATED = datetime.datetime.utcnow().replace(
+    tzinfo=pytz.UTC, microsecond=0)
+ARBITRARY_ISSUE = {
+    'title': 'Hallo',
+    'html_url': 'https://github.com/arbitrary_username/arbitrary_repo/pull/1',
+    'url': 'https://api.github.com/repos/arbitrary_username/arbitrary_repo/issues/1',
+    'number': 10,
+    'body': 'Something',
+    'user': {'login': 'arbitrary_login'},
+    'milestone': {'title': 'alpha'},
+    'labels': [{'name': 'bugfix'}],
+    'created_at': ARBITRARY_CREATED.isoformat(),
+    'updated_at': ARBITRARY_UPDATED.isoformat(),
+    'repo': 'ralphbean/bugwarrior',
+}
+ARBITRARY_EXTRA = {
+    'project': 'one',
+    'type': 'issue',
+    'annotations': [],
+}
+
+
 class TestGithubIssue(AbstractServiceTest, ServiceTest):
     maxDiff = None
     SERVICE_CONFIG = {
         'github.login': 'arbitrary_login',
         'github.password': 'arbitrary_password',
         'github.username': 'arbitrary_username',
-    }
-    arbitrary_created = (
-        datetime.datetime.utcnow() - datetime.timedelta(hours=1)
-    ).replace(tzinfo=pytz.UTC, microsecond=0)
-    arbitrary_updated = datetime.datetime.utcnow().replace(
-        tzinfo=pytz.UTC, microsecond=0)
-    arbitrary_issue = {
-        'title': 'Hallo',
-        'html_url': 'http://whanot.com/',
-        'url': 'https://api.github.com/repos/arbitrary_username/arbitrary_repo/issues/1',
-        'number': 10,
-        'body': 'Something',
-        'user': {'login': 'arbitrary_login'},
-        'milestone': {'title': 'alpha'},
-        'labels': [{'name': 'bugfix'}],
-        'created_at': arbitrary_created.isoformat(),
-        'updated_at': arbitrary_updated.isoformat(),
-        'repo': 'ralphbean/bugwarrior',
-    }
-    arbitrary_extra = {
-        'project': 'one',
-        'type': 'issue',
-        'annotations': [],
     }
 
     def setUp(self):
@@ -48,8 +50,8 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
 
     def test_normalize_label_to_tag(self):
         issue = self.service.get_issue_for_record(
-            self.arbitrary_issue,
-            self.arbitrary_extra
+            ARBITRARY_ISSUE,
+            ARBITRARY_EXTRA
         )
         self.assertEqual(issue._normalize_label_to_tag('needs work'),
                          'needs_work')
@@ -57,25 +59,25 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
     def test_to_taskwarrior(self):
         self.service.import_labels_as_tags = True
         issue = self.service.get_issue_for_record(
-            self.arbitrary_issue,
-            self.arbitrary_extra
+            ARBITRARY_ISSUE,
+            ARBITRARY_EXTRA
         )
 
         expected_output = {
-            'project': self.arbitrary_extra['project'],
+            'project': ARBITRARY_EXTRA['project'],
             'priority': self.service.default_priority,
             'annotations': [],
             'tags': ['bugfix'],
-            issue.URL: self.arbitrary_issue['html_url'],
-            issue.REPO: self.arbitrary_issue['repo'],
-            issue.TYPE: self.arbitrary_extra['type'],
-            issue.TITLE: self.arbitrary_issue['title'],
-            issue.NUMBER: self.arbitrary_issue['number'],
-            issue.UPDATED_AT: self.arbitrary_updated,
-            issue.CREATED_AT: self.arbitrary_created,
-            issue.BODY: self.arbitrary_issue['body'],
-            issue.MILESTONE: self.arbitrary_issue['milestone']['title'],
-            issue.USER: self.arbitrary_issue['user']['login'],
+            issue.URL: ARBITRARY_ISSUE['html_url'],
+            issue.REPO: ARBITRARY_ISSUE['repo'],
+            issue.TYPE: ARBITRARY_EXTRA['type'],
+            issue.TITLE: ARBITRARY_ISSUE['title'],
+            issue.NUMBER: ARBITRARY_ISSUE['number'],
+            issue.UPDATED_AT: ARBITRARY_UPDATED,
+            issue.CREATED_AT: ARBITRARY_CREATED,
+            issue.BODY: ARBITRARY_ISSUE['body'],
+            issue.MILESTONE: ARBITRARY_ISSUE['milestone']['title'],
+            issue.USER: ARBITRARY_ISSUE['user']['login'],
         }
         actual_output = issue.to_taskwarrior()
 
@@ -99,11 +101,11 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
 
         self.add_response(
             'https://api.github.com/repos/arbitrary_username/arbitrary_repo/issues?per_page=100',
-            json=[self.arbitrary_issue])
+            json=[ARBITRARY_ISSUE])
 
         self.add_response(
             'https://api.github.com/user/issues?per_page=100',
-            json=[self.arbitrary_issue])
+            json=[ARBITRARY_ISSUE])
 
         self.add_response(
             'https://api.github.com/repos/arbitrary_username/arbitrary_repo/issues/10/comments?per_page=100',
@@ -116,16 +118,67 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
 
         expected = {
             'annotations': [u'@arbitrary_login - Arbitrary comment.'],
-            'description': u'(bw)Is#10 - Hallo .. http://whanot.com/',
+            'description': u'(bw)Is#10 - Hallo .. https://github.com/arbitrary_username/arbitrary_repo/pull/1',
             'githubbody': u'Something',
-            'githubcreatedon': self.arbitrary_created,
+            'githubcreatedon': ARBITRARY_CREATED,
             'githubmilestone': u'alpha',
             'githubnumber': 10,
             'githubrepo': 'arbitrary_username/arbitrary_repo',
             'githubtitle': u'Hallo',
             'githubtype': 'issue',
-            'githubupdatedat': self.arbitrary_updated,
-            'githuburl': u'http://whanot.com/',
+            'githubupdatedat': ARBITRARY_UPDATED,
+            'githuburl': u'https://github.com/arbitrary_username/arbitrary_repo/pull/1',
+            'githubuser': u'arbitrary_login',
+            'priority': 'M',
+            'project': 'arbitrary_repo',
+            'tags': []}
+
+        self.assertEqual(issue.get_taskwarrior_record(), expected)
+
+
+class TestGithubIssueQuery(AbstractServiceTest, ServiceTest):
+    maxDiff = None
+    SERVICE_CONFIG = {
+        'github.login': 'arbitrary_login',
+        'github.password': 'arbitrary_password',
+        'github.username': 'arbitrary_username',
+        'github.query': 'is:open reviewer:octocat',
+    }
+
+    def setUp(self):
+        super(TestGithubIssueQuery, self).setUp()
+        self.service = self.get_mock_service(GithubService)
+
+    def test_to_taskwarrior(self):
+        pass
+
+    @responses.activate
+    def test_issues(self):
+        self.add_response(
+            'https://api.github.com/search/issues?q=is%3Aopen+reviewer%3Aoctocat&per_page=100',
+            json={'items': [ARBITRARY_ISSUE]})
+
+        self.add_response(
+            'https://api.github.com/repos/arbitrary_username/arbitrary_repo/issues/10/comments?per_page=100',
+            json=[{
+                'user': {'login': 'arbitrary_login'},
+                'body': 'Arbitrary comment.'
+            }])
+
+        issue = list(self.service.issues())[0]
+
+        expected = {
+            'annotations': [u'@arbitrary_login - Arbitrary comment.'],
+            'description': u'(bw)Is#10 - Hallo .. https://github.com/arbitrary_username/arbitrary_repo/pull/1',
+            'githubbody': u'Something',
+            'githubcreatedon': ARBITRARY_CREATED,
+            'githubmilestone': u'alpha',
+            'githubnumber': 10,
+            'githubrepo': 'arbitrary_username/arbitrary_repo',
+            'githubtitle': u'Hallo',
+            'githubtype': 'issue',
+            'githubupdatedat': ARBITRARY_UPDATED,
+            'githuburl': u'https://github.com/arbitrary_username/arbitrary_repo/pull/1',
             'githubuser': u'arbitrary_login',
             'priority': 'M',
             'project': 'arbitrary_repo',


### PR DESCRIPTION
Fixes #423 and then some by allowing arbitrary github queries.

I'm not sure this is the best way to do the tests -- it repeats a lot of boilerplate just to run the service with slightly different parameters.