### PR TITLE
Service config refactor.

### DIFF
--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -8,7 +8,8 @@ from lockfile.pidlockfile import PIDLockFile
 import getpass
 import click
 
-from bugwarrior.config import get_data_path, get_keyring, load_config
+from bugwarrior.config import (
+    get_data_path, get_keyring, load_config, ServiceConfig)
 from bugwarrior.services import aggregate_issues, get_service
 from bugwarrior.db import (
     get_defined_udas_as_strings,
@@ -107,7 +108,9 @@ def targets():
             if not value:
                 continue
             if '@oracle:use_keyring' in value:
-                yield service_class.get_keyring_service(config, section)
+                service_config = ServiceConfig(
+                    service_class.CONFIG_PREFIX, config, section)
+                yield service_class.get_keyring_service(service_config)
 
 
 @vault.command()

--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -277,7 +277,8 @@ class ServiceConfig(object):
         """ Proxy undefined attributes/methods to ConfigParser object. """
         return getattr(self.config_parser, name)
 
-    def has(self, key):
+    def __contains__(self, key):
+        """ Does service section specify this option? """
         return self.config_parser.has_option(
             self.service_target, self._get_key(key))
 

--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -281,17 +281,14 @@ class ServiceConfig(object):
         return self.config_parser.has_option(
             self.service_target, self._get_key(key))
 
-    def get_default(self, key, default=None, to_type=None):
+    def get(self, key, default=None, to_type=None):
         try:
-            return self.get(key, to_type=to_type)
+            value = self.config_parser.get(self.service_target, self._get_key(key))
+            if to_type:
+                return to_type(value)
+            return value
         except:
             return default
-
-    def get(self, key=None, to_type=None):
-        value = self.config_parser.get(self.service_target, self._get_key(key))
-        if to_type:
-            return to_type(value)
-        return value
 
     def _get_key(self, key):
         return '%s.%s' % (self.config_prefix, key)

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -132,7 +132,7 @@ class IssueService(object):
         return templates
 
     def get_password(self, key, login='nousername'):
-        password = self.config.get_default(key)
+        password = self.config.get(key)
         keyring_service = self.get_keyring_service(self.config)
         if not password or password.startswith("@oracle:"):
             password = get_service_password(
@@ -187,20 +187,18 @@ class IssueService(object):
 
     def include(self, issue):
         """ Return true if the issue in question should be included """
-        only_if_assigned = self.config.get_default(
-            'only_if_assigned', None)
+        only_if_assigned = self.config.get('only_if_assigned', None)
 
         if only_if_assigned:
             owner = self.get_owner(issue)
             include_owners = [only_if_assigned]
 
-            if self.config.get_default('also_unassigned', None, asbool):
+            if self.config.get('also_unassigned', None, asbool):
                 include_owners.append(None)
 
             return owner in include_owners
 
-        only_if_author = self.config.get_default(
-            'only_if_author', None)
+        only_if_author = self.config.get('only_if_author', None)
 
         if only_if_author:
             return self.get_author(issue) == only_if_author

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -85,14 +85,14 @@ class IssueService(object):
             self.shorten = asbool(main_config.get(self.main_section, 'shorten'))
 
         self.add_tags = []
-        if self.config.has('add_tags'):
+        if 'add_tags' in self.config:
             for raw_option in self.config.get('add_tags').split(','):
                 option = raw_option.strip(' +;')
                 if option:
                     self.add_tags.append(option)
 
         self.default_priority = 'M'
-        if self.config.has('default_priority'):
+        if 'default_priority' in self.config:
             self.default_priority = self.config.get('default_priority')
 
         log.info("Working on [%s]", self.target)

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -131,7 +131,7 @@ class IssueService(object):
                 templates[key] = self.config.get(template_key)
         return templates
 
-    def config_get_password(self, key, login='nousername'):
+    def get_password(self, key, login='nousername'):
         password = self.config.get_default(key)
         keyring_service = self.get_keyring_service(self.config)
         if not password or password.startswith("@oracle:"):

--- a/bugwarrior/services/activecollab.py
+++ b/bugwarrior/services/activecollab.py
@@ -166,9 +166,9 @@ class ActiveCollabService(IssueService):
     def __init__(self, *args, **kw):
         super(ActiveCollabService, self).__init__(*args, **kw)
 
-        self.url = self.config_get('url').rstrip('/')
-        self.key = self.config_get('key')
-        self.user_id = int(self.config_get('user_id'))
+        self.url = self.config.get('url').rstrip('/')
+        self.key = self.config.get('key')
+        self.user_id = int(self.config.get('user_id'))
         self.client = ActiveCollabClient(
             self.url, self.key, self.user_id
         )
@@ -176,14 +176,12 @@ class ActiveCollabService(IssueService):
                                          user_id=self.user_id)
 
     @classmethod
-    def validate_config(cls, config, target):
-        for k in (
-            'activecollab.url', 'activecollab.key', 'activecollab.user_id'
-        ):
-            if not config.has_option(target, k):
-                die("[%s] has no '%s'" % (target, k))
+    def validate_config(cls, service_config, target):
+        for k in ('url', 'key', 'user_id'):
+            if not service_config.has(k):
+                die("[%s] has no 'activecollab.%s'" % (target, k))
 
-        IssueService.validate_config(config, target)
+        IssueService.validate_config(service_config, target)
 
     def _comments(self, issue):
         comments = self.activecollab.get_comments(

--- a/bugwarrior/services/activecollab.py
+++ b/bugwarrior/services/activecollab.py
@@ -178,7 +178,7 @@ class ActiveCollabService(IssueService):
     @classmethod
     def validate_config(cls, service_config, target):
         for k in ('url', 'key', 'user_id'):
-            if not service_config.has(k):
+            if k not in service_config:
                 die("[%s] has no 'activecollab.%s'" % (target, k))
 
         IssueService.validate_config(service_config, target)

--- a/bugwarrior/services/activecollab2.py
+++ b/bugwarrior/services/activecollab2.py
@@ -197,7 +197,7 @@ class ActiveCollab2Service(IssueService):
             'projects',
             'user_id'
         ):
-            if not service_config.has(k):
+            if k not in service_config:
                 die("[%s] has no 'activecollab2.%s'" % (target, k))
 
         super(ActiveCollab2Service, cls).validate_config(service_config, target)

--- a/bugwarrior/services/activecollab2.py
+++ b/bugwarrior/services/activecollab2.py
@@ -171,10 +171,10 @@ class ActiveCollab2Service(IssueService):
     def __init__(self, *args, **kw):
         super(ActiveCollab2Service, self).__init__(*args, **kw)
 
-        self.url = self.config_get('url').rstrip('/')
-        self.key = self.config_get('key')
-        self.user_id = self.config_get('user_id')
-        projects_raw = self.config_get('projects')
+        self.url = self.config.get('url').rstrip('/')
+        self.key = self.config.get('key')
+        self.user_id = self.config.get('user_id')
+        projects_raw = self.config.get('projects')
 
         projects_list = projects_raw.split(',')
         projects = []
@@ -190,17 +190,17 @@ class ActiveCollab2Service(IssueService):
         )
 
     @classmethod
-    def validate_config(cls, config, target):
+    def validate_config(cls, service_config, target):
         for k in (
-            'activecollab2.url',
-            'activecollab2.key',
-            'activecollab2.projects',
-            'activecollab2.user_id'
+            'url',
+            'key',
+            'projects',
+            'user_id'
         ):
-            if not config.has_option(target, k):
-                die("[%s] has no '%s'" % (target, k))
+            if not service_config.has(k):
+                die("[%s] has no 'activecollab2.%s'" % (target, k))
 
-        super(ActiveCollab2Service, cls).validate_config(config, target)
+        super(ActiveCollab2Service, cls).validate_config(service_config, target)
 
     def issues(self):
         # Loop through each project

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -69,8 +69,8 @@ class BitbucketService(IssueService, ServiceClient):
     def __init__(self, *args, **kw):
         super(BitbucketService, self).__init__(*args, **kw)
 
-        key = self.config.get_default('key')
-        secret = self.config.get_default('secret')
+        key = self.config.get('key')
+        secret = self.config.get('secret')
         auth = {'oauth': (key, secret)}
 
         refresh_token = self.config.data.get('bitbucket_refresh_token')
@@ -107,10 +107,10 @@ class BitbucketService(IssueService, ServiceClient):
         elif 'basic' in auth:
             self.requests_kwargs['auth'] = auth['basic']
 
-        self.exclude_repos = self.config.get_default('exclude_repos', [], aslist)
-        self.include_repos = self.config.get_default('include_repos', [], aslist)
+        self.exclude_repos = self.config.get('exclude_repos', [], aslist)
+        self.include_repos = self.config.get('include_repos', [], aslist)
 
-        self.filter_merge_requests = self.config.get_default(
+        self.filter_merge_requests = self.config.get(
             'filter_merge_requests', default=False, to_type=asbool
         )
 

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -77,7 +77,7 @@ class BitbucketService(IssueService, ServiceClient):
 
         if not refresh_token:
             login = self.config.get('login')
-            password = self.config_get_password('password', login)
+            password = self.get_password('password', login)
             auth['basic'] = (login, password)
 
         if key and secret:

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -152,9 +152,9 @@ class BitbucketService(IssueService, ServiceClient):
 
     @classmethod
     def validate_config(cls, service_config, target):
-        if not service_config.has('username'):
+        if 'username' not in service_config:
             die("[%s] has no 'username'" % target)
-        if not service_config.has('login'):
+        if 'login' not in service_config:
             die("[%s] has no 'login'" % target)
 
         IssueService.validate_config(service_config, target)

--- a/bugwarrior/services/bts.py
+++ b/bugwarrior/services/bts.py
@@ -110,17 +110,16 @@ class BTSService(IssueService, ServiceClient):
 
     @classmethod
     def validate_config(cls, service_config, target):
-        if (service_config.has('udd') and
+        if ('udd' in service_config and
                 asbool(service_config.get('udd')) and
-                not service_config.has('email')):
+                'email' not in service_config):
             die("[%s] has no 'bts.email' but UDD search was requested" %
                 (target,))
 
-        if (not service_config.has('packages') and
-                not service_config.has('email')):
+        if 'packages' not in service_config and 'email' not in service_config:
             die("[%s] has neither 'bts.email' or 'bts.packages'" % (target,))
 
-        if (service_config.has('udd_ignore_sponsor') and
+        if ('udd_ignore_sponsor' in service_config and
             (not asbool(service_config.get('udd')))):
             die("[%s] defines settings for UDD search without enabling"
                 " UDD search" % (target,))

--- a/bugwarrior/services/bts.py
+++ b/bugwarrior/services/bts.py
@@ -97,18 +97,16 @@ class BTSService(IssueService, ServiceClient):
 
     def __init__(self, *args, **kw):
         super(BTSService, self).__init__(*args, **kw)
-        self.email = self.config.get_default('email', default=None)
-        self.packages = self.config.get_default('packages', default=None)
-        self.udd = self.config.get_default('udd', default=False,
-                                           to_type=asbool)
-        self.udd_ignore_sponsor = self.config.get_default('udd_ignore_sponsor',
-                                                          default=True,
-                                                          to_type=asbool)
-        self.ignore_pkg = self.config.get_default('ignore_pkg', default=None)
-        self.ignore_src = self.config.get_default('ignore_src', default=None)
-        self.ignore_pending = self.config.get_default('ignore_pending',
-                                                      default=True,
-                                                      to_type=asbool)
+        self.email = self.config.get('email', default=None)
+        self.packages = self.config.get('packages', default=None)
+        self.udd = self.config.get(
+            'udd', default=False, to_type=asbool)
+        self.udd_ignore_sponsor = self.config.get(
+            'udd_ignore_sponsor', default=True, to_type=asbool)
+        self.ignore_pkg = self.config.get('ignore_pkg', default=None)
+        self.ignore_src = self.config.get('ignore_src', default=None)
+        self.ignore_pending = self.config.get(
+            'ignore_pending', default=True, to_type=asbool)
 
     @classmethod
     def validate_config(cls, service_config, target):

--- a/bugwarrior/services/bts.py
+++ b/bugwarrior/services/bts.py
@@ -97,37 +97,37 @@ class BTSService(IssueService, ServiceClient):
 
     def __init__(self, *args, **kw):
         super(BTSService, self).__init__(*args, **kw)
-        self.email = self.config_get_default('email', default=None)
-        self.packages = self.config_get_default('packages', default=None)
-        self.udd = self.config_get_default('udd', default=False,
+        self.email = self.config.get_default('email', default=None)
+        self.packages = self.config.get_default('packages', default=None)
+        self.udd = self.config.get_default('udd', default=False,
                                            to_type=asbool)
-        self.udd_ignore_sponsor = self.config_get_default('udd_ignore_sponsor',
+        self.udd_ignore_sponsor = self.config.get_default('udd_ignore_sponsor',
                                                           default=True,
                                                           to_type=asbool)
-        self.ignore_pkg = self.config_get_default('ignore_pkg', default=None)
-        self.ignore_src = self.config_get_default('ignore_src', default=None)
-        self.ignore_pending = self.config_get_default('ignore_pending',
+        self.ignore_pkg = self.config.get_default('ignore_pkg', default=None)
+        self.ignore_src = self.config.get_default('ignore_src', default=None)
+        self.ignore_pending = self.config.get_default('ignore_pending',
                                                       default=True,
                                                       to_type=asbool)
 
     @classmethod
-    def validate_config(cls, config, target):
-        if (config.has_option(target, 'bts.udd') and
-                asbool(config.get(target, 'bts.udd')) and
-                not config.has_option(target, 'bts.email')):
+    def validate_config(cls, service_config, target):
+        if (service_config.has('udd') and
+                asbool(service_config.get('udd')) and
+                not service_config.has('email')):
             die("[%s] has no 'bts.email' but UDD search was requested" %
                 (target,))
 
-        if (not config.has_option(target, 'bts.packages') and
-                not config.has_option(target, 'bts.email')):
+        if (not service_config.has('packages') and
+                not service_config.has('email')):
             die("[%s] has neither 'bts.email' or 'bts.packages'" % (target,))
 
-        if (config.has_option(target, 'bts.udd_ignore_sponsor') and
-            (not asbool(config.get(target, 'bts.udd')))):
+        if (service_config.has('udd_ignore_sponsor') and
+            (not asbool(service_config.get('udd')))):
             die("[%s] defines settings for UDD search without enabling"
                 " UDD search" % (target,))
 
-        IssueService.validate_config(config, target)
+        IssueService.validate_config(service_config, target)
 
     def _record_for_bug(self, bug):
         return {'number': bug.bug_num,

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -106,14 +106,14 @@ class BugzillaService(IssueService):
 
     def __init__(self, *args, **kw):
         super(BugzillaService, self).__init__(*args, **kw)
-        self.base_uri = self.config_get('base_uri')
-        self.username = self.config_get('username')
-        self.ignore_cc = self.config_get_default('ignore_cc', default=False,
+        self.base_uri = self.config.get('base_uri')
+        self.username = self.config.get('username')
+        self.ignore_cc = self.config.get_default('ignore_cc', default=False,
                                                  to_type=lambda x: x == "True")
-        self.query_url = self.config_get_default('query_url', default=None)
-        self.include_needinfos = self.config_get_default(
+        self.query_url = self.config.get_default('query_url', default=None)
+        self.include_needinfos = self.config.get_default(
             'include_needinfos', False, to_type=lambda x: x == "True")
-        self.open_statuses = self.config_get_default(
+        self.open_statuses = self.config.get_default(
             'open_statuses', _open_statuses, to_type=lambda x: x.split(','))
         log.debug(" filtering on statuses: %r", self.open_statuses)
 
@@ -123,7 +123,7 @@ class BugzillaService(IssueService):
         # ...but older bugzilla's don't know anything about that argument.
         # Here we make it possible for the user to specify whether they want
         # to pass that argument or not.
-        self.advanced = asbool(self.config_get_default('advanced', 'no'))
+        self.advanced = asbool(self.config.get_default('advanced', 'no'))
 
         self.password = self.config_get_password('password', self.username)
 
@@ -131,20 +131,20 @@ class BugzillaService(IssueService):
         self.bz = bugzilla.Bugzilla(url=url)
         self.bz.login(self.username, self.password)
 
-    @classmethod
-    def get_keyring_service(cls, config, section):
-        username = config.get(section, cls._get_key('username'))
-        base_uri = config.get(section, cls._get_key('base_uri'))
+    @staticmethod
+    def get_keyring_service(service_config):
+        username = service_config.get('username')
+        base_uri = service_config.get('base_uri')
         return "bugzilla://%s@%s" % (username, base_uri)
 
     @classmethod
-    def validate_config(cls, config, target):
-        req = ['bugzilla.username', 'bugzilla.password', 'bugzilla.base_uri']
+    def validate_config(cls, service_config, target):
+        req = ['username', 'password', 'base_uri']
         for option in req:
-            if not config.has_option(target, option):
-                die("[%s] has no '%s'" % (target, option))
+            if not service_config.has(option):
+                die("[%s] has no 'bugzilla.%s'" % (target, option))
 
-        super(BugzillaService, cls).validate_config(config, target)
+        super(BugzillaService, cls).validate_config(service_config, target)
 
     def get_owner(self, issue):
         # NotImplemented, but we should never get called since .include() isn't

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -125,7 +125,7 @@ class BugzillaService(IssueService):
         # to pass that argument or not.
         self.advanced = asbool(self.config.get_default('advanced', 'no'))
 
-        self.password = self.config_get_password('password', self.username)
+        self.password = self.get_password('password', self.username)
 
         url = 'https://%s/xmlrpc.cgi' % self.base_uri
         self.bz = bugzilla.Bugzilla(url=url)

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -108,12 +108,12 @@ class BugzillaService(IssueService):
         super(BugzillaService, self).__init__(*args, **kw)
         self.base_uri = self.config.get('base_uri')
         self.username = self.config.get('username')
-        self.ignore_cc = self.config.get_default('ignore_cc', default=False,
+        self.ignore_cc = self.config.get('ignore_cc', default=False,
                                                  to_type=lambda x: x == "True")
-        self.query_url = self.config.get_default('query_url', default=None)
-        self.include_needinfos = self.config.get_default(
+        self.query_url = self.config.get('query_url', default=None)
+        self.include_needinfos = self.config.get(
             'include_needinfos', False, to_type=lambda x: x == "True")
-        self.open_statuses = self.config.get_default(
+        self.open_statuses = self.config.get(
             'open_statuses', _open_statuses, to_type=lambda x: x.split(','))
         log.debug(" filtering on statuses: %r", self.open_statuses)
 
@@ -123,7 +123,7 @@ class BugzillaService(IssueService):
         # ...but older bugzilla's don't know anything about that argument.
         # Here we make it possible for the user to specify whether they want
         # to pass that argument or not.
-        self.advanced = asbool(self.config.get_default('advanced', 'no'))
+        self.advanced = asbool(self.config.get('advanced', 'no'))
 
         self.password = self.get_password('password', self.username)
 

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -141,7 +141,7 @@ class BugzillaService(IssueService):
     def validate_config(cls, service_config, target):
         req = ['username', 'password', 'base_uri']
         for option in req:
-            if not service_config.has(option):
+            if option not in service_config:
                 die("[%s] has no 'bugzilla.%s'" % (target, option))
 
         super(BugzillaService, cls).validate_config(service_config, target)

--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -71,7 +71,7 @@ class GerritService(IssueService, ServiceClient):
         super(GerritService, self).__init__(*args, **kw)
         self.url = self.config.get('base_uri').strip('/')
         self.username = self.config.get('username')
-        self.password = self.config_get_password('password', self.username)
+        self.password = self.get_password('password', self.username)
         self.ssl_ca_path = self.config.get_default('ssl_ca_path', None)
         self.session = requests.session()
         self.session.headers.update({

--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -72,7 +72,7 @@ class GerritService(IssueService, ServiceClient):
         self.url = self.config.get('base_uri').strip('/')
         self.username = self.config.get('username')
         self.password = self.get_password('password', self.username)
-        self.ssl_ca_path = self.config.get_default('ssl_ca_path', None)
+        self.ssl_ca_path = self.config.get('ssl_ca_path', None)
         self.session = requests.session()
         self.session.headers.update({
             'Accept': 'application/json',

--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -69,10 +69,10 @@ class GerritService(IssueService, ServiceClient):
 
     def __init__(self, *args, **kw):
         super(GerritService, self).__init__(*args, **kw)
-        self.url = self.config_get('base_uri').strip('/')
-        self.username = self.config_get('username')
+        self.url = self.config.get('base_uri').strip('/')
+        self.username = self.config.get('username')
         self.password = self.config_get_password('password', self.username)
-        self.ssl_ca_path = self.config_get_default('ssl_ca_path', None)
+        self.ssl_ca_path = self.config.get_default('ssl_ca_path', None)
         self.session = requests.session()
         self.session.headers.update({
             'Accept': 'application/json',
@@ -85,9 +85,9 @@ class GerritService(IssueService, ServiceClient):
         if self.ssl_ca_path != None:
             self.session.verify = os.path.expanduser(self.ssl_ca_path)
 
-    @classmethod
-    def get_keyring_service(cls, config, section):
-        base_uri = config.get(section, cls._get_key('base_uri'))
+    @staticmethod
+    def get_keyring_service(service_config):
+        base_uri = service_config.get('base_uri')
         return "gerrit://%s" % base_uri
 
     def get_service_metadata(self):
@@ -96,12 +96,12 @@ class GerritService(IssueService, ServiceClient):
         }
 
     @classmethod
-    def validate_config(cls, config, target):
-        for option in ('gerrit.username', 'gerrit.password', 'gerrit.base_uri'):
-            if not config.has_option(target, option):
-                die("[%s] has no '%s'" % (target, option))
+    def validate_config(cls, service_config, target):
+        for option in ('username', 'password', 'base_uri'):
+            if not service_config.has(option):
+                die("[%s] has no 'gerrit.%s'" % (target, option))
 
-        IssueService.validate_config(config, target)
+        IssueService.validate_config(service_config, target)
 
     def issues(self):
         # Construct the whole url by hand here, because otherwise requests will

--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -98,7 +98,7 @@ class GerritService(IssueService, ServiceClient):
     @classmethod
     def validate_config(cls, service_config, target):
         for option in ('username', 'password', 'base_uri'):
-            if not service_config.has(option):
+            if option not in service_config:
                 die("[%s] has no 'gerrit.%s'" % (target, option))
 
         IssueService.validate_config(service_config, target)

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -243,10 +243,10 @@ class GithubService(IssueService):
         auth = {}
         token = self.config.get_default('token')
         if self.config.has('token'):
-            token = self.config_get_password('token', self.login)
+            token = self.get_password('token', self.login)
             auth['token'] = token
         else:
-            password = self.config_get_password('password', self.login)
+            password = self.get_password('password', self.login)
             auth['basic'] = (self.login, password)
 
         self.client = GithubClient(self.host, auth)

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -242,7 +242,7 @@ class GithubService(IssueService):
 
         auth = {}
         token = self.config.get('token')
-        if self.config.has('token'):
+        if 'token' in self.config:
             token = self.get_password('token', self.login)
             auth['token'] = token
         else:
@@ -430,14 +430,13 @@ class GithubService(IssueService):
 
     @classmethod
     def validate_config(cls, service_config, target):
-        if not service_config.has('login'):
+        if 'login' not in service_config:
             die("[%s] has no 'github.login'" % target)
 
-        if (not service_config.has('token') and
-                not service_config.has('password')):
+        if 'token' not in service_config and 'password' not in service_config:
             die("[%s] has no 'github.token' or 'github.password'" % target)
 
-        if not service_config.has('username'):
+        if 'username' not in service_config:
             die("[%s] has no 'github.username'" % target)
 
         super(GithubService, cls).validate_config(service_config, target)

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -237,11 +237,11 @@ class GithubService(IssueService):
     def __init__(self, *args, **kw):
         super(GithubService, self).__init__(*args, **kw)
 
-        self.host = self.config.get_default('host', 'github.com')
+        self.host = self.config.get('host', 'github.com')
         self.login = self.config.get('login')
 
         auth = {}
-        token = self.config.get_default('token')
+        token = self.config.get('token')
         if self.config.has('token'):
             token = self.get_password('token', self.login)
             auth['token'] = token
@@ -251,24 +251,24 @@ class GithubService(IssueService):
 
         self.client = GithubClient(self.host, auth)
 
-        self.exclude_repos = self.config.get_default('exclude_repos', [], aslist)
-        self.include_repos = self.config.get_default('include_repos', [], aslist)
+        self.exclude_repos = self.config.get('exclude_repos', [], aslist)
+        self.include_repos = self.config.get('include_repos', [], aslist)
 
         self.username = self.config.get('username')
-        self.filter_pull_requests = self.config.get_default(
+        self.filter_pull_requests = self.config.get(
             'filter_pull_requests', default=False, to_type=asbool
         )
-        self.involved_issues = self.config.get_default(
+        self.involved_issues = self.config.get(
             'involved_issues', default=False, to_type=asbool
         )
-        self.import_labels_as_tags = self.config.get_default(
+        self.import_labels_as_tags = self.config.get(
             'import_labels_as_tags', default=False, to_type=asbool
         )
-        self.label_template = self.config.get_default(
+        self.label_template = self.config.get(
             'label_template', default='{{label}}', to_type=six.text_type
         )
 
-        self.query = self.config.get_default(
+        self.query = self.config.get(
             'query',
             default='involves: {user} state:open'.format(
                 user=self.username) if self.involved_issues else '',
@@ -279,7 +279,7 @@ class GithubService(IssueService):
     def get_keyring_service(service_config):
         login = service_config.get('login')
         username = service_config.get('username')
-        host = service_config.get_default('host', default='github.com')
+        host = service_config.get('host', default='github.com')
         return "github://{login}@{host}/{username}".format(
             login=login, username=username, host=host)
 
@@ -394,7 +394,7 @@ class GithubService(IssueService):
         if self.query:
             issues.update(self.get_query(self.query))
 
-        if self.config.get_default('include_user_repos', True, asbool):
+        if self.config.get('include_user_repos', True, asbool):
             all_repos = self.client.get_repos(self.username)
             assert(type(all_repos) == list)
             repos = filter(self.filter_repos, all_repos)
@@ -404,7 +404,7 @@ class GithubService(IssueService):
                     self.get_owned_repo_issues(
                         self.username + "/" + repo['name'])
                 )
-        if self.config.get_default('include_user_issues', True, asbool):
+        if self.config.get('include_user_issues', True, asbool):
             issues.update(
                 filter(self.filter_issues,
                        self.get_directly_assigned_issues().items())

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -237,12 +237,12 @@ class GithubService(IssueService):
     def __init__(self, *args, **kw):
         super(GithubService, self).__init__(*args, **kw)
 
-        self.host = self.config_get_default('host', 'github.com')
-        self.login = self.config_get('login')
+        self.host = self.config.get_default('host', 'github.com')
+        self.login = self.config.get('login')
 
         auth = {}
-        token = self.config_get_default('token')
-        if self.config_has('token'):
+        token = self.config.get_default('token')
+        if self.config.has('token'):
             token = self.config_get_password('token', self.login)
             auth['token'] = token
         else:
@@ -251,37 +251,35 @@ class GithubService(IssueService):
 
         self.client = GithubClient(self.host, auth)
 
-        self.exclude_repos = self.config_get_default('exclude_repos', [], aslist)
-        self.include_repos = self.config_get_default('include_repos', [], aslist)
+        self.exclude_repos = self.config.get_default('exclude_repos', [], aslist)
+        self.include_repos = self.config.get_default('include_repos', [], aslist)
 
-        self.username = self.config_get('username')
-        self.filter_pull_requests = self.config_get_default(
+        self.username = self.config.get('username')
+        self.filter_pull_requests = self.config.get_default(
             'filter_pull_requests', default=False, to_type=asbool
         )
-        self.involved_issues = self.config_get_default(
+        self.involved_issues = self.config.get_default(
             'involved_issues', default=False, to_type=asbool
         )
-        self.import_labels_as_tags = self.config_get_default(
+        self.import_labels_as_tags = self.config.get_default(
             'import_labels_as_tags', default=False, to_type=asbool
         )
-        self.label_template = self.config_get_default(
+        self.label_template = self.config.get_default(
             'label_template', default='{{label}}', to_type=six.text_type
         )
 
-        self.query = self.config_get_default(
+        self.query = self.config.get_default(
             'query',
             default='involves: {user} state:open'.format(
                 user=self.username) if self.involved_issues else '',
             to_type=six.text_type
         )
 
-    @classmethod
-    def get_keyring_service(cls, config, section):
-        login = config.get(section, cls._get_key('login'))
-        username = config.get(section, cls._get_key('username'))
-        host = (config.get(section, cls._get_key('host'))
-            if config.has_option(section, cls._get_key('host'))
-            else 'github.com')
+    @staticmethod
+    def get_keyring_service(service_config):
+        login = service_config.get('login')
+        username = service_config.get('username')
+        host = service_config.get_default('host', default='github.com')
         return "github://{login}@{host}/{username}".format(
             login=login, username=username, host=host)
 
@@ -396,7 +394,7 @@ class GithubService(IssueService):
         if self.query:
             issues.update(self.get_query(self.query))
 
-        if self.config_get_default('include_user_repos', True, asbool):
+        if self.config.get_default('include_user_repos', True, asbool):
             all_repos = self.client.get_repos(self.username)
             assert(type(all_repos) == list)
             repos = filter(self.filter_repos, all_repos)
@@ -406,7 +404,7 @@ class GithubService(IssueService):
                     self.get_owned_repo_issues(
                         self.username + "/" + repo['name'])
                 )
-        if self.config_get_default('include_user_issues', True, asbool):
+        if self.config.get_default('include_user_issues', True, asbool):
             issues.update(
                 filter(self.filter_issues,
                        self.get_directly_assigned_issues().items())
@@ -431,15 +429,15 @@ class GithubService(IssueService):
             yield issue_obj
 
     @classmethod
-    def validate_config(cls, config, target):
-        if not config.has_option(target, 'github.login'):
+    def validate_config(cls, service_config, target):
+        if not service_config.has('login'):
             die("[%s] has no 'github.login'" % target)
 
-        if not config.has_option(target, 'github.token') and \
-           not config.has_option(target, 'github.password'):
+        if (not service_config.has('token') and
+                not service_config.has('password')):
             die("[%s] has no 'github.token' or 'github.password'" % target)
 
-        if not config.has_option(target, 'github.username'):
+        if not service_config.has('username'):
             die("[%s] has no 'github.username'" % target)
 
-        super(GithubService, cls).validate_config(config, target)
+        super(GithubService, cls).validate_config(service_config, target)

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -484,13 +484,13 @@ class GitlabService(IssueService, ServiceClient):
 
     @classmethod
     def validate_config(cls, service_config, target):
-        if not service_config.has('host'):
+        if 'host' not in service_config:
             die("[%s] has no 'gitlab.host'" % target)
 
-        if not service_config.has('login'):
+        if 'login' not in service_config:
             die("[%s] has no 'gitlab.login'" % target)
 
-        if not service_config.has('token'):
+        if 'token' not in service_config:
             die("[%s] has no 'gitlab.token'" % target)
 
         super(GitlabService, cls).validate_config(service_config, target)

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -210,40 +210,40 @@ class GitlabService(IssueService, ServiceClient):
     def __init__(self, *args, **kw):
         super(GitlabService, self).__init__(*args, **kw)
 
-        host = self.config_get_default(
+        host = self.config.get_default(
             'host', default='gitlab.com', to_type=six.text_type)
-        self.login = self.config_get('login')
+        self.login = self.config.get('login')
         token = self.config_get_password('token', self.login)
         self.auth = (host, token)
 
-        if self.config_get_default('use_https', default=True, to_type=asbool):
+        if self.config.get_default('use_https', default=True, to_type=asbool):
             self.scheme = 'https'
         else:
             self.scheme = 'http'
 
-        self.verify_ssl = self.config_get_default(
+        self.verify_ssl = self.config.get_default(
             'verify_ssl', default=True, to_type=asbool
         )
 
-        self.exclude_repos = self.config_get_default('exclude_repos', [], aslist)
-        self.include_repos = self.config_get_default('include_repos', [], aslist)
+        self.exclude_repos = self.config.get_default('exclude_repos', [], aslist)
+        self.include_repos = self.config.get_default('include_repos', [], aslist)
 
         self.include_repos = list(map(self.add_default_namespace, self.include_repos))
         self.exclude_repos = list(map(self.add_default_namespace, self.exclude_repos))
 
-        self.import_labels_as_tags = self.config_get_default(
+        self.import_labels_as_tags = self.config.get_default(
             'import_labels_as_tags', default=False, to_type=asbool
         )
-        self.label_template = self.config_get_default(
+        self.label_template = self.config.get_default(
             'label_template', default='{{label}}', to_type=six.text_type
         )
-        self.filter_merge_requests = self.config_get_default(
+        self.filter_merge_requests = self.config.get_default(
             'filter_merge_requests', default=False, to_type=asbool
         )
-        self.include_todos = self.config_get_default(
+        self.include_todos = self.config.get_default(
             'include_todos', default=False, to_type=asbool
         )
-        self.include_all_todos = self.config_get_default(
+        self.include_all_todos = self.config.get_default(
             'include_all_todos', default=True, to_type=asbool
         )
 
@@ -259,13 +259,10 @@ class GitlabService(IssueService, ServiceClient):
         else:
             return repo
 
-    @classmethod
-    def get_keyring_service(cls, config, section):
-        login = config.get(section, cls._get_key('login'))
-        try:
-            host = config.get(section, cls._get_key('host'))
-        except NoOptionError:
-            host = 'gitlab.com'
+    @staticmethod
+    def get_keyring_service(service_config):
+        login = service_config.get('login')
+        host = service_config.get_default('host', default='gitlab.com')
         return "gitlab://%s@%s" % (login, host)
 
     def get_service_metadata(self):
@@ -486,14 +483,14 @@ class GitlabService(IssueService, ServiceClient):
                 yield todo_obj
 
     @classmethod
-    def validate_config(cls, config, target):
-        if not config.has_option(target, 'gitlab.host'):
+    def validate_config(cls, service_config, target):
+        if not service_config.has('host'):
             die("[%s] has no 'gitlab.host'" % target)
 
-        if not config.has_option(target, 'gitlab.login'):
+        if not service_config.has('login'):
             die("[%s] has no 'gitlab.login'" % target)
 
-        if not config.has_option(target, 'gitlab.token'):
+        if not service_config.has('token'):
             die("[%s] has no 'gitlab.token'" % target)
 
-        super(GitlabService, cls).validate_config(config, target)
+        super(GitlabService, cls).validate_config(service_config, target)

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -210,40 +210,40 @@ class GitlabService(IssueService, ServiceClient):
     def __init__(self, *args, **kw):
         super(GitlabService, self).__init__(*args, **kw)
 
-        host = self.config.get_default(
+        host = self.config.get(
             'host', default='gitlab.com', to_type=six.text_type)
         self.login = self.config.get('login')
         token = self.get_password('token', self.login)
         self.auth = (host, token)
 
-        if self.config.get_default('use_https', default=True, to_type=asbool):
+        if self.config.get('use_https', default=True, to_type=asbool):
             self.scheme = 'https'
         else:
             self.scheme = 'http'
 
-        self.verify_ssl = self.config.get_default(
+        self.verify_ssl = self.config.get(
             'verify_ssl', default=True, to_type=asbool
         )
 
-        self.exclude_repos = self.config.get_default('exclude_repos', [], aslist)
-        self.include_repos = self.config.get_default('include_repos', [], aslist)
+        self.exclude_repos = self.config.get('exclude_repos', [], aslist)
+        self.include_repos = self.config.get('include_repos', [], aslist)
 
         self.include_repos = list(map(self.add_default_namespace, self.include_repos))
         self.exclude_repos = list(map(self.add_default_namespace, self.exclude_repos))
 
-        self.import_labels_as_tags = self.config.get_default(
+        self.import_labels_as_tags = self.config.get(
             'import_labels_as_tags', default=False, to_type=asbool
         )
-        self.label_template = self.config.get_default(
+        self.label_template = self.config.get(
             'label_template', default='{{label}}', to_type=six.text_type
         )
-        self.filter_merge_requests = self.config.get_default(
+        self.filter_merge_requests = self.config.get(
             'filter_merge_requests', default=False, to_type=asbool
         )
-        self.include_todos = self.config.get_default(
+        self.include_todos = self.config.get(
             'include_todos', default=False, to_type=asbool
         )
-        self.include_all_todos = self.config.get_default(
+        self.include_all_todos = self.config.get(
             'include_all_todos', default=True, to_type=asbool
         )
 
@@ -262,7 +262,7 @@ class GitlabService(IssueService, ServiceClient):
     @staticmethod
     def get_keyring_service(service_config):
         login = service_config.get('login')
-        host = service_config.get_default('host', default='gitlab.com')
+        host = service_config.get('host', default='gitlab.com')
         return "gitlab://%s@%s" % (login, host)
 
     def get_service_metadata(self):

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -213,7 +213,7 @@ class GitlabService(IssueService, ServiceClient):
         host = self.config.get_default(
             'host', default='gitlab.com', to_type=six.text_type)
         self.login = self.config.get('login')
-        token = self.config_get_password('token', self.login)
+        token = self.get_password('token', self.login)
         self.auth = (host, token)
 
         if self.config.get_default('use_https', default=True, to_type=asbool):

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -230,7 +230,7 @@ class JiraService(IssueService):
 
         default_query = 'assignee=' + self.username + \
             ' AND resolution is null'
-        self.query = self.config.get_default('query', default_query)
+        self.query = self.config.get('query', default_query)
         if password == '@kerberos':
             auth = dict(kerberos=True)
         else:
@@ -239,17 +239,17 @@ class JiraService(IssueService):
             options={
                 'server': self.config.get('base_uri'),
                 'rest_api_version': 'latest',
-                'verify': self.config.get_default('verify_ssl', default=True, to_type=asbool),
+                'verify': self.config.get('verify_ssl', default=True, to_type=asbool),
             },
             **auth
         )
-        self.import_labels_as_tags = self.config.get_default(
+        self.import_labels_as_tags = self.config.get(
             'import_labels_as_tags', default=False, to_type=asbool
         )
-        self.import_sprints_as_tags = self.config.get_default(
+        self.import_sprints_as_tags = self.config.get(
             'import_sprints_as_tags', default=False, to_type=asbool
         )
-        self.label_template = self.config.get_default(
+        self.label_template = self.config.get(
             'label_template', default='{{label}}', to_type=six.text_type
         )
 

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -226,7 +226,7 @@ class JiraService(IssueService):
         super(JiraService, self).__init__(*args, **kw)
         self.username = self.config.get('username')
         self.url = self.config.get('base_uri')
-        password = self.config_get_password('password', self.username)
+        password = self.get_password('password', self.username)
 
         default_query = 'assignee=' + self.username + \
             ' AND resolution is null'

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -282,7 +282,7 @@ class JiraService(IssueService):
     @classmethod
     def validate_config(cls, service_config, target):
         for option in ('username', 'password', 'base_uri'):
-            if not service_config.has(option):
+            if option not in service_config:
                 die("[%s] has no 'jira.%s'" % (target, option))
 
         IssueService.validate_config(service_config, target)

--- a/bugwarrior/services/mplan.py
+++ b/bugwarrior/services/mplan.py
@@ -73,21 +73,21 @@ class MegaplanService(IssueService):
     def __init__(self, *args, **kw):
         super(MegaplanService, self).__init__(*args, **kw)
 
-        self.hostname = self.config_get('hostname')
-        _login = self.config_get('login')
+        self.hostname = self.config.get('hostname')
+        _login = self.config.get('login')
         _password = self.config_get_password('password', _login)
 
         self.client = megaplan.Client(self.hostname)
         self.client.authenticate(_login, _password)
 
-        self.project_name = self.config_get_default(
+        self.project_name = self.config.get_default(
             'project_name', self.hostname
         )
 
-    @classmethod
-    def get_keyring_service(cls, config, section):
-        login = config.get(section, cls._get_key('login'))
-        hostname = config.get(section, cls._get_key('hostname'))
+    @staticmethod
+    def get_keyring_service(service_config):
+        login = service_config.get('login')
+        hostname = service_config.get('hostname')
         return "megaplan://%s@%s" % (login, hostname)
 
     def get_service_metadata(self):
@@ -97,12 +97,12 @@ class MegaplanService(IssueService):
         }
 
     @classmethod
-    def validate_config(cls, config, target):
-        for k in ('megaplan.login', 'megaplan.password', 'megaplan.hostname'):
-            if not config.has_option(target, k):
-                die("[%s] has no '%s'" % (target, k))
+    def validate_config(cls, service_config, target):
+        for k in ('login', 'password', 'hostname'):
+            if not service_config.has(k):
+                die("[%s] has no 'mplan.%s'" % (target, k))
 
-        IssueService.validate_config(config, target)
+        IssueService.validate_config(service_config, target)
 
     def issues(self):
         issues = self.client.get_actual_tasks()

--- a/bugwarrior/services/mplan.py
+++ b/bugwarrior/services/mplan.py
@@ -75,7 +75,7 @@ class MegaplanService(IssueService):
 
         self.hostname = self.config.get('hostname')
         _login = self.config.get('login')
-        _password = self.config_get_password('password', _login)
+        _password = self.get_password('password', _login)
 
         self.client = megaplan.Client(self.hostname)
         self.client.authenticate(_login, _password)

--- a/bugwarrior/services/mplan.py
+++ b/bugwarrior/services/mplan.py
@@ -80,9 +80,7 @@ class MegaplanService(IssueService):
         self.client = megaplan.Client(self.hostname)
         self.client.authenticate(_login, _password)
 
-        self.project_name = self.config.get_default(
-            'project_name', self.hostname
-        )
+        self.project_name = self.config.get('project_name', self.hostname)
 
     @staticmethod
     def get_keyring_service(service_config):

--- a/bugwarrior/services/mplan.py
+++ b/bugwarrior/services/mplan.py
@@ -97,7 +97,7 @@ class MegaplanService(IssueService):
     @classmethod
     def validate_config(cls, service_config, target):
         for k in ('login', 'password', 'hostname'):
-            if not service_config.has(k):
+            if k not in service_config:
                 die("[%s] has no 'mplan.%s'" % (target, k))
 
         IssueService.validate_config(service_config, target)

--- a/bugwarrior/services/pagure.py
+++ b/bugwarrior/services/pagure.py
@@ -108,17 +108,17 @@ class PagureService(IssueService):
 
         self.session = requests.Session()
 
-        self.tag = self.config_get_default('tag')
-        self.repo = self.config_get_default('repo')
-        self.base_url = self.config_get_default('base_url')
+        self.tag = self.config.get_default('tag')
+        self.repo = self.config.get_default('repo')
+        self.base_url = self.config.get_default('base_url')
 
-        self.exclude_repos = self.config_get_default('exclude_repos', [], aslist)
-        self.include_repos = self.config_get_default('include_repos', [], aslist)
+        self.exclude_repos = self.config.get_default('exclude_repos', [], aslist)
+        self.include_repos = self.config.get_default('include_repos', [], aslist)
 
-        self.import_tags = self.config_get_default(
+        self.import_tags = self.config.get_default(
             'import_tags', default=False, to_type=asbool
         )
-        self.tag_template = self.config_get_default(
+        self.tag_template = self.config.get_default(
             'tag_template', default='{{label}}', to_type=six.text_type
         )
 
@@ -216,12 +216,11 @@ class PagureService(IssueService):
             yield issue_obj
 
     @classmethod
-    def validate_config(cls, config, target):
-        if not config.has_option(target, 'pagure.tag') and \
-           not config.has_option(target, 'pagure.repo'):
+    def validate_config(cls, service_config, target):
+        if not service_config.has('tag') and not service_config.has('repo'):
             die("[%s] has no 'pagure.tag' or 'pagure.repo'" % target)
 
-        if not config.has_option(target, 'pagure.base_url'):
+        if not service_config.option('base_url'):
             die("[%s] has no 'pagure.base_url'" % target)
 
-        super(PagureService, cls).validate_config(config, target)
+        super(PagureService, cls).validate_config(service_config, target)

--- a/bugwarrior/services/pagure.py
+++ b/bugwarrior/services/pagure.py
@@ -108,17 +108,17 @@ class PagureService(IssueService):
 
         self.session = requests.Session()
 
-        self.tag = self.config.get_default('tag')
-        self.repo = self.config.get_default('repo')
-        self.base_url = self.config.get_default('base_url')
+        self.tag = self.config.get('tag')
+        self.repo = self.config.get('repo')
+        self.base_url = self.config.get('base_url')
 
-        self.exclude_repos = self.config.get_default('exclude_repos', [], aslist)
-        self.include_repos = self.config.get_default('include_repos', [], aslist)
+        self.exclude_repos = self.config.get('exclude_repos', [], aslist)
+        self.include_repos = self.config.get('include_repos', [], aslist)
 
-        self.import_tags = self.config.get_default(
+        self.import_tags = self.config.get(
             'import_tags', default=False, to_type=asbool
         )
-        self.tag_template = self.config.get_default(
+        self.tag_template = self.config.get(
             'tag_template', default='{{label}}', to_type=six.text_type
         )
 

--- a/bugwarrior/services/pagure.py
+++ b/bugwarrior/services/pagure.py
@@ -217,10 +217,10 @@ class PagureService(IssueService):
 
     @classmethod
     def validate_config(cls, service_config, target):
-        if not service_config.has('tag') and not service_config.has('repo'):
+        if 'tag' not in service_config and 'repo' not in service_config:
             die("[%s] has no 'pagure.tag' or 'pagure.repo'" % target)
 
-        if not service_config.option('base_url'):
+        if 'base_url' not in service_config:
             die("[%s] has no 'pagure.base_url'" % target)
 
         super(PagureService, cls).validate_config(service_config, target)

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -68,10 +68,10 @@ class PhabricatorService(IssueService):
         self.api = phabricator.Phabricator()
 
         self.shown_user_phids = (
-            self.config_get_default("user_phids", None, aslist))
+            self.config.get_default("user_phids", None, aslist))
 
         self.shown_project_phids = (
-            self.config_get_default("project_phids", None, aslist))
+            self.config.get_default("project_phids", None, aslist))
 
     def issues(self):
 

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -68,10 +68,10 @@ class PhabricatorService(IssueService):
         self.api = phabricator.Phabricator()
 
         self.shown_user_phids = (
-            self.config.get_default("user_phids", None, aslist))
+            self.config.get("user_phids", None, aslist))
 
         self.shown_project_phids = (
-            self.config.get_default("project_phids", None, aslist))
+            self.config.get("project_phids", None, aslist))
 
     def issues(self):
 

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -250,7 +250,7 @@ class RedMineService(IssueService):
     @classmethod
     def validate_config(cls, service_config, target):
         for k in ('url', 'key'):
-            if not service_config.has(k):
+            if k not in service_config:
                 die("[%s] has no 'redmine.%s'" % (target, k))
 
         IssueService.validate_config(service_config, target)

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -227,13 +227,13 @@ class RedMineService(IssueService):
         self.key = self.config.get('key')
         self.issue_limit = self.config.get('issue_limit')
 
-        login = self.config.get_default('login')
+        login = self.config.get('login')
         if login:
             password = self.get_password('password', login)
         auth = (login, password) if (login and password) else None
         self.client = RedMineClient(self.url, self.key, auth, self.issue_limit)
 
-        self.project_name = self.config.get_default('project_name')
+        self.project_name = self.config.get('project_name')
 
     def get_service_metadata(self):
         return {
@@ -256,7 +256,7 @@ class RedMineService(IssueService):
         IssueService.validate_config(service_config, target)
 
     def issues(self):
-        only_if_assigned = self.config.get_default('only_if_assigned', False)
+        only_if_assigned = self.config.get('only_if_assigned', False)
         issues = self.client.find_issues(self.issue_limit, only_if_assigned)
         log.debug(" Found %i total.", len(issues))
         for issue in issues:

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -223,17 +223,17 @@ class RedMineService(IssueService):
     def __init__(self, *args, **kw):
         super(RedMineService, self).__init__(*args, **kw)
 
-        self.url = self.config_get('url').rstrip("/")
-        self.key = self.config_get('key')
-        self.issue_limit = self.config_get('issue_limit')
+        self.url = self.config.get('url').rstrip("/")
+        self.key = self.config.get('key')
+        self.issue_limit = self.config.get('issue_limit')
 
-        login = self.config_get_default('login')
+        login = self.config.get_default('login')
         if login:
             password = self.config_get_password('password', login)
         auth = (login, password) if (login and password) else None
         self.client = RedMineClient(self.url, self.key, auth, self.issue_limit)
 
-        self.project_name = self.config_get_default('project_name')
+        self.project_name = self.config.get_default('project_name')
 
     def get_service_metadata(self):
         return {
@@ -241,22 +241,22 @@ class RedMineService(IssueService):
             'url': self.url,
         }
 
-    @classmethod
-    def get_keyring_service(cls, config, section):
-        url = config.get(section, cls._get_key('url'))
-        login = config.get(section, cls._get_key('login'))
+    @staticmethod
+    def get_keyring_service(service_config):
+        url = service_config.get('url')
+        login = service_config.get('login')
         return "redmine://%s@%s/%s" % (login, url)
 
     @classmethod
-    def validate_config(cls, config, target):
-        for k in ('redmine.url', 'redmine.key'):
-            if not config.has_option(target, k):
-                die("[%s] has no '%s'" % (target, k))
+    def validate_config(cls, service_config, target):
+        for k in ('url', 'key'):
+            if not service_config.has(k):
+                die("[%s] has no 'redmine.%s'" % (target, k))
 
-        IssueService.validate_config(config, target)
+        IssueService.validate_config(service_config, target)
 
     def issues(self):
-        only_if_assigned = self.config_get_default('only_if_assigned', False)
+        only_if_assigned = self.config.get_default('only_if_assigned', False)
         issues = self.client.find_issues(self.issue_limit, only_if_assigned)
         log.debug(" Found %i total.", len(issues))
         for issue in issues:

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -229,7 +229,7 @@ class RedMineService(IssueService):
 
         login = self.config.get_default('login')
         if login:
-            password = self.config_get_password('password', login)
+            password = self.get_password('password', login)
         auth = (login, password) if (login and password) else None
         self.client = RedMineClient(self.url, self.key, auth, self.issue_limit)
 

--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -56,9 +56,9 @@ class TaigaService(IssueService, ServiceClient):
 
     def __init__(self, *args, **kw):
         super(TaigaService, self).__init__(*args, **kw)
-        self.url = self.config_get('base_uri')
+        self.url = self.config.get('base_uri')
         self.auth_token = self.config_get_password('auth_token')
-        self.label_template = self.config_get_default(
+        self.label_template = self.config.get_default(
             'label_template', default='{{label}}', to_type=six.text_type
         )
         self.session = requests.session()
@@ -67,9 +67,9 @@ class TaigaService(IssueService, ServiceClient):
             'Authorization': 'Bearer %s' % self.auth_token,
         })
 
-    @classmethod
-    def get_keyring_service(cls, config, section):
-        base_uri = config.get(section, cls._get_key('base_uri'))
+    @staticmethod
+    def get_keyring_service(service_config):
+        base_uri = service_config.get('base_uri')
         return "taiga://%s" % base_uri
 
     def get_service_metadata(self):
@@ -79,12 +79,12 @@ class TaigaService(IssueService, ServiceClient):
         }
 
     @classmethod
-    def validate_config(cls, config, target):
-        for option in ('taiga.auth_token', 'taiga.base_uri'):
-            if not config.has_option(target, option):
-                die("[%s] has no '%s'" % (target, option))
+    def validate_config(cls, service_config, target):
+        for option in ('auth_token', 'base_uri'):
+            if not service_config.has(option):
+                die("[%s] has no 'taiga.%s'" % (target, option))
 
-        IssueService.validate_config(config, target)
+        IssueService.validate_config(service_config, target)
 
     def issues(self):
         url = self.url + '/api/v1/users/me'

--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -57,7 +57,7 @@ class TaigaService(IssueService, ServiceClient):
     def __init__(self, *args, **kw):
         super(TaigaService, self).__init__(*args, **kw)
         self.url = self.config.get('base_uri')
-        self.auth_token = self.config_get_password('auth_token')
+        self.auth_token = self.get_password('auth_token')
         self.label_template = self.config.get_default(
             'label_template', default='{{label}}', to_type=six.text_type
         )

--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -81,7 +81,7 @@ class TaigaService(IssueService, ServiceClient):
     @classmethod
     def validate_config(cls, service_config, target):
         for option in ('auth_token', 'base_uri'):
-            if not service_config.has(option):
+            if option not in service_config:
                 die("[%s] has no 'taiga.%s'" % (target, option))
 
         IssueService.validate_config(service_config, target)

--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -58,7 +58,7 @@ class TaigaService(IssueService, ServiceClient):
         super(TaigaService, self).__init__(*args, **kw)
         self.url = self.config.get('base_uri')
         self.auth_token = self.get_password('auth_token')
-        self.label_template = self.config.get_default(
+        self.label_template = self.config.get(
             'label_template', default='{{label}}', to_type=six.text_type
         )
         self.session = requests.session()

--- a/bugwarrior/services/teamlab.py
+++ b/bugwarrior/services/teamlab.py
@@ -114,9 +114,7 @@ class TeamLabService(IssueService):
         self.client = TeamLabClient(self.hostname)
         self.client.authenticate(_login, _password)
 
-        self.project_name = self.config.get_default(
-            'project_name', self.hostname
-        )
+        self.project_name = self.config.get('project_name', self.hostname)
 
     @staticmethod
     def get_keyring_service(service_config):

--- a/bugwarrior/services/teamlab.py
+++ b/bugwarrior/services/teamlab.py
@@ -107,21 +107,21 @@ class TeamLabService(IssueService):
     def __init__(self, *args, **kw):
         super(TeamLabService, self).__init__(*args, **kw)
 
-        self.hostname = self.config_get('hostname')
-        _login = self.config_get('login')
+        self.hostname = self.config.get('hostname')
+        _login = self.config.get('login')
         _password = self.config_get_password('password', _login)
 
         self.client = TeamLabClient(self.hostname)
         self.client.authenticate(_login, _password)
 
-        self.project_name = self.config_get_default(
+        self.project_name = self.config.get_default(
             'project_name', self.hostname
         )
 
-    @classmethod
-    def get_keyring_service(cls, config, section):
-        login = config.get(section, cls._get_key('login'))
-        hostname = config.get(section, cls._get_key('hostname'))
+    @staticmethod
+    def get_keyring_service(service_config):
+        login = service_config.get('login')
+        hostname = service_config.get('hostname')
         return "teamlab://%s@%s" % (login, hostname)
 
     def get_service_metadata(self):
@@ -131,12 +131,12 @@ class TeamLabService(IssueService):
         }
 
     @classmethod
-    def validate_config(cls, config, target):
-        for k in ('teamlab.login', 'teamlab.password', 'teamlab.hostname'):
-            if not config.has_option(target, k):
-                die("[%s] has no '%s'" % (target, k))
+    def validate_config(cls, service_config, target):
+        for k in ('login', 'password', 'hostname'):
+            if not service_config.has(k):
+                die("[%s] has no 'teamlab.%s'" % (target, k))
 
-        IssueService.validate_config(config, target)
+        IssueService.validate_config(service_config, target)
 
     def issues(self):
         issues = self.client.get_task_list()

--- a/bugwarrior/services/teamlab.py
+++ b/bugwarrior/services/teamlab.py
@@ -109,7 +109,7 @@ class TeamLabService(IssueService):
 
         self.hostname = self.config.get('hostname')
         _login = self.config.get('login')
-        _password = self.config_get_password('password', _login)
+        _password = self.get_password('password', _login)
 
         self.client = TeamLabClient(self.hostname)
         self.client.authenticate(_login, _password)

--- a/bugwarrior/services/teamlab.py
+++ b/bugwarrior/services/teamlab.py
@@ -131,7 +131,7 @@ class TeamLabService(IssueService):
     @classmethod
     def validate_config(cls, service_config, target):
         for k in ('login', 'password', 'hostname'):
-            if not service_config.has(k):
+            if k not in service_config:
                 die("[%s] has no 'teamlab.%s'" % (target, k))
 
         IssueService.validate_config(service_config, target)

--- a/bugwarrior/services/trac.py
+++ b/bugwarrior/services/trac.py
@@ -90,15 +90,15 @@ class TracService(IssueService):
     def __init__(self, *args, **kw):
         super(TracService, self).__init__(*args, **kw)
         base_uri = self.config.get('base_uri')
-        scheme = self.config.get_default('scheme', default='https')
-        username = self.config.get_default('username', default=None)
+        scheme = self.config.get('scheme', default='https')
+        username = self.config.get('username', default=None)
         if username:
             password = self.get_password('password', username)
 
             auth = urllib.parse.quote_plus('%s:%s' % (username, password)) + '@'
         else:
             auth = ''
-        if self.config.get_default('no_xmlrpc', default=False, to_type=asbool):
+        if self.config.get('no_xmlrpc', default=False, to_type=asbool):
             uri = '%s://%s%s/' % (scheme, auth, base_uri)
             self.uri = uri
             self.trac = None

--- a/bugwarrior/services/trac.py
+++ b/bugwarrior/services/trac.py
@@ -93,7 +93,7 @@ class TracService(IssueService):
         scheme = self.config.get_default('scheme', default='https')
         username = self.config.get_default('username', default=None)
         if username:
-            password = self.config_get_password('password', username)
+            password = self.get_password('password', username)
 
             auth = urllib.parse.quote_plus('%s:%s' % (username, password)) + '@'
         else:

--- a/bugwarrior/services/trac.py
+++ b/bugwarrior/services/trac.py
@@ -114,7 +114,7 @@ class TracService(IssueService):
 
     @classmethod
     def validate_config(cls, service_config, target):
-        if not service_config.has('base_uri'):
+        if 'base_uri' not in service_config:
             die("[%s] has no 'base_uri'" % target)
         elif '://' in service_config.get('base_uri'):
             die("[%s] do not include scheme in 'base_uri'" % target)

--- a/bugwarrior/services/trello.py
+++ b/bugwarrior/services/trello.py
@@ -82,7 +82,7 @@ class TrelloService(IssueService, ServiceClient):
     def validate_config(cls, service_config, target):
         def check_key(opt):
             """ Check that the given key exist in the configuration  """
-            if not service_config.has(opt):
+            if opt not in service_config:
                 die("[{}] has no 'trello.{}'".format(target, opt))
         super(TrelloService, cls).validate_config(service_config, target)
         check_key('token')
@@ -127,7 +127,7 @@ class TrelloService(IssueService, ServiceClient):
         trello.include_boards use that, otherwise ask the Trello API for the
         user's boards.
         """
-        if self.config.has('include_boards'):
+        if 'include_boards' in self.config:
             for boardid in self.config.get('include_boards', to_type=aslist):
                 # Get the board name
                 yield self.api_request(

--- a/bugwarrior/services/trello.py
+++ b/bugwarrior/services/trello.py
@@ -94,9 +94,9 @@ class TrelloService(IssueService, ServiceClient):
         """
         return {
             'import_labels_as_tags':
-            self.config.get_default('import_labels_as_tags', False, asbool),
+            self.config.get('import_labels_as_tags', False, asbool),
             'label_template':
-            self.config.get_default('label_template', DEFAULT_LABEL_TEMPLATE),
+            self.config.get('label_template', DEFAULT_LABEL_TEMPLATE),
             }
 
     def issues(self):
@@ -128,7 +128,7 @@ class TrelloService(IssueService, ServiceClient):
         user's boards.
         """
         if self.config.has('include_boards'):
-            for boardid in self.config.get('include_boards', aslist):
+            for boardid in self.config.get('include_boards', to_type=aslist):
                 # Get the board name
                 yield self.api_request(
                     "/1/boards/{id}".format(id=boardid), fields='name')
@@ -146,16 +146,15 @@ class TrelloService(IssueService, ServiceClient):
         lists = self.api_request(
             "/1/boards/{board_id}/lists/open".format(board_id=board),
             fields='name')
-        try:
-            include_lists = self.config.get('include_lists', aslist)
+
+        include_lists = self.config.get('include_lists', to_type=aslist)
+        if include_lists:
             lists = [l for l in lists if l['name'] in include_lists]
-        except NoOptionError:
-            pass
-        try:
-            exclude_lists = self.config.get('exclude_lists', aslist)
+
+        exclude_lists = self.config.get('exclude_lists', to_type=aslist)
+        if exclude_lists:
             lists = [l for l in lists if l['name'] not in exclude_lists]
-        except NoOptionError:
-            pass
+
         return lists
 
     def get_cards(self, list_id):
@@ -163,8 +162,8 @@ class TrelloService(IssueService, ServiceClient):
         according to configuration values of trello.only_if_assigned and
         trello.also_unassigned """
         params = {'fields': 'name,idShort,shortLink,shortUrl,url,labels'}
-        member = self.config.get_default('only_if_assigned', None)
-        unassigned = self.config.get_default('also_unassigned', False, asbool)
+        member = self.config.get('only_if_assigned', None)
+        unassigned = self.config.get('also_unassigned', False, asbool)
         if member is not None:
             params['members'] = 'true'
             params['member_fields'] = 'username'

--- a/bugwarrior/services/versionone.py
+++ b/bugwarrior/services/versionone.py
@@ -181,26 +181,24 @@ class VersionOneService(IssueService):
         super(VersionOneService, self).__init__(*args, **kw)
 
         parsed_address = parse.urlparse(
-            self.config_get('base_uri')
+            self.config.get('base_uri')
         )
         self.address = parsed_address.netloc
         self.instance = parsed_address.path.strip('/')
-        self.username = self.config_get('username')
+        self.username = self.config.get('username')
         self.password = self.config_get_password('password', self.username)
 
-        self.timezone = self.config_get_default(
+        self.timezone = self.config.get_default(
             'timezone',
             default=LOCAL_TIMEZONE
         )
-        self.project = self.config_get_default('project_name', default='')
-        self.timebox_name = self.config_get_default('timebox_name')
+        self.project = self.config.get_default('project_name', default='')
+        self.timebox_name = self.config.get_default('timebox_name')
 
-    @classmethod
-    def get_keyring_service(cls, config, section):
-        parsed_address = parse.urlparse(
-            config.get(section, cls._get_key('base_uri'))
-        )
-        username = config.get(section, cls._get_key('username'))
+    @staticmethod
+    def get_keyring_service(service_config):
+        parsed_address = parse.urlparse(service_config.get('base_uri'))
+        username = service_config.get('username')
         return "versionone://%s@%s%s" % (
             username,
             parsed_address.netloc,
@@ -213,16 +211,16 @@ class VersionOneService(IssueService):
         }
 
     @classmethod
-    def validate_config(cls, config, target):
+    def validate_config(cls, service_config, target):
         options = (
-            'versionone.base_uri',
-            'versionone.username',
+            'base_uri',
+            'username',
         )
         for option in options:
-            if not config.has_option(target, option):
-                die("[%s] has no '%s'" % (target, option))
+            if not service_config.has(option):
+                die("[%s] has no 'versionone.%s'" % (target, option))
 
-        IssueService.validate_config(config, target)
+        IssueService.validate_config(service_config, target)
 
     def get_meta(self):
         if not hasattr(self, '_meta'):

--- a/bugwarrior/services/versionone.py
+++ b/bugwarrior/services/versionone.py
@@ -188,12 +188,9 @@ class VersionOneService(IssueService):
         self.username = self.config.get('username')
         self.password = self.get_password('password', self.username)
 
-        self.timezone = self.config.get_default(
-            'timezone',
-            default=LOCAL_TIMEZONE
-        )
-        self.project = self.config.get_default('project_name', default='')
-        self.timebox_name = self.config.get_default('timebox_name')
+        self.timezone = self.config.get('timezone', default=LOCAL_TIMEZONE)
+        self.project = self.config.get('project_name', default='')
+        self.timebox_name = self.config.get('timebox_name')
 
     @staticmethod
     def get_keyring_service(service_config):

--- a/bugwarrior/services/versionone.py
+++ b/bugwarrior/services/versionone.py
@@ -214,7 +214,7 @@ class VersionOneService(IssueService):
             'username',
         )
         for option in options:
-            if not service_config.has(option):
+            if option not in service_config:
                 die("[%s] has no 'versionone.%s'" % (target, option))
 
         IssueService.validate_config(service_config, target)

--- a/bugwarrior/services/versionone.py
+++ b/bugwarrior/services/versionone.py
@@ -186,7 +186,7 @@ class VersionOneService(IssueService):
         self.address = parsed_address.netloc
         self.instance = parsed_address.path.strip('/')
         self.username = self.config.get('username')
-        self.password = self.config_get_password('password', self.username)
+        self.password = self.get_password('password', self.username)
 
         self.timezone = self.config.get_default(
             'timezone',

--- a/bugwarrior/services/youtrack.py
+++ b/bugwarrior/services/youtrack.py
@@ -138,7 +138,7 @@ class YoutrackService(IssueService, ServiceClient):
             self.session.verify = False
 
         login = self.config.get('login')
-        password = self.config_get_password('password', login)
+        password = self.get_password('password', login)
         if not self.config.get_default('anonymous', False):
             self._login(login, password)
 

--- a/bugwarrior/services/youtrack.py
+++ b/bugwarrior/services/youtrack.py
@@ -174,7 +174,7 @@ class YoutrackService(IssueService, ServiceClient):
     @classmethod
     def validate_config(cls, service_config, target):
         for k in ('login', 'password', 'host'):
-            if not service_config.has(k):
+            if k not in service_config:
                 die("[%s] has no 'youtrack.%s'" % (target, k))
 
         IssueService.validate_config(service_config, target)

--- a/bugwarrior/services/youtrack.py
+++ b/bugwarrior/services/youtrack.py
@@ -120,35 +120,35 @@ class YoutrackService(IssueService, ServiceClient):
         super(YoutrackService, self).__init__(*args, **kw)
 
         self.host = self.config.get('host')
-        if self.config.get_default('use_https', default=True, to_type=asbool):
+        if self.config.get('use_https', default=True, to_type=asbool):
             self.scheme = 'https'
             self.port = '443'
         else:
             self.scheme = 'http'
             self.port = '80'
-        self.port = self.config.get_default('port', self.port)
+        self.port = self.config.get('port', self.port)
         self.base_url = '%s://%s:%s' % (self.scheme, self.host, self.port)
         self.rest_url = self.base_url + '/rest'
 
         self.session = requests.Session()
         self.session.headers['Accept'] = 'application/json'
-        self.verify_ssl = self.config.get_default('verify_ssl', default=True, to_type=asbool)
+        self.verify_ssl = self.config.get('verify_ssl', default=True, to_type=asbool)
         if not self.verify_ssl:
             requests.packages.urllib3.disable_warnings()
             self.session.verify = False
 
         login = self.config.get('login')
         password = self.get_password('password', login)
-        if not self.config.get_default('anonymous', False):
+        if not self.config.get('anonymous', False):
             self._login(login, password)
 
-        self.query = self.config.get_default('query', default='for:me #Unresolved')
-        self.query_limit = self.config.get_default('query_limit', default="100")
+        self.query = self.config.get('query', default='for:me #Unresolved')
+        self.query_limit = self.config.get('query_limit', default="100")
 
-        self.import_tags = self.config.get_default(
+        self.import_tags = self.config.get(
             'import_tags', default=True, to_type=asbool
         )
-        self.tag_template = self.config.get_default(
+        self.tag_template = self.config.get(
             'tag_template', default='{{tag|lower}}', to_type=six.text_type
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -126,7 +126,6 @@ class TestBugwarriorConfigParser(TestCase):
         self.config.set('general', 'somenone', '')
         self.config.set('general', 'somechar', 'somestring')
 
-
     def test_getint(self):
         self.assertEqual(self.config.getint('general', 'someint'), 4)
 
@@ -136,3 +135,46 @@ class TestBugwarriorConfigParser(TestCase):
     def test_getint_valueerror(self):
         with self.assertRaises(ValueError):
             self.config.getint('general', 'somechar')
+
+
+class TestServiceConfig(TestCase):
+    def setUp(self):
+        self.target = 'someservice'
+
+        self.config = config.BugwarriorConfigParser()
+        self.config.add_section(self.target)
+        self.config.set(self.target, 'someprefix.someint', '4')
+        self.config.set(self.target, 'someprefix.somenone', '')
+        self.config.set(self.target, 'someprefix.somechar', 'somestring')
+        self.config.set(self.target, 'someprefix.somebool', 'true')
+
+        self.service_config = config.ServiceConfig(
+            'someprefix', self.config, self.target)
+
+    def test_configparser_proxy(self):
+        """
+        Methods not defined in ServiceConfig should be proxied to configparser.
+        """
+        self.assertTrue(
+            self.service_config.has_option(self.target, 'someprefix.someint'))
+
+    def test_has(self):
+        self.assertTrue(self.service_config.has('someint'))
+
+    def test_get(self):
+        self.assertEqual(self.service_config.get('someint'), '4')
+
+    def test_get_default(self):
+        self.assertEqual(
+            self.service_config.get('someoption', default='somedefault'),
+            'somedefault'
+        )
+
+    def test_get_default_none(self):
+        self.assertIsNone(self.service_config.get('someoption'))
+
+    def test_get_to_type(self):
+        self.assertIs(
+            self.service_config.get('somebool', to_type=config.asbool),
+            True
+        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,8 +158,8 @@ class TestServiceConfig(TestCase):
         self.assertTrue(
             self.service_config.has_option(self.target, 'someprefix.someint'))
 
-    def test_has(self):
-        self.assertTrue(self.service_config.has('someint'))
+    def test__contains__(self):
+        self.assertTrue('someint' in self.service_config)
 
     def test_get(self):
         self.assertEqual(self.service_config.get('someint'), '4')

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -6,6 +6,7 @@ from configparser import RawConfigParser
 import pytz
 import responses
 
+from bugwarrior.config import ServiceConfig
 from bugwarrior.services.github import GithubService, GithubClient
 
 from .base import ServiceTest, AbstractServiceTest
@@ -200,6 +201,8 @@ class TestGithubService(TestCase):
         self.config.set('mygithub', 'github.login', 'tintin')
         self.config.set('mygithub', 'github.username', 'milou')
         self.config.set('mygithub', 'github.password', 't0ps3cr3t')
+        self.service_config = ServiceConfig(
+            GithubService.CONFIG_PREFIX, self.config, 'mygithub')
 
     def test_token_authorization_header(self):
         self.config.remove_option('mygithub', 'github.password')
@@ -222,15 +225,13 @@ class TestGithubService(TestCase):
 
     def test_keyring_service(self):
         """ Checks that the keyring service name """
-        keyring_service = (
-            GithubService.get_keyring_service(self.config, 'mygithub'))
+        keyring_service = GithubService.get_keyring_service(self.service_config)
         self.assertEquals("github://tintin@github.com/milou", keyring_service)
 
     def test_keyring_service_host(self):
         """ Checks that the keyring key depends on the github host. """
         self.config.set('mygithub', 'github.host', 'github.example.com')
-        keyring_service = (
-            GithubService.get_keyring_service(self.config, 'mygithub'))
+        keyring_service = GithubService.get_keyring_service(self.service_config)
         self.assertEquals("github://tintin@github.example.com/milou", keyring_service)
 
     def test_get_repository_from_issue_url__issue(self):

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -7,6 +7,7 @@ import datetime
 import pytz
 import responses
 
+from bugwarrior.config import ServiceConfig
 from bugwarrior.services.gitlab import GitlabService
 
 from .base import ConfigTest, ServiceTest, AbstractServiceTest
@@ -21,16 +22,18 @@ class TestGitlabService(ConfigTest):
         self.config.add_section('myservice')
         self.config.set('myservice', 'gitlab.login', 'foobar')
         self.config.set('myservice', 'gitlab.token', 'XXXXXX')
+        self.service_config = ServiceConfig(
+            GitlabService.CONFIG_PREFIX, self.config, 'myservice')
 
     def test_get_keyring_service_default_host(self):
         self.assertEqual(
-            GitlabService.get_keyring_service(self.config, 'myservice'),
+            GitlabService.get_keyring_service(self.service_config),
             'gitlab://foobar@gitlab.com')
 
     def test_get_keyring_service_custom_host(self):
         self.config.set('myservice', 'gitlab.host', 'gitlab.example.com')
         self.assertEqual(
-            GitlabService.get_keyring_service(self.config, 'myservice'),
+            GitlabService.get_keyring_service(self.service_config),
             'gitlab://foobar@gitlab.example.com')
 
     def test_add_default_namespace_to_included_repos(self):

--- a/tests/test_trello.py
+++ b/tests/test_trello.py
@@ -7,6 +7,7 @@ import configparser
 from mock import patch
 import responses
 
+from bugwarrior.config import ServiceConfig
 from bugwarrior.services.trello import TrelloService, TrelloIssue
 from .base import ConfigTest, ServiceTest
 
@@ -68,6 +69,8 @@ class TestTrelloService(ConfigTest):
         self.config.add_section('mytrello')
         self.config.set('mytrello', 'trello.api_key', 'XXXX')
         self.config.set('mytrello', 'trello.token', 'YYYY')
+        self.service_config = ServiceConfig(
+            TrelloService.CONFIG_PREFIX, self.config, 'mytrello')
         responses.add(responses.GET,
                       'https://api.trello.com/1/lists/L15T/cards/open',
                       json=[self.CARD1, self.CARD2, self.CARD3])
@@ -194,17 +197,17 @@ class TestTrelloService(ConfigTest):
 
     @patch('bugwarrior.services.trello.die')
     def test_validate_config(self, die):
-        TrelloService.validate_config(self.config, 'mytrello')
+        TrelloService.validate_config(self.service_config, 'mytrello')
         die.assert_not_called()
 
     @patch('bugwarrior.services.trello.die')
     def test_valid_config_no_access_token(self, die):
         self.config.remove_option('mytrello', 'trello.token')
-        TrelloService.validate_config(self.config, 'mytrello')
+        TrelloService.validate_config(self.service_config, 'mytrello')
         die.assert_called_with("[mytrello] has no 'trello.token'")
 
     @patch('bugwarrior.services.trello.die')
     def test_valid_config_no_api_key(self, die):
         self.config.remove_option('mytrello', 'trello.api_key')
-        TrelloService.validate_config(self.config, 'mytrello')
+        TrelloService.validate_config(self.service_config, 'mytrello')
         die.assert_called_with("[mytrello] has no 'trello.api_key'")

--- a/tests/test_youtrak.py
+++ b/tests/test_youtrak.py
@@ -4,6 +4,7 @@ from builtins import next
 import configparser
 import responses
 
+from bugwarrior.services import ServiceConfig
 from bugwarrior.services.youtrack import YoutrackService
 
 from .base import ConfigTest, ServiceTest, AbstractServiceTest
@@ -17,11 +18,12 @@ class TestYoutrackService(ConfigTest):
         self.config.add_section('myservice')
         self.config.set('myservice', 'youtrack.login', 'foobar')
         self.config.set('myservice', 'youtrack.password', 'XXXXXX')
-
     def test_get_keyring_service(self):
         self.config.set('myservice', 'youtrack.host', 'youtrack.example.com')
+        service_config = ServiceConfig(
+            YoutrackService.CONFIG_PREFIX, self.config, 'myservice')
         self.assertEqual(
-            YoutrackService.get_keyring_service(self.config, 'myservice'),
+            YoutrackService.get_keyring_service(service_config),
             'youtrack://foobar@youtrack.example.com')
 
 


### PR DESCRIPTION
The `IssueService.config_*` methods are part of a concept that wants to be it's own
object. The functionality of these convenience methods is
duplicated wherever an `IssueService` instance is not available
(validate_config, get_keyring_service, etc.), indicating that they're in
the wrong place.