### PR TITLE
Add product and component as UDA for bugzilla

### DIFF
--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -18,6 +18,8 @@ class BugzillaIssue(Issue):
     BUG_ID = 'bugzillabugid'
     STATUS = 'bugzillastatus'
     NEEDINFO = 'bugzillaneedinfo'
+    PRODUCT = 'bugzillaproduct'
+    COMPONENT = 'bugzillacomponent'
 
     UDAS = {
         URL: {
@@ -40,6 +42,14 @@ class BugzillaIssue(Issue):
             'type': 'date',
             'label': 'Bugzilla Needinfo',
         },
+        PRODUCT: {
+            'type': 'string',
+            'label': 'Bugzilla Product',
+        },
+        COMPONENT: {
+            'type': 'string',
+            'label': 'Bugzilla Component',
+        },
     }
     UNIQUE_KEY = (URL, )
 
@@ -61,6 +71,8 @@ class BugzillaIssue(Issue):
             self.SUMMARY: self.record['summary'],
             self.BUG_ID: self.record['id'],
             self.STATUS: self.record['status'],
+            self.PRODUCT: self.record['product'],
+            self.COMPONENT: self.record['component'],
         }
         if self.extra.get('needinfo_since', None) is not None:
             task[self.NEEDINFO] = self.extra.get('needinfo_since')
@@ -99,6 +111,7 @@ class BugzillaService(IssueService):
         'status',
         'summary',
         'priority',
+        'product',
         'component',
         'flags',
         'longdescs',

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -61,6 +61,7 @@ class TestBugzillaService(AbstractServiceTest, ServiceTest):
     }
 
     arbitrary_record = {
+        'product': 'Product',
         'component': 'Something',
         'priority': 'urgent',
         'status': 'NEW',
@@ -111,7 +112,9 @@ class TestBugzillaService(AbstractServiceTest, ServiceTest):
             issue.STATUS: self.arbitrary_record['status'],
             issue.URL: arbitrary_extra['url'],
             issue.SUMMARY: self.arbitrary_record['summary'],
-            issue.BUG_ID: self.arbitrary_record['id']
+            issue.BUG_ID: self.arbitrary_record['id'],
+            issue.PRODUCT: self.arbitrary_record['product'],
+            issue.COMPONENT: self.arbitrary_record['component'],
         }
         actual_output = issue.to_taskwarrior()
 
@@ -126,6 +129,8 @@ class TestBugzillaService(AbstractServiceTest, ServiceTest):
             'bugzillastatus': 'NEW',
             'bugzillasummary': 'This is the issue summary',
             'bugzillaurl': u'https://http://one.com//show_bug.cgi?id=1234567',
+            'bugzillaproduct': 'Product',
+            'bugzillacomponent': 'Something',
             'description': u'(bw)Is#1234567 - This is the issue summary .. https://http://one.com//show_bug.cgi?id=1234567',
             'priority': 'H',
             'project': 'Something',


### PR DESCRIPTION
This allows to use a ```project_template``` with a value of
```{{ bugzillaproduct }}.{{ bugzillacomponent }}``` which is nicely rendered
by taskwarrior as:
```
  $ task projects
  Project                      Tasks
  product                         10
    component1                     1
    component2                     7
    componentN                     2
```

Bugzilla has more fields which might be useful as UDA:
* 5.0: https://bugzilla.readthedocs.io/en/5.0/using/understanding.html
* 4.4: https://www.bugzilla.org/docs/4.4/en/html/bug_page.html