### PR TITLE
Issue #450 fix for JIRA entry datetime comparison

### DIFF
--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from builtins import str
 
-from datetime import datetime
 
 import six
 from jinja2 import Template

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -123,11 +123,9 @@ class JiraIssue(Issue):
 
     def get_entry(self):
         created_at = self.record['fields']['created']
-
-        # strip off the timezone offset
-        timestamp, timezone = created_at[:-5], created_at[-5:]
-        timestamp = datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S.%f')
-        return timestamp.strftime('%Y%m%dT%H%M%S') + timezone
+        # Convert timestamp to an offset-aware datetime
+        date = self.parse_date(created_at)
+        return date
 
     def get_tags(self):
         return self._get_tags_from_labels() + self._get_tags_from_sprints()

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -3,6 +3,7 @@ from builtins import object
 from collections import namedtuple
 
 import mock
+from dateutil.tz import tzoffset, datetime
 
 from bugwarrior.services.jira import JiraService
 from .base import ServiceTest, AbstractServiceTest
@@ -71,7 +72,7 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
             ),
             'annotations': arbitrary_extra['annotations'],
             'tags': [],
-            'entry': '20160606T060708-0700',
+            'entry': datetime.datetime(2016, 6, 6, 6, 7, 8, 123000, tzinfo=tzoffset(None, -25200)),
             'jirafixversion': '1.2.3',
 
             issue.URL: arbitrary_url,
@@ -95,7 +96,7 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
         expected = {
             'annotations': [],
             'description': '(bw)Is#10 - lkjaldsfjaldf .. two/browse/DONUT-10',
-            'entry': '20160606T060708-0700',
+            'entry': datetime.datetime(2016, 6, 6, 6, 7, 8, 123000, tzinfo=tzoffset(None, -25200)),
             'jiradescription': None,
             'jiraestimate': 1,
             'jirafixversion': '1.2.3',


### PR DESCRIPTION
Fix for issue #450 by converting unicode timestamp to offset-aware datetime object.
