### PR TITLE
GMail service for bugwarrior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
   - JIRAVERSION=1.0.10
 install:
   - pip install jira==$JIRAVERSION
-  - pip install .[jira,megaplan,activecollab,bts,bugzilla,trac]
+  - pip install .[jira,megaplan,activecollab,bts,bugzilla,trac,gmail]
   - pip install codecov
   - pip install coverage
 script: nosetests -w tests --with-coverage --cover-branches --cover-package=bugwarrior -v

--- a/bugwarrior/data.py
+++ b/bugwarrior/data.py
@@ -8,6 +8,7 @@ class BugwarriorData(object):
     def __init__(self, data_path):
         self.datafile = os.path.join(data_path, 'bugwarrior.data')
         self.lockfile = os.path.join(data_path, 'bugwarrior-data.lockfile')
+        self.path = data_path
 
     def get_data(self):
         with open(self.datafile, 'r') as jsondata:

--- a/bugwarrior/docs/configuration.rst
+++ b/bugwarrior/docs/configuration.rst
@@ -192,11 +192,4 @@ Example Configuration
     [my_gmail]
     service = gmail
     gmail.query = label:action OR label:readme
-    # You need a get a client_secret.json. Follow the instructions on: https://developers.google.com/gmail/api/quickstart/python
-    gmail.client_secret_path = ~/.config/bugwarrior/client_secret.json
-    # This file will be created when you authenticate.
-    gmail.credentials_path = ~/.config/bugwarrior/credentials.json
-    # Restrict to a particular e-mail address. This is optional and will cause the pull to fail if the credentials don't match
-    # the specified user. When working with multiple accounts it's a bit a tricky to make sure you always authorise the correct
-    # account.
-    gmail.login_name = name@example.com
+    gmail.login_name = you@example.com

--- a/bugwarrior/docs/configuration.rst
+++ b/bugwarrior/docs/configuration.rst
@@ -188,3 +188,15 @@ Example Configuration
     activecollab2.key = your-api-key
     activecollab2.user_id = 15
     activecollab2.projects = 1:first_project, 5:another_project
+
+    [my_gmail]
+    service = gmail
+    gmail.query = label:action OR label:readme
+    # You need a get a client_secret.json. Follow the instructions on: https://developers.google.com/gmail/api/quickstart/python
+    gmail.client_secret_path = ~/.config/bugwarrior/client_secret.json
+    # This file will be created when you authenticate.
+    gmail.credentials_path = ~/.config/bugwarrior/credentials.json
+    # Restrict to a particular e-mail address. This is optional and will cause the pull to fail if the credentials don't match
+    # the specified user. When working with multiple accounts it's a bit a tricky to make sure you always authorise the correct
+    # account.
+    gmail.login_name = name@example.com

--- a/bugwarrior/docs/services/gmail.rst
+++ b/bugwarrior/docs/services/gmail.rst
@@ -1,0 +1,64 @@
+Gmail
+=====
+
+You can create tasks from e-mails in your Gmail account using the ``gmail``
+service name.
+
+Additional Dependencies
+-----------------------
+
+Install packages needed for Gmail support with:
+
+::
+   pip install bugwarrior[gmail]
+
+Client Secret
+-------------
+
+In order to use this service, you need to create a product and download a
+client secret file. Do this by following the instructions on:
+``https://developers.google.com/gmail/api/quickstart/python``. You should save
+the resulting secret in your home directory as ``.gmail_client_secret.json``.
+You can override this location by setting the ``client_secret_path`` option.
+
+Example Service
+---------------
+
+Here's an example of a gmail target:
+
+::
+    [my_gmail]
+    service = gmail
+    gmail.query = label:action OR label:readme
+    gmail.login_name = you@example.com
+
+The specified query can be any gmail search term. By default it will select
+starred threads. One task is created per selected thread, not per e-mail.
+
+You do not need to specify the ``login_name``, but it can be useful to avoid
+accidentally fetching data from the wrong account. (This also allows multiple
+targets with the same login to share the same authentication token.)
+
+Authentication
+--------------
+
+When you first run ``bugwarrior-pull``, a browser will be opened and you'll be
+asked to authorise the application to access your e-mail. Once authorised a
+token will be stored in your bugwarrior data directory.
+
+Provided UDA Fields
+-------------------
+
++---------------------+-----------------------------------+---------------|
+| ``gmailthreadid``   | Thread Id                         | Text (string) |
++---------------------+-----------------------------------+---------------|
+| ``gmailsubject``    | Subject                           | Text (string) |
++---------------------+-----------------------------------+---------------|
+| ``gmailurl``        | URL                               | Text (string) |
++---------------------+-----------------------------------+---------------|
+| ``gmaillastsender`` | Last Sender's Name                | Text (string) |
++---------------------+-----------------------------------+---------------|
+| ``gmaillastsender`` | Last Sender's E-mail Address      | Text (string) |
++---------------------+-----------------------------------+---------------|
+| ``gmailsnippet``    | Snippet of text from conversation | Text (string) |
++---------------------+-----------------------------------+---------------|

--- a/bugwarrior/services/gmail.py
+++ b/bugwarrior/services/gmail.py
@@ -1,0 +1,180 @@
+import httplib2
+import os
+import email
+import re
+
+import googleapiclient.discovery
+import oauth2client.client
+import oauth2client.tools
+import oauth2client.file
+
+from bugwarrior.services import IssueService, Issue
+
+import logging
+log = logging.getLogger(__name__)
+
+class GmailIssue(Issue):
+    THREAD_ID = 'gmailthreadid'
+    SUBJECT = 'gmailsubject'
+    URL = 'gmailurl'
+    LAST_SENDER = 'gmaillastsender'
+    LAST_SENDER_ADDR = 'gmaillastsenderaddr'
+    SNIPPET = 'gmailsnippet'
+
+    UNIQUE_KEY = (THREAD_ID,)
+    UDAS = {
+        THREAD_ID: {
+            'type': 'string',
+            'label': 'GMail Thread Id',
+        },
+        SUBJECT: {
+            'type': 'string',
+            'label': 'GMail Subject',
+        },
+        URL: {
+            'type': 'string',
+            'label': 'GMail URL',
+        },
+        LAST_SENDER: {
+            'type': 'string',
+            'label': 'GMail last sender name',
+        },
+        LAST_SENDER_ADDR: {
+            'type': 'string',
+            'label': 'GMail last sender address',
+        },
+        SNIPPET: {
+            'type': 'string',
+            'label': 'GMail snippet',
+        }
+    }
+    EXCLUDE_LABELS = [
+        'IMPORTANT',
+        'CATEGORY_PERSONAL',
+        'CATEGORY_PROMOTIONS',
+        'CATEGORY_UPDATES',
+        'CATEGORY_FORUMS',
+        'SENT']
+
+    def to_taskwarrior(self):
+        return {
+            'tags': [label
+                for label in self.extra['labels']
+                if label not in self.EXCLUDE_LABELS],
+            'priority': self.origin['default_priority'],
+            self.THREAD_ID: self.record['id'],
+            self.SUBJECT: self.extra['subject'],
+            self.URL: self.extra['url'],
+            self.LAST_SENDER: self.extra['last_sender_name'],
+            self.LAST_SENDER_ADDR: self.extra['last_sender_address'],
+            self.SNIPPET: self.extra['snippet'],
+        }
+
+    def get_default_description(self):
+        return self.build_default_description(
+            title=self.extra['subject'],
+            url=self.get_processed_url(self.extra['url']),
+            number=self.record['id'],
+            cls='issue',
+        )
+
+class GmailService(IssueService):
+    APPLICATION_NAME = 'Bugwarrior Gmail Service'
+    SCOPES = 'https://www.googleapis.com/auth/gmail.readonly'
+    DEFAULT_CLIENT_SECRET_PATH = '~/.gmail_client_secret.json'
+
+    ISSUE_CLASS = GmailIssue
+    CONFIG_PREFIX = 'gmail'
+
+    def __init__(self, *args, **kw):
+        super(GmailService, self).__init__(*args, **kw)
+
+        self.query = self.config.get('query', 'label:Starred')
+        self.login_name = self.config.get('login_name', 'me')
+        self.client_secret_path = self.get_config_path(
+                'client_secret_path',
+                self.DEFAULT_CLIENT_SECRET_PATH)
+        credentials_name = clean_filename(self.login_name
+                if self.login_name != 'me' else self.target)
+        self.credentials_path = os.path.join(
+                self.config.data.path,
+                'gmail_credentials_%s.json' % (credentials_name,))
+        self.gmail_api = self.build_api()
+
+    def get_config_path(self, varname, default_path=None):
+        return os.path.expanduser(self.config.get(varname, default_path))
+
+    def build_api(self):
+        credentials = self.get_credentials()
+        http = credentials.authorize(httplib2.Http())
+        return googleapiclient.discovery.build('gmail', 'v1', http=http)
+
+    def get_credentials(self):
+        """Gets valid user credentials from storage.
+
+        If nothing has been stored, or if the stored credentials are invalid,
+        the OAuth2 flow is completed to obtain the new credentials.
+
+        Returns:
+            Credentials, the obtained credential.
+        """
+        store = oauth2client.file.Storage(self.credentials_path)
+        credentials = store.get()
+        if not credentials or credentials.invalid:
+            log.info("No valid login. Starting OAUTH flow.")
+            flow = oauth2client.client.flow_from_clientsecrets(self.client_secret_path, self.SCOPES)
+            flow.user_agent = self.APPLICATION_NAME
+            flags = oauth2client.tools.argparser.parse_args()
+            credentials = oauth2client.tools.run_flow(flow, store, flags)
+            log.info('Storing credentials to %r', self.credentials_path)
+        return credentials
+
+    def get_labels(self):
+        result = self.gmail_api.users().labels().list(userId=self.login_name).execute()
+        return {label['id']: label['name'] for label in result['labels']}
+
+    def get_threads(self):
+        thread_service = self.gmail_api.users().threads()
+
+        result = thread_service.list(userId=self.login_name, q=self.query).execute()
+        return [
+            thread_service.get(userId='me', id=thread['id']).execute()
+            for thread in result.get('threads', [])]
+
+    def issues(self):
+        labels = self.get_labels()
+        for thread in self.get_threads():
+            yield self.get_issue_for_record(thread, thread_extras(thread, labels))
+
+def thread_extras(thread, labels):
+    (name, address) = thread_last_sender(thread)
+    return {
+        'labels': [labels[label_id] for label_id in thread_labels(thread)],
+        'subject': message_header(thread['messages'][0], 'Subject'),
+        'url': "https://mail.google.com/mail/u/0/#all/%s" % (thread['id'],),
+        'last_sender_name': name,
+        'last_sender_address': address,
+        'snippet': thread_snippet(thread),
+    }
+
+def thread_labels(thread):
+    return {label for message in thread['messages'] for label in message['labelIds']}
+
+def thread_subject(thread):
+    return message_header(thread['messages'][0], 'Subject')
+
+def thread_last_sender(thread):
+    from_header = message_header(thread['messages'][-1], 'From')
+    (name, address) = email.utils.parseaddr(from_header)
+    return (name if name else address, address)
+
+def thread_snippet(thread):
+    return thread['messages'][-1]['snippet']
+
+def message_header(message, header_name):
+    for item in message['payload']['headers']:
+        if item['name'] == header_name:
+            return item['value']
+
+def clean_filename(name):
+    return re.sub(r'[^A-Za-z0-9_]+', '_', name)

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(name='bugwarrior',
           bts=["PySimpleSOAP","python-debianbts>=2.6.1"],
           trac=["offtrac"],
           bugzilla=["python-bugzilla"],
+          gmail=["google-api-python-client", "oauth2client<4.0.0"],
       ),
       tests_require=[
           "Mock",
@@ -57,6 +58,7 @@ setup(name='bugwarrior',
           "bugwarrior[megaplan]",
           "bugwarrior[activecollab]",
           "bugwarrior[bts]",
+          "bugwarrior[gmail]",
           "bugwarrior[trac]",
           "bugwarrior[bugzilla]",
       ],
@@ -86,5 +88,6 @@ setup(name='bugwarrior',
       gerrit=bugwarrior.services.gerrit:GerritService
       trello=bugwarrior.services.trello:TrelloService
       youtrack=bugwarrior.services.youtrack:YoutrackService
+      gmail=bugwarrior.services.gmail:GmailService
       """,
       )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -36,3 +36,6 @@ class TestData(ConfigTest):
 
         self.assertEqual(self.data.get('key'), 'value')
         self.assert0600()
+
+    def test_path_attribute(self):
+        self.assertEqual(self.data.path, self.lists_path)

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -1,0 +1,131 @@
+import mock
+import os.path
+from .base import ServiceTest, AbstractServiceTest
+import bugwarrior.services.gmail as gmail
+
+TEST_THREAD = {
+        "messages": [
+            {
+                "payload": {
+                    "headers": [
+                        {
+                            "name": "From",
+                            "value": "Foo Bar <foobar@example.com>"
+                        },
+                        {
+                            "name": "Subject",
+                            "value": "Regarding Bugwarrior"
+                        },
+                        {
+                            "name": "To",
+                            "value": "ct@example.com"
+                        }
+                    ],
+                    "parts": [
+                        {
+                        }
+                    ]
+                },
+                "snippet": "Bugwarrior is great",
+                "threadId": "1234",
+                "labelIds": [
+                    "IMPORTANT",
+                    "Label_1",
+                    "Label_43",
+                    "CATEGORY_PERSONAL"
+                ],
+                "id": "9999"
+            }
+        ],
+        "id": "1234"
+    }
+
+TEST_LABELS = [
+        {'id': 'IMPORTANT', 'name': 'IMPORTANT'},
+        {'id': 'CATEGORY_PERSONAL', 'name': 'CATEGORY_PERSONAL'},
+        {'id': 'Label_1', 'name': 'sticky'},
+        {'id': 'Label_43', 'name': 'postit'},
+]
+
+class TestGmailIssue(AbstractServiceTest, ServiceTest):
+    SERVICE_CONFIG = {
+        'gmail.add_tags': 'added',
+        'gmail.login_name': 'test@example.com',
+    }
+
+    def setUp(self):
+        super(TestGmailIssue, self).setUp()
+
+        mock_api = mock.Mock()
+        mock_api().users().labels().list().execute.return_value = {'labels': TEST_LABELS}
+        mock_api().users().threads().list().execute.return_value = {'threads': [{'id': TEST_THREAD['id']}]}
+        mock_api().users().threads().get().execute.return_value = TEST_THREAD
+        gmail.GmailService.build_api = mock_api
+        self.service = self.get_mock_service(gmail.GmailService, section='test_section')
+
+    def test_config_paths(self):
+        credentials_path = os.path.join(
+            self.service.config.data.path,
+            'gmail_credentials_test_example_com.json')
+        self.assertEqual(self.service.credentials_path, credentials_path)
+
+    def test_to_taskwarrior(self):
+        thread = TEST_THREAD
+        issue = self.service.get_issue_for_record(
+                thread,
+                gmail.thread_extras(thread, self.service.get_labels()))
+        expected = {
+            'gmailthreadid': '1234',
+            'gmailsnippet': 'Bugwarrior is great',
+            'gmaillastsender': 'Foo Bar',
+            'tags': set(['sticky', 'postit']),
+            'gmailsubject': 'Regarding Bugwarrior',
+            'gmailurl': 'https://mail.google.com/mail/u/0/#all/1234',
+            'priority': 'M',
+            'gmaillastsenderaddr': 'foobar@example.com'}
+
+        taskwarrior = issue.to_taskwarrior()
+        taskwarrior['tags'] = set(taskwarrior['tags'])
+
+        self.assertEqual(taskwarrior, expected)
+
+    def test_issues(self):
+        issue = next(self.service.issues())
+        expected = {
+            'gmailthreadid': '1234',
+            'gmailsnippet': 'Bugwarrior is great',
+            'gmaillastsender': 'Foo Bar',
+            'description': u'(bw)Is#1234 - Regarding Bugwarrior .. https://mail.google.com/mail/u/0/#all/1234',
+            'priority': 'M',
+            'tags': set(['sticky', 'postit', 'added']),
+            'gmailsubject': 'Regarding Bugwarrior',
+            'gmailurl': 'https://mail.google.com/mail/u/0/#all/1234',
+            'gmaillastsenderaddr': 'foobar@example.com'}
+
+        taskwarrior = issue.get_taskwarrior_record()
+        taskwarrior['tags'] = set(taskwarrior['tags'])
+
+        self.assertEqual(taskwarrior, expected)
+
+    def test_last_sender(self):
+        test_thread = {
+                'messages': [
+                    {
+                        'payload':
+                        {
+                            'headers': [
+                                {'name': 'From', 'value': 'Xyz <xyz@example.com'}
+                            ]
+                        }
+                    },
+                    {
+                        'payload':
+                        {
+                            'headers': [
+                                {'name': 'From', 'value': 'Foo Bar <foobar@example.com'}
+                            ]
+                        }
+                    },
+                ]
+            }
+        self.assertEqual(gmail.thread_last_sender(test_thread), ('Foo Bar', 'foobar@example.com'))


### PR DESCRIPTION
Add a service using Google APIs to fetch e-mails as tasks. You
can specify a query using the google search syntex to specify
which e-mails to fetch. Authentication is performed via oauth
and will require the user to set up a production and download
a client_secret file.

The default query is starred threads. No support for pinning and
snoozing yet as I don't use this. I think support for google tasks
could be extended from this easily. 