### PR TITLE
Phab: Add support for tags based on project

### DIFF
--- a/bugwarrior/docs/services/phabricator.rst
+++ b/bugwarrior/docs/services/phabricator.rst
@@ -60,6 +60,34 @@ you can find it out by querying Phabricator Conduit
 the methods which return the needed info are ``user.query``, ``project.query``
 and ``repository.query`` respectively.
 
+Import Projects as Tags
++++++++++++++++++++++++
+
+Phabricator tasks may belong to multiple projects, and differentials (PRs)
+belong to a diffusion repository which may belong to multiple projects; to
+use those projects' slugs (short identifying, human readable strings) as
+tags, you can use the ``phabricator.should_set_tags`` option::
+
+    phabricator.should_set_tags = True
+
+Also, if you would like to control how these tags are created, you can
+specify a template used for converting the project slug into a Taskwarrior
+tag.
+
+For example, to prefix all incoming labels with the string 'phab_' (perhaps
+to differentiate them from any existing tags you might have), you could
+add the following configuration option::
+
+    phabricator.tag_template = phab_{{project_slug}}
+
+In addition to the context variable ``{{project_slug}}``, you also have
+access to all fields on the Taskwarrior task if needed.
+
+.. note::
+
+   See :ref:`field_templates` for more details regarding how templates
+   are processed.
+
 
 Provided UDA Fields
 -------------------

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -1,7 +1,10 @@
 from builtins import str
+import re
+
+from jinja2 import Template
 import six
 
-from bugwarrior.config import aslist
+from bugwarrior.config import aslist, asbool
 from bugwarrior.services import IssueService, Issue
 
 # This comes from PyPI
@@ -42,6 +45,7 @@ class PhabricatorIssue(Issue):
             'project': self.extra['project'],
             'priority': self.origin['default_priority'],
             'annotations': self.extra.get('annotations', []),
+            'tags': self.get_tags(),
 
             self.URL: self.record['uri'],
             self.TYPE: self.extra['type'],
@@ -56,6 +60,27 @@ class PhabricatorIssue(Issue):
             number=self.record['uri'].split('/')[-1],
             cls=self.extra['type'],
         )
+
+    def _normalize_to_tag(self, s):
+        return re.sub(r'[^a-zA-Z0-9]', '_', s)
+
+    def get_tags(self):
+        tags = []
+
+        if not self.origin['should_set_tags']:
+            return tags
+
+        projects = self.extra['projects']
+
+        template = Template(self.origin['tag_template'])
+        for p in projects:
+            context = self.record.copy()
+            context.update({
+                'project_slug': self._normalize_to_tag(p['fields']['slug'])
+            })
+            rendered = template.render(context)
+            tags.append(rendered)
+        return tags
 
 
 class PhabricatorService(IssueService):
@@ -73,10 +98,21 @@ class PhabricatorService(IssueService):
         self.shown_project_phids = (
             self.config.get("project_phids", None, aslist))
 
+        self.should_set_tags = self.config.get(
+            'should_set_tags', default=False, to_type=asbool
+        )
+        self.tag_template = self.config.get(
+            'tag_template', default='{{project_slug}}', to_type=six.text_type
+        )
+
+    def get_service_metadata(self):
+        return {
+            'should_set_tags': self.should_set_tags,
+            'tag_template': self.tag_template,
+        }
+
     def issues(self):
 
-        # TODO -- get a list of these from the api
-        projects = {}
         # If self.shown_user_phids or self.shown_project_phids is set, retrict API calls to user_phids or project_phids
         # to avoid time out with Phabricator installations with huge userbase
         if (self.shown_user_phids is not None) or (self.shown_project_phids is not None):
@@ -97,13 +133,13 @@ class PhabricatorService(IssueService):
 
         log.info("Found %i issues" % len(issues))
 
+        projects = fetch_issue_metadata(self.api, issues)
+
         for phid, issue in issues:
 
-            project = self.target  # a sensible default
-            try:
-                project = projects.get(issue['projectPHIDs'][0], project)
-            except IndexError:
-                pass
+            # TODO fix this now that we have access to proper projects.
+            # It was bugged before
+            project = self.target
 
             this_issue_matches = False
 
@@ -129,6 +165,7 @@ class PhabricatorService(IssueService):
 
             extra = {
                 'project': project,
+                'projects': get_projects_of_issue(issue, projects),
                 'type': 'issue',
                 #'annotations': self.annotations(phid, issue)
             }
@@ -140,13 +177,15 @@ class PhabricatorService(IssueService):
 
         log.info("Found %i differentials" % len(diffs))
 
+        diff_metadata = fetch_diff_metadata(self.api, diffs)
+
         for diff in diffs:
 
+            # TODO fix this now that we have access to proper projects.
+            # It was bugged before
             project = self.target  # a sensible default
-            try:
-                project = projects.get(issue['projectPHIDs'][0], project)
-            except IndexError:
-                pass
+
+            projects_from_repo = diff_metadata['repo_binds'][diff['repositoryPHID']]
 
             this_diff_matches = False
 
@@ -169,6 +208,10 @@ class PhabricatorService(IssueService):
                 except KeyError:
                     pass
 
+                phabricator_projects += projects_from_repo
+
+                # TODO The docs say project PHIDs decide relevancy, but here a
+                # repository PHID is used instead
                 diff_relevant_to = set(phabricator_projects + [diff['repositoryPHID']])
                 if len(diff_relevant_to.intersection(self.shown_user_phids)) > 0:
                     this_diff_matches = True
@@ -178,7 +221,89 @@ class PhabricatorService(IssueService):
 
             extra = {
                 'project': project,
+                'projects': [diff_metadata['projects'][p_phid] for p_phid in projects_from_repo],
                 'type': 'pull_request',
                 #'annotations': self.annotations(phid, issue)
             }
             yield self.get_issue_for_record(diff, extra)
+
+def fetch_issue_metadata(api, issues):
+    """Get projects related to a list of issues from Phab
+
+    :api: Phabricator api object
+    :issues: A list of phab issue tuples with form (issue_phid, issue)
+    :returns: A dictionary with form {project_phid: project_data}
+    """
+    proj_phid_lists = [i[1]['projectPHIDs'] for i in issues]
+    return fetch_all_related_projects(api, proj_phid_lists)
+
+def fetch_diff_metadata(api, diffs):
+    """Get repo and projects related to a list of issues from Phab
+
+    :api: Phabricator api object
+    :diffs: A list of phab diffs
+    :returns: A dictionary with form {
+        'repo_binds': {repo_phid: [project_phid, ...]},
+        'projects': {project_phid: project_data}
+    }
+    """
+    repo_phids = [d['repositoryPHID'] for d in diffs]
+    repo_phids = [p for p in set(repo_phids)] # make unique
+
+    # We could try to also use the diff['auxiliary']['phabricator:projects']
+    # here, which the diff relevancy filtering code tries to do,
+    # but I haven't seen this information actually be set in any real
+    # calls to the phab conduit API
+
+    repos = api.diffusion.repository.search(
+        constraints={'phids': repo_phids},
+        attachments={'projects': True}
+    )
+
+    repo_proj_phid = {}
+    for r in repos.data:
+        repo_phid = r['phid']
+        att = r.get('attachments', None)
+        if att is None:
+            repo_proj_phid[repo_phid] = None
+            continue
+        proj_att = att.get('projects', None)
+        if proj_att is None:
+            repo_proj_phid[repo_phid] = None
+            continue
+        repo_proj_phid[repo_phid] = proj_att.get('projectPHIDs', None)
+
+    projects = fetch_all_related_projects(api, repo_proj_phid.values())
+
+    return {
+        'repo_binds': repo_proj_phid,
+        'projects': projects
+    }
+
+def fetch_all_related_projects(api, proj_phid_lists):
+    phids = set()
+    for pl in proj_phid_lists:
+        if pl is None:
+            continue
+        for phid in pl:
+            phids.add(phid)
+
+    phids = [p for p in phids] # set to list
+    projs = api.project.search(constraints={'phids': phids})
+
+    resdict = {}
+    for p in projs.data:
+        resdict[p['phid']] = p
+    return resdict
+
+def get_projects_of_issue(issue, projects):
+    """Get projects related to an issue from a dict of Phab projects
+
+    :issue: Issue which we want to get related projects of
+    :returns: A list of related projects
+    """
+    proj_phids = issue.get('projectPHIDs', None)
+    if proj_phids is None:
+        return []
+
+    return [projects[phid] for phid in proj_phids]


### PR DESCRIPTION
I used the GitHub service's code as reference for implementing this, assuming that it would be the most up to date one. Give me a ping if there's anything I should change.

You can see that I added some `TODO`s. It might look like I've removed functionality where those are located, but I've just removed code that was buggy or doing nothing. Access to the projects that my code is now giving would make it possible to implement those things without much trouble, however.