### PR TITLE
Fix common service config. options: default_priority + add_tags

### DIFF
--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -85,15 +85,15 @@ class IssueService(object):
             self.shorten = asbool(main_config.get(self.main_section, 'shorten'))
 
         self.add_tags = []
-        if 'add_tags' in self.config:
-            for raw_option in self.config.get('add_tags').split(','):
+        if main_config.has_option(target, 'add_tags'):
+            for raw_option in main_config.get(target, 'add_tags').split(','):
                 option = raw_option.strip(' +;')
                 if option:
                     self.add_tags.append(option)
 
         self.default_priority = 'M'
-        if 'default_priority' in self.config:
-            self.default_priority = self.config.get('default_priority')
+        if main_config.has_option(target, 'default_priority'):
+            self.default_priority = main_config.get(target, 'default_priority')
 
         log.info("Working on [%s]", self.target)
 

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -49,7 +49,7 @@ TEST_LABELS = [
 
 class TestGmailIssue(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
-        'gmail.add_tags': 'added',
+        'add_tags': 'added',
         'gmail.login_name': 'test@example.com',
     }
 


### PR DESCRIPTION
The "default_priority" and "add_tags" common service configuration options were not working because
the "if 'option' in self.config:" instructions in lines [88](https://github.com/ralphbean/bugwarrior/blob/develop/bugwarrior/services/__init__.py#L88) and [95](https://github.com/ralphbean/bugwarrior/blob/develop/bugwarrior/services/__init__.py#L95) of `bugwarrior/services/__init__.py` were always returning False. This occurred because these options were being fetched from a `ServiceConfig` object, which requires that these options are given in the "service.option" format (e.g. `github.add_tags`).

Consequently, using the "default_priority" and "add_tags" options without the service prefix (as described in the Bugwarrior documentation), resulted in `IssueService.add_tags` being set to an empty list and `IssueService.default_priority` being set to the default 'M' regardless of what was specified in the configuration.

In the proposed fix these options are now accessed directly from the `BugwarriorConfigParser` object (variable `main_config` in the constructor of `IssueService`), bypassing the `ServiceConfig` object.

If the future of Bugwarrior is to use the "service.option" format for the "default_priority" and "add_tags" service options, then please disregard this pull request and please update the documentation and configuration examples accordingly (if this is the case I won't mind helping out).

I also updated the Gmail test which assumed the "service.option" format for the common "default_priority" and "add_tags" service options.