### PR TITLE
Gmail oauth flow shouldn't attempt to parse the command line.

### DIFF
--- a/bugwarrior/services/gmail.py
+++ b/bugwarrior/services/gmail.py
@@ -128,7 +128,7 @@ class GmailService(IssueService):
                 log.info("No valid login. Starting OAUTH flow.")
                 flow = oauth2client.client.flow_from_clientsecrets(self.client_secret_path, self.SCOPES)
                 flow.user_agent = self.APPLICATION_NAME
-                flags = oauth2client.tools.argparser.parse_args()
+                flags = oauth2client.tools.argparser.parse_args([])
                 credentials = oauth2client.tools.run_flow(flow, store, flags)
                 log.info('Storing credentials to %r', self.credentials_path)
             return credentials


### PR DESCRIPTION
If any command line arguments are passed to bugwarrior, gmail will try
to parse them and fail. It's not possible pass arguments to Oauth this
way anyway (because bugwarrior would reject the unrecognised command
line arguments), so we shouldn't try to do it. (I see no reason to pass
flags to OAuth here, if needed we'd have to find another way.)

Should resolve issue #488.