### PR TITLE
services/__init__: Refactor handling of defaults

### DIFF
--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -31,6 +31,13 @@ def aslist(value):
     return [item.strip() for item in value.strip().split(',')]
 
 
+def asint(value):
+    """ Cast config values to int, or None for empty strings."""
+    if value == '':
+        return None
+    return int(value)
+
+
 def get_keyring():
     """ Try to import and return optional keyring dependency. """
     try:

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -16,7 +16,7 @@ import six
 
 from taskw.task import Task
 
-from bugwarrior.config import asbool, die, get_service_password, ServiceConfig
+from bugwarrior.config import asbool, asint, die, get_service_password, ServiceConfig
 from bugwarrior.db import MARKUP, URLShortener
 
 import logging
@@ -53,13 +53,6 @@ class IssueService(object):
         self.main_section = main_section
         self.main_config = main_config
         self.target = target
-
-        # Our configuration allows integers to also be 'None'. For example, for
-        # unlimited annotation length. Our private 'asint' function respects this.
-        def asint(x):
-            if x == '':
-                return None
-            return int(x)
 
         self.desc_len = self._get_config_or_default('description_length', 35, asint);
         self.anno_len = self._get_config_or_default('annotation_length', 45, asint);

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -60,7 +60,7 @@ class IssueService(object):
         self.annotation_links = self._get_config_or_default('annotation_links', not self.inline_links, asbool)
         self.annotation_comments = self._get_config_or_default('annotation_comments', True, asbool)
         self.shorten = self._get_config_or_default('shorten', False, asbool)
-        self.default_priority = self._get_config_or_default('default_priority','M', lambda x: x)
+        self.default_priority = self._get_config_or_default('default_priority','M')
 
         self.add_tags = []
         if 'add_tags' in self.config:
@@ -72,7 +72,7 @@ class IssueService(object):
         log.info("Working on [%s]", self.target)
 
 
-    def _get_config_or_default(self, key, default, as_type):
+    def _get_config_or_default(self, key, default, as_type=lambda x: x):
         """Return a main config value, or default if it does not exist."""
 
         if self.main_config.has_option(self.main_section, key):


### PR DESCRIPTION
Hi there fabulous maintainers! You've probably seen me bouncing around issues for a while, so I'm hoping to give something back to the main codebase. To help familiarise myself with the code I'm working on making very small and easy changes where I can spot them.

I'm still a relative python newbie, and this is my first pull-request to bugwarrior, so feedback on style and code is very much appreciated. If I've done things in a particularly odd way it's probably because I didn't know there was a better alternative. :)

I noticed that `services/__init__` had a lot of repeated code for handling defaults and configuration. In this change I've refactored that int a separate method, which reduces our line-count and I hope also reduces our complexity.

If these sorts of code cleaning changes are appreciated, then let me know, and I can send through more.

Apologies this change doesn't come with a test suite. I have tested it locally on my machine, but I was making my changes in my brief lunch-break. I'm happy to add tests on request.
