### PR TITLE
Common configuration options: update documentation + complete validation

### DIFF
--- a/bugwarrior/docs/common_configuration.rst
+++ b/bugwarrior/docs/common_configuration.rst
@@ -68,6 +68,9 @@ service example:
   tags by defining one of your tags following the example set in
   `Field Templates`_.
 
+These configuration options should be prefixed with the service name, e.g.
+`github.add_tags`.
+
 .. _field_templates:
 
 Field Templates

--- a/bugwarrior/docs/configuration.rst
+++ b/bugwarrior/docs/configuration.rst
@@ -84,8 +84,8 @@ Example Configuration
     # or not."
     [my_github]
     service = github
-    default_priority = H
-    add_tags = open_source
+    github.default_priority = H
+    github.add_tags = open_source
 
     # This specifies that we should pull issues from repositories belonging
     # to the 'ralphbean' github account.  See the note below about
@@ -120,10 +120,10 @@ Example Configuration
     trac.username = ralph
     trac.password = OMG_LULZ
 
-    only_if_assigned = ralph
-    also_unassigned = True
-    default_priority = H
-    add_tags = work
+    trac.only_if_assigned = ralph
+    trac.also_unassigned = True
+    trac.default_priority = H
+    trac.add_tags = work
 
     # Here's an example of a megaplan target.
     [my_megaplan]
@@ -150,7 +150,7 @@ Example Configuration
     # 4 and 5(the default). You can find your particular version in the footer at
     # the dashboard.
     jira.version = 5
-    add_tags = enterprisey work
+    jira.add_tags = enterprisey work
 
     # Here's an example of a phabricator target
     [my_phabricator]
@@ -173,14 +173,14 @@ Example Configuration
     redmine.key = c0c4c014cafebabe
     redmine.user_id = 7
     redmine.project_name = redmine
-    add_tags = chiliproject
+    redmine.add_tags = chiliproject
 
     [activecollab]
     service = activecollab
     activecollab.url = https://ac.example.org/api.php
     activecollab.key = your-api-key
     activecollab.user_id = 15
-    add_tags = php
+    activecollab.add_tags = php
 
     [activecollab2]
     service = activecollab2

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -184,6 +184,12 @@ class IssueService(object):
         if service_config.has_option(target, 'also_unassigned'):
             die("[%s] has an 'also_unassigned' option.  Should be "
                 "'%s.also_unassigned'." % (target, cls.CONFIG_PREFIX))
+        if service_config.has_option(target, 'default_priority'):
+            die("[%s] has a 'default_priority' option.  Should be "
+                "'%s.default_priority'." % (target, cls.CONFIG_PREFIX))
+        if service_config.has_option(target, 'add_tags'):
+            die("[%s] has an 'add_tags' option.  Should be "
+                "'%s.add_tags'." % (target, cls.CONFIG_PREFIX))
 
     def include(self, issue):
         """ Return true if the issue in question should be included """


### PR DESCRIPTION
Update documentation for common service configuration options, namely the new requirement of prefixing these options with the service name.

Also add validation for `default_priority` and `add_tags` options (previously only done for `only_if_assigned` and `also_unassigned`).