### PR TITLE
Use aslist everywhere when parsing list config options.

### DIFF
--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -158,8 +158,8 @@ def validate_config(config, main_section):
     if not config.has_option(main_section, 'targets'):
         die("No targets= item in [%s] found." % main_section)
 
-    targets = config.get(main_section, 'targets')
-    targets = [t for t in [t.strip() for t in targets.split(",")] if len(t)]
+    targets = aslist(config.get(main_section, 'targets'))
+    targets = [t for t in targets if len(t)]
 
     if not targets:
         die("Empty targets= item in [%s]." % main_section)

--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -16,7 +16,7 @@ import six
 from taskw import TaskWarriorShellout
 from taskw.exceptions import TaskwarriorError
 
-from bugwarrior.config import asbool, get_taskrc_path
+from bugwarrior.config import asbool, get_taskrc_path, aslist
 from bugwarrior.notifications import send_notification
 
 import logging
@@ -265,9 +265,7 @@ def merge_left(field, local_task, remote_issue, hamming=False):
 
 def run_hooks(conf, name):
     if conf.has_option('hooks', name):
-        pre_import = [
-            t.strip() for t in conf.get('hooks', name).split(',')
-        ]
+        pre_import = aslist(conf.get('hooks', name))
         if pre_import is not None:
             for hook in pre_import:
                 exit_code = subprocess.call(hook, shell=True)
@@ -286,7 +284,7 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
         except (NoSectionError, NoOptionError):
             return default
 
-    targets = [t.strip() for t in conf.get(main_section, 'targets').split(',')]
+    targets = aslist(conf.get(main_section, 'targets'))
     services = set([conf.get(target, 'service') for target in targets])
     key_list = build_key_list(services)
     uda_list = build_uda_config_overrides(services)
@@ -300,7 +298,7 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
 
     static_fields = ['priority']
     if conf.has_option(main_section, 'static_fields'):
-        static_fields = conf.get(main_section, 'static_fields').split(',')
+        static_fields = aslist(conf.get(main_section, 'static_fields'))
 
     # Before running CRUD operations, call the pre_import hook(s).
     run_hooks(conf, 'pre_import')
@@ -462,7 +460,7 @@ def build_key_list(targets):
 
 
 def get_defined_udas_as_strings(conf, main_section):
-    targets = [t.strip() for t in conf.get(main_section, 'targets').split(',')]
+    targets = aslist(conf.get(main_section, 'targets'))
     services = set([conf.get(target, 'service') for target in targets])
     uda_list = build_uda_config_overrides(services)
 

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -16,7 +16,7 @@ import six
 
 from taskw.task import Task
 
-from bugwarrior.config import asbool, asint, die, get_service_password, ServiceConfig
+from bugwarrior.config import asbool, asint, aslist, die, get_service_password, ServiceConfig
 from bugwarrior.db import MARKUP, URLShortener
 
 import logging
@@ -64,7 +64,7 @@ class IssueService(object):
 
         self.add_tags = []
         if 'add_tags' in self.config:
-            for raw_option in self.config.get('add_tags').split(','):
+            for raw_option in aslist(self.config.get('add_tags')):
                 option = raw_option.strip(' +;')
                 if option:
                     self.add_tags.append(option)
@@ -519,7 +519,7 @@ def aggregate_issues(conf, main_section, debug):
     log.info("Starting to aggregate remote issues.")
 
     # Create and call service objects for every target in the config
-    targets = [t.strip() for t in conf.get(main_section, 'targets').split(',')]
+    targets = aslist(conf.get(main_section, 'targets'))
 
     queue = multiprocessing.Queue()
 

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -5,7 +5,7 @@ import pytz
 import datetime
 import six
 
-from bugwarrior.config import die, asbool
+from bugwarrior.config import die, asbool, aslist
 from bugwarrior.services import IssueService, Issue
 
 import logging
@@ -126,8 +126,7 @@ class BugzillaService(IssueService):
         self.query_url = self.config.get('query_url', default=None)
         self.include_needinfos = self.config.get(
             'include_needinfos', False, to_type=lambda x: x == "True")
-        self.open_statuses = self.config.get(
-            'open_statuses', _open_statuses, to_type=lambda x: x.split(','))
+        self.open_statuses = self.config.get('open_statuses', _open_statuses, to_type=aslist)
         log.debug(" filtering on statuses: %r", self.open_statuses)
 
         # So more modern bugzilla's require that we specify

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -58,6 +58,7 @@ class TestSynchronize(ConfigTest):
         config = ConfigParser.RawConfigParser()
         config.add_section('general')
         config.set('general', 'targets', 'my_service')
+        config.set('general', 'static_fields', 'project, priority')
         config.add_section('my_service')
         config.set('my_service', 'service', 'github')
 
@@ -66,6 +67,7 @@ class TestSynchronize(ConfigTest):
 
         issue = {
             'description': 'Blah blah blah. ☃',
+            'project': 'sample_project',
             'githubtype': 'issue',
             'githuburl': 'https://example.com',
             'priority': 'M',
@@ -78,17 +80,21 @@ class TestSynchronize(ConfigTest):
             self.assertEqual(get_tasks(tw), {
                 'completed': [],
                 'pending': [{
+                    u'project': u'sample_project',
                     u'priority': u'M',
                     u'status': u'pending',
                     u'description': u'Blah blah blah. ☃',
                     u'githuburl': u'https://example.com',
                     u'githubtype': u'issue',
                     u'id': 1,
-                    u'urgency': 3.9,
+                    u'urgency': 4.9,
                 }]})
 
         # TEST CHANGED ISSUE.
         issue['description'] = 'Yada yada yada.'
+
+        # Change static field
+        issue['project'] = 'other_project'
 
         db.synchronize(iter((issue,)), config, 'general')
 
@@ -96,12 +102,13 @@ class TestSynchronize(ConfigTest):
             'completed': [],
             'pending': [{
                 u'priority': u'M',
+                u'project': u'sample_project',
                 u'status': u'pending',
                 u'description': u'Yada yada yada.',
                 u'githuburl': u'https://example.com',
                 u'githubtype': u'issue',
                 u'id': 1,
-                u'urgency': 3.9,
+                u'urgency': 4.9,
             }]})
 
         # TEST CLOSED ISSUE.
@@ -117,13 +124,14 @@ class TestSynchronize(ConfigTest):
 
         self.assertEqual(tasks, {
             'completed': [{
+                u'project': u'sample_project',
                 u'description': u'Yada yada yada.',
                 u'githubtype': u'issue',
                 u'githuburl': u'https://example.com',
                 u'id': 0,
                 u'priority': u'M',
                 u'status': u'completed',
-                u'urgency': 3.9,
+                u'urgency': 4.9,
             }],
              'pending': []})
 


### PR DESCRIPTION
Code to split config options on commas was duplicated in a number of
places, not all of which remembered to strip leading and trailing
whitespace.
Resolves issue #490.