### PR TITLE
Globally exclude __pycache__ and py[co] from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,5 @@ include LICENSE.txt
 recursive-include docs *
 recursive-include bugwarrior/docs *.rst
 recursive-include tests *
+global-exclude __pycache__
+global-exclude *.py[co]


### PR DESCRIPTION
The current (1.5.1) source distribution contains compiled python files/artifacts in the tests/ directory.

This change excludes them globally from source distributions.