### PR TITLE
add fallback way for annotation on gerrit service

### DIFF
--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -135,7 +135,12 @@ class GerritService(IssueService, ServiceClient):
     def annotations(self, change):
         entries = []
         for item in change['messages']:
-            username = item['author']['username']
+            for key in ['name', 'username', 'email']:
+                if key in item['author']:
+                    username = item['author'][key]
+                    break
+            else:
+                username = item['author']['_account_id']
             # Gerrit messages are really messy
             message = item['message']\
                 .lstrip('Patch Set ')\


### PR DESCRIPTION
The account information [1] and [2] on gerrit has changed over time. The
change add a fallback way when all optional fields are not set to use
the non-optional fields `_account_id`.

Additionally I use `[author][name]` as default, because `[author][username]` is more a information for authentication systems.

[1]: https://gerrit-documentation.storage.googleapis.com/Documentation/2.9/rest-api-accounts.html#account-info
[2]: https://gerrit-documentation.storage.googleapis.com/Documentation/2.14/rest-api-accounts.html#account-info

Signed-off-by: Silvio Fricke <silvio.fricke@gmail.com>