### PR TITLE
gitlab: filter repositories by regex

### DIFF
--- a/bugwarrior/docs/services/gitlab.rst
+++ b/bugwarrior/docs/services/gitlab.rst
@@ -60,6 +60,33 @@ In this example, ``noisy/repository`` is the repository you would
        gitlab.login = foo
        gitlab.include_repos = foo/bar
 
+Filtering Repositories with Regular Expressions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you don't want to list every single repository you want to include or
+exclude, you can additionally use the options ``gitlab.include_regex`` and
+``gitlab.exclude_regex`` and specify a regular expression (suitable for Python's
+``re`` module).
+No default namespace is applied here, the regular expressions are matched to the
+full repository name with its namespace.
+
+The regular expressions can be used in addition to the lists explained above.
+So if a repository is not included in ``gitlab.include_repos``, it can still be
+included by ``gitlab.include_regex``, and vice versa; and likewise for
+``gitlab.exclude_repos`` and ``gitlab.exclude_regex``.
+
+.. note::
+   If a repository matches both the inclusion and the exclusion options, the
+   exclusion takes precedence.
+
+For example, you want to include only the repositories ``foo/node`` and
+``bar/node`` as well as all repositories in the namespace ``foo`` starting with
+``ep_``, but not ``foo/ep_example``::
+
+    gitlab.include_repos = foo/node, bar/node
+    gitlab.include_regex = foo/ep_.*
+    gitlab.exclude_repos = foo/ep_example
+
 Import Labels as Tags
 +++++++++++++++++++++
 


### PR DESCRIPTION
This introduces the service options `gitlab.include_regex` and `gitlab.exclude_regex`, which can be used in addition to the existing lists in `gitlab.include_repos` and `gitlab.exclude_repos`.

For my use case: I would like to import all issues of the repos in my own namespace; I feel responsible of those even when I'm not assigned. Also I want the issues that are assigned to me in organization repos (I don't care about the rest, someone else can grab them :P)

So basically I want two different services, one with `gitlab.only_if_assigned` seti to my username, matching only the organization repos, and one without that option matching my own repos. However, the GitLab service (or even the API? I'm not sure) lists all accessible repos, even in organizations. So I would have to maintain an exclude list of organization repos in the one service definition, and a list of my own repos in the other service definition. Without regexes, listing them all and keeping the lists in sync with reality seems like a tedious nightmare.