### PR TITLE
Modify drop static field logic to prevent KeyError

### DIFF
--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -346,7 +346,8 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
             # Drop static fields from the upstream issue.  We don't want to
             # overwrite local changes to fields we declare static.
             for field in static_fields:
-                del issue_dict[field]
+                if field in issue_dict:
+                    del issue_dict[field]
 
             # Merge annotations & tags from online into our task object
             if merge_annotations:


### PR DESCRIPTION
A KeyError is thrown when I have a field in the static_fields config that is not implemented in a specific service. Rather than have the KeyError get thrown, I figured it makes sense to add a check to confirm whether or not the field even exists in the issue.
