### PR TITLE
TypeError: not enough arguments for format string

### DIFF
--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -245,7 +245,7 @@ class RedMineService(IssueService):
     def get_keyring_service(service_config):
         url = service_config.get('url')
         login = service_config.get('login')
-        return "redmine://%s@%s/%s" % (login, url)
+        return "redmine://%s@%s/" % (login, url)
 
     @classmethod
     def validate_config(cls, service_config, target):


### PR DESCRIPTION
python is complaining about not enough arguments.

I couldn't test because of retro-incompatibility with my Redmine (3.2.0.stable.15005)
I got NameError: name 'DESCRIPTION' is not defined
