### PR TITLE
Preserve PERL5LIB environment when calling out to taskw

### DIFF
--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -245,6 +245,11 @@ def get_data_path(config, main_section):
     if taskdata:
         env['TASKDATA'] = taskdata
 
+    # Let's not break TaskWarrior's Kusarigama
+    perl5lib = os.getenv('PERL5LIB')
+    if perl5lib:
+        env['PERL5LIB'] = perl5lib
+
     tw_show = subprocess.Popen(
         ('task', '_show'), stdout=subprocess.PIPE, env=env)
     data_location = subprocess.check_output(


### PR DESCRIPTION
When we call out to TaskWarrior, we provide a very restricted
environment. However TaskWarrior may have hooks installed which rely
upon certain environment variables to be set.

In particular, any hooks written in Perl, or loaded using the
Taskwarrior::Kusarigama hook framework, will depend upon the `PERL5LIB`
environment variable being set.

This change passes through the `PERL5LIB` environment variable if it
exists. Since neither BugWarrior nor the TaskWarrior core is written in
Perl, this is essentially a no-op on systems that aren't using Perl
hooks.

There's also potentially scope to discuss what environment cleaning
should happen when running TaskWarrior (possibly with `.bugwarriorrc`
config settings), but this change fixes the conflict that currently
exists between BugWarrior and Kusarigama (which I both use heavily).