### PR TITLE
Preserve existing environment variables when calling task

### DIFF
--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -240,11 +240,6 @@ def get_data_path(config, main_section):
     env = dict(os.environ)
     env['TASKRC'] = taskrc
 
-    # Prune the TASKDATA variable if it's completely empty, since otherwise
-    # taskwarrior tries to open the empty-string directory, which fails.
-    if not env.get('TASKDATA',''):
-        del env['TASKDATA']
-
     tw_show = subprocess.Popen(
         ('task', '_show'), stdout=subprocess.PIPE, env=env)
     data_location = subprocess.check_output(

--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -236,14 +236,14 @@ def get_data_path(config, main_section):
     # the `_` subcommands properly (`rc:` can't be used for them).
     line_prefix = 'data.location='
 
-    env={
-        'PATH': os.getenv('PATH'),
-        'TASKRC': taskrc,
-    }
-    # If TASKDATA is set but empty, taskwarrior's data.location is empty.
-    taskdata = os.getenv('TASKDATA')
-    if taskdata:
-        env['TASKDATA'] = taskdata
+    # Take a copy of the environment and add our taskrc to it.
+    env = os.environ
+    env['TASKRC'] = taskrc
+
+    # Prune the TASKDATA variable if it's completely empty, since otherwise
+    # taskwarrior tries to open the empty-string directory, which fails.
+    if not env.get('TASKDATA',''):
+        del env['TASKDATA']
 
     tw_show = subprocess.Popen(
         ('task', '_show'), stdout=subprocess.PIPE, env=env)

--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -237,7 +237,7 @@ def get_data_path(config, main_section):
     line_prefix = 'data.location='
 
     # Take a copy of the environment and add our taskrc to it.
-    env = os.environ
+    env = dict(os.environ)
     env['TASKRC'] = taskrc
 
     # Prune the TASKDATA variable if it's completely empty, since otherwise

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -96,7 +96,7 @@ class TestGetDataPath(ConfigTest):
         """
         When TASKDATA is not set, data.location in taskrc should be respected.
         """
-        os.environ['TASKDATA'] = ''
+        self.assertTrue('TASKDATA' not in os.environ)
         self.assertDataPath(self.lists_path)
 
     def test_unassigned(self):
@@ -107,7 +107,7 @@ class TestGetDataPath(ConfigTest):
         with open(self.taskrc, 'w'):
             pass
 
-        os.environ['TASKDATA'] = ''
+        self.assertTrue('TASKDATA' not in os.environ)
 
         self.assertDataPath(os.path.expanduser('~/.task'))
 


### PR DESCRIPTION
This change copies our existing environment and then makes changes to it
before calling `task`, rather than creating an empty environment and
populating it.

This is much friendlier to any hooks the user may have set.

Replaces #531.
Closes #533.