### PR TITLE
Use comma instead of space separated list for [service].add_tags in example configuration

### DIFF
--- a/bugwarrior/docs/configuration.rst
+++ b/bugwarrior/docs/configuration.rst
@@ -150,7 +150,7 @@ Example Configuration
     # 4 and 5(the default). You can find your particular version in the footer at
     # the dashboard.
     jira.version = 5
-    jira.add_tags = enterprisey work
+    jira.add_tags = enterprisey,work
 
     # Here's an example of a phabricator target
     [my_phabricator]


### PR DESCRIPTION
add_tags requires a comma separated list of tags, not a space separated list as currently in the example configuration. This changes the example accordingly.