### PR TITLE
Add phabricator.host option to enable multiple instances

### DIFF
--- a/bugwarrior/docs/services/phabricator.rst
+++ b/bugwarrior/docs/services/phabricator.rst
@@ -60,6 +60,13 @@ you can find it out by querying Phabricator Conduit
 the methods which return the needed info are ``user.query``, ``project.query``
 and ``repository.query`` respectively.
 
+If your ``~/.arcrc`` includes credentials for multiple Phabricator instances,
+it is undefined which one will be used. To make it explicit, you can use::
+
+    phabricator.host = https://YOUR_PHABRICATOR_HOST
+
+Where ``https://YOUR_PHABRICATOR_HOST`` **must match** the corresponding json key
+in ``~/.arcrc``, which may include ``/api/`` besides your hostname.
 
 Provided UDA Fields
 -------------------

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -64,8 +64,14 @@ class PhabricatorService(IssueService):
 
     def __init__(self, *args, **kw):
         super(PhabricatorService, self).__init__(*args, **kw)
-        # These reads in login credentials from ~/.arcrc
-        self.api = phabricator.Phabricator()
+
+        self.host = self.config.get("host", None)
+
+        # These read login credentials from ~/.arcrc
+        if self.host is not None:
+            self.api = phabricator.Phabricator(host=self.host)
+        else:
+            self.api = phabricator.Phabricator()
 
         self.shown_user_phids = (
             self.config.get("user_phids", None, aslist))


### PR DESCRIPTION
Right now behaviour is undefined as the phabricator library uses:
`(defined_hosts.keys())[0]` when the `host` parameter is not passed.
This enables usage of multiple phabricator instances with bugwarrior.