### PR TITLE
Convert Jira time to UTC and strip microseconds (Closes: #450)

### DIFF
--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -6,6 +6,7 @@ import six
 from jinja2 import Template
 from jira.client import JIRA as BaseJIRA
 from requests.cookies import RequestsCookieJar
+from dateutil.tz.tz import tzutc
 
 from bugwarrior.config import asbool, die
 from bugwarrior.services import IssueService, Issue
@@ -123,7 +124,7 @@ class JiraIssue(Issue):
     def get_entry(self):
         created_at = self.record['fields']['created']
         # Convert timestamp to an offset-aware datetime
-        date = self.parse_date(created_at)
+        date = self.parse_date(created_at).astimezone(tzutc()).replace(microsecond=0)
         return date
 
     def get_tags(self):

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 
 import mock
 from dateutil.tz import tzoffset, datetime
+from dateutil.tz.tz import tzutc
 
 from bugwarrior.services.jira import JiraService
 from .base import ServiceTest, AbstractServiceTest
@@ -72,7 +73,7 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
             ),
             'annotations': arbitrary_extra['annotations'],
             'tags': [],
-            'entry': datetime.datetime(2016, 6, 6, 6, 7, 8, 123000, tzinfo=tzoffset(None, -25200)),
+            'entry': datetime.datetime(2016, 6, 6, 13, 7, 8, tzinfo=tzutc()),
             'jirafixversion': '1.2.3',
 
             issue.URL: arbitrary_url,
@@ -96,7 +97,7 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
         expected = {
             'annotations': [],
             'description': '(bw)Is#10 - lkjaldsfjaldf .. two/browse/DONUT-10',
-            'entry': datetime.datetime(2016, 6, 6, 6, 7, 8, 123000, tzinfo=tzoffset(None, -25200)),
+            'entry': datetime.datetime(2016, 6, 6, 13, 7, 8, tzinfo=tzutc()),
             'jiradescription': None,
             'jiraestimate': 1,
             'jirafixversion': '1.2.3',


### PR DESCRIPTION
bugwarrior-pull updates all Jira issues on every run like this:

entry: datetime.datetime(2018, 1, 8, 16, 31, 4, tzinfo=tzutc())
-> datetime.datetime(2018, 1, 8, 17, 31, 4, 855000, tzinfo=tzoffset(None, 3600))

This patch changes timezone of the Jira issue to UTC (as is the default
for taskwarrior) and strips away the microseconds, as they are not
represented in taskwarrior.