### PR TITLE
redmine: add UDA to export .project.name

### DIFF
--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -56,6 +56,7 @@ class RedMineIssue(Issue):
     UPDATED_ON = 'redmineupdatedon'
     DUEDATE = 'redmineduedate'
     ASSIGNED_TO = 'redmineassignedto'
+    PROJECT_NAME = 'redmineprojectname'
 
     UDAS = {
         URL: {
@@ -118,7 +119,10 @@ class RedMineIssue(Issue):
             'type': 'string',
             'label': 'Redmine Assigned To',
         },
-
+        PROJECT_NAME: {
+            'type': 'string',
+            'label': 'Redmine Project',
+        },
     }
     UNIQUE_KEY = (ID, )
 
@@ -170,6 +174,7 @@ class RedMineIssue(Issue):
             self.TRACKER: self.record['tracker']['name'],
             self.STATUS: self.record['status']['name'],
             self.AUTHOR: self.record['author']['name'],
+            self.PROJECT_NAME: self.record['project']['name'],
             self.ASSIGNED_TO: assigned_to,
             self.CATEGORY: category,
             self.START_DATE: start_date,


### PR DESCRIPTION
Since the default filter for some spurious reason does a regexp replace
on the project name, I at least want to export it to use it in my own
`project_template`.

This is only the top-level project, though, as the parent/child
relationship for projects is done outside of the issue object.