### PR TITLE
Use get_password to evaluate API key

### DIFF
--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -224,7 +224,7 @@ class RedMineService(IssueService):
         super(RedMineService, self).__init__(*args, **kw)
 
         self.url = self.config.get('url').rstrip("/")
-        self.key = self.config.get('key')
+        self.key = self.get_password('key')
         self.issue_limit = self.config.get('issue_limit')
 
         login = self.config.get('login')


### PR DESCRIPTION
This allows you to put the API key into @oracle mode so you don't have
to store clear text API keys in your configuration.

This should not have any effect on existing configuration.