### PR TITLE
gitlab: make the gitlabnumber UDA a string (fixes #552)

### DIFF
--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -75,7 +75,7 @@ class GitlabIssue(Issue):
             'label': 'Gitlab Type',
         },
         NUMBER: {
-            'type': 'numeric',
+            'type': 'string',
             'label': 'Gitlab Issue/MR #',
         },
         STATE: {
@@ -168,7 +168,7 @@ class GitlabIssue(Issue):
             self.TITLE: title,
             self.DESCRIPTION: description,
             self.MILESTONE: milestone,
-            self.NUMBER: number,
+            self.NUMBER: str(number),
             self.CREATED_AT: created,
             self.UPDATED_AT: updated,
             self.DUEDATE: duedate,


### PR DESCRIPTION
The gitlabnumber's of todos on gitlab.com have grown beyond the limits of the
numeric type, and that may happen on other instances too.