### PR TITLE
Phabricator: mention Maniphest, how to create .arcrc

### DIFF
--- a/bugwarrior/docs/services/phabricator.rst
+++ b/bugwarrior/docs/services/phabricator.rst
@@ -1,7 +1,7 @@
 Phabricator
 ===========
 
-You can import tasks from your Phabricator instance using
+You can import Maniphest tasks from your Phabricator instance using
 the ``phabricator`` service name.
 
 Additional Requirements
@@ -24,6 +24,9 @@ Here's an example of a Phabricator target::
    Although this may not look like enough information for us
    to gather information from Phabricator,
    but credentials will be gathered from the user's ``~/.arcrc``.
+
+   To set up an ``~/.arcrc``, install arcanist and run ``arc
+   install-certificate``
 
 The above example is the minimum required to import issues from
 Phabricator.  You can also feel free to use any of the


### PR DESCRIPTION
Mozilla doesn't use Maniphest, so I wasted some time setting this up (hoping it would sync revisions needing my review).

It was also hard for me to figure out how to create `~/.arcrc`.