### PR TITLE
Fix default_priority option

### DIFF
--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -60,7 +60,8 @@ class IssueService(object):
         self.annotation_links = self._get_config_or_default('annotation_links', not self.inline_links, asbool)
         self.annotation_comments = self._get_config_or_default('annotation_comments', True, asbool)
         self.shorten = self._get_config_or_default('shorten', False, asbool)
-        self.default_priority = self._get_config_or_default('default_priority','M')
+
+        self.default_priority = self.config.get('default_priority', 'M')
 
         self.add_tags = []
         if 'add_tags' in self.config:

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -188,14 +188,9 @@ class GithubIssue(Issue):
         if body:
             body = body.replace('\r\n', '\n')
 
-        if self.extra['type'] == 'pull_request':
-            priority = 'H'
-        else:
-            priority = self.origin['default_priority']
-
         return {
             'project': self.extra['project'],
-            'priority': priority,
+            'priority': self.origin['default_priority'],
             'annotations': self.extra.get('annotations', []),
             'tags': self.get_tags(),
 

--- a/bugwarrior/services/trello.py
+++ b/bugwarrior/services/trello.py
@@ -58,7 +58,7 @@ class TrelloIssue(Issue):
     def to_taskwarrior(self):
         twdict = {
             'project': self.extra['boardname'],
-            'priority': 'M',
+            'priority': self.origin['default_priority'],
             self.NAME: self.record['name'],
             self.CARDID: self.record['id'],
             self.BOARD: self.extra['boardname'],


### PR DESCRIPTION
This has been broken since 02e9bf615000ed11a92f368b85932a5ba2357819, which incorrectly assumed like, all the other options here, it came from the main section rather than the target section. I left a blank line to show that it's different.

I also removed hard coded priorities in the Trello and GitHub services (the only ones I use so can reasonably test). Overriding like the GitHub service currently does makes it _impossible_ to set any other default priority for pull requests, while it's still possible to have them default to high priority by using a template or another target.