### PR TITLE
[phabricator] Connect to phabricator without Differential

### DIFF
--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -140,11 +140,13 @@ class PhabricatorService(IssueService):
             }
 
             yield self.get_issue_for_record(issue, extra)
+
         try:
-                diffs = self.api.differential.query(status='status-open')
+            diffs = self.api.differential.query(status='status-open')
         except phabricator.APIError as err:
-                log.warn("Could not read reviews: %s" % err)
-                return
+            log.warn("Could not read reviews: %s" % err)
+            return
+
         diffs = list(diffs)
 
         log.info("Found %i differentials" % len(diffs))

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -142,7 +142,7 @@ class PhabricatorService(IssueService):
             yield self.get_issue_for_record(issue, extra)
         try:
                 diffs = self.api.differential.query(status='status-open')
-        except Exception as err:
+        except phabricator.APIError as err:
                 log.warn("Could not read reviews: %s" % err)
                 return
         diffs = list(diffs)

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -140,8 +140,11 @@ class PhabricatorService(IssueService):
             }
 
             yield self.get_issue_for_record(issue, extra)
-
-        diffs = self.api.differential.query(status='status-open')
+        try:
+                diffs = self.api.differential.query(status='status-open')
+        except:
+                log.warn("Could not read reviews")
+                return
         diffs = list(diffs)
 
         log.info("Found %i differentials" % len(diffs))

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -142,8 +142,8 @@ class PhabricatorService(IssueService):
             yield self.get_issue_for_record(issue, extra)
         try:
                 diffs = self.api.differential.query(status='status-open')
-        except:
-                log.warn("Could not read reviews")
+        except Exception as err:
+                log.warn("Could not read reviews: %s" % err)
                 return
         diffs = list(diffs)
 


### PR DESCRIPTION
phabricator could be runned without `Differential` or Review.

```
phabricator.APIError: ERR-CONDUIT-CALL: Method 'differential.query' belongs to application 'Differential', which is not installed.
```

---
A solution is to put this part in a try block
