### PR TITLE
gitlab WIP status is True or False. This does not convert to numerics.

### DIFF
--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -125,7 +125,7 @@ class GitlabIssue(Issue):
         state = self.record['state']
         upvotes = self.record.get('upvotes', 0)
         downvotes = self.record.get('downvotes', 0)
-        work_in_progress = self.record.get('work_in_progress', 0)
+        work_in_progress = int(asbool(self.record.get('work_in_progress', 0)))
         assignee = self.record.get('assignee')
         duedate = self.record.get('due_date')
         weight = self.record.get('weight')

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -54,66 +54,66 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
         'gitlab.login': 'arbitrary_login',
         'gitlab.token': 'arbitrary_token',
     }
-    arbitrary_created = (
-        datetime.datetime.utcnow() - datetime.timedelta(hours=1)
-    ).replace(tzinfo=pytz.UTC, microsecond=0)
-    arbitrary_updated = datetime.datetime.utcnow().replace(
-        tzinfo=pytz.UTC, microsecond=0)
-    arbitrary_duedate = (
-        datetime.datetime.combine(datetime.date.today(),
-                                  datetime.datetime.min.time())
-    ).replace(tzinfo=pytz.UTC)
-    arbitrary_issue = {
-        "id": 42,
-        "iid": 3,
-        "project_id": 8,
-        "title": "Add user settings",
-        "description": "",
-        "labels": [
-            "feature"
-        ],
-        "milestone": {
-            "id": 1,
-            "title": "v1.0",
-            "description": "",
-            "due_date": arbitrary_duedate.date().isoformat(),
-            "state": "closed",
-            "updated_at": "2012-07-04T13:42:48Z",
-            "created_at": "2012-07-04T13:42:48Z"
-        },
-        "assignee": {
-            "id": 2,
-            "username": "jack_smith",
-            "email": "jack@example.com",
-            "name": "Jack Smith",
-            "state": "active",
-            "created_at": "2012-05-23T08:01:01Z"
-        },
-        "author": {
-            "id": 1,
-            "username": "john_smith",
-            "email": "john@example.com",
-            "name": "John Smith",
-            "state": "active",
-            "created_at": "2012-05-23T08:00:58Z"
-        },
-        "state": "opened",
-        "updated_at": arbitrary_updated.isoformat(),
-        "created_at": arbitrary_created.isoformat(),
-        "weight": 3,
-        "work_in_progress": "true",
-    }
-    arbitrary_extra = {
-        'issue_url': 'https://gitlab.example.com/arbitrary_username/project/issues/3',
-        'project': 'project',
-        'namespace': 'arbitrary_namespace',
-        'type': 'issue',
-        'annotations': [],
-    }
 
     def setUp(self):
         super(TestGitlabIssue, self).setUp()
         self.service = self.get_mock_service(GitlabService)
+        self.arbitrary_created = (
+            datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+        ).replace(tzinfo=pytz.UTC, microsecond=0)
+        self.arbitrary_updated = datetime.datetime.utcnow().replace(
+            tzinfo=pytz.UTC, microsecond=0)
+        self.arbitrary_duedate = (
+            datetime.datetime.combine(datetime.date.today(),
+                                      datetime.datetime.min.time())
+        ).replace(tzinfo=pytz.UTC)
+        self.arbitrary_issue = {
+            "id": 42,
+            "iid": 3,
+            "project_id": 8,
+            "title": "Add user settings",
+            "description": "",
+            "labels": [
+                "feature"
+            ],
+            "milestone": {
+                "id": 1,
+                "title": "v1.0",
+                "description": "",
+                "due_date": self.arbitrary_duedate.date().isoformat(),
+                "state": "closed",
+                "updated_at": "2012-07-04T13:42:48Z",
+                "created_at": "2012-07-04T13:42:48Z"
+            },
+            "assignee": {
+                "id": 2,
+                "username": "jack_smith",
+                "email": "jack@example.com",
+                "name": "Jack Smith",
+                "state": "active",
+                "created_at": "2012-05-23T08:01:01Z"
+            },
+            "author": {
+                "id": 1,
+                "username": "john_smith",
+                "email": "john@example.com",
+                "name": "John Smith",
+                "state": "active",
+                "created_at": "2012-05-23T08:00:58Z"
+            },
+            "state": "opened",
+            "updated_at": self.arbitrary_updated.isoformat(),
+            "created_at": self.arbitrary_created.isoformat(),
+            "weight": 3,
+            "work_in_progress": "true"
+        }
+        self.arbitrary_extra = {
+            'issue_url': 'https://gitlab.example.com/arbitrary_username/project/issues/3',
+            'project': 'project',
+            'namespace': 'arbitrary_namespace',
+            'type': 'issue',
+            'annotations': [],
+        }
 
     def test_normalize_label_to_tag(self):
         issue = self.service.get_issue_for_record(
@@ -159,11 +159,10 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
         self.assertEqual(actual_output, expected_output)
 
     def test_work_in_progress(self):
-        arbitrary_issue_2 = self.arbitrary_issue
-        arbitrary_issue_2['work_in_progress'] = 'false'
+        self.arbitrary_issue['work_in_progress'] = 'false'
         self.service.import_labels_as_tags = True
         issue = self.service.get_issue_for_record(
-            arbitrary_issue_2,
+            self.arbitrary_issue,
             self.arbitrary_extra
         )
 

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -101,6 +101,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
         "updated_at": arbitrary_updated.isoformat(),
         "created_at": arbitrary_created.isoformat(),
         "weight": 3,
+        "work_in_progress": "true",
     }
     arbitrary_extra = {
         'issue_url': 'https://gitlab.example.com/arbitrary_username/project/issues/3',
@@ -126,6 +127,43 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
         self.service.import_labels_as_tags = True
         issue = self.service.get_issue_for_record(
             self.arbitrary_issue,
+            self.arbitrary_extra
+        )
+
+        expected_output = {
+            'project': self.arbitrary_extra['project'],
+            'priority': self.service.default_priority,
+            'annotations': [],
+            'tags': [u'feature'],
+            issue.URL: self.arbitrary_extra['issue_url'],
+            issue.REPO: 'project',
+            issue.STATE: self.arbitrary_issue['state'],
+            issue.TYPE: self.arbitrary_extra['type'],
+            issue.TITLE: self.arbitrary_issue['title'],
+            issue.NUMBER: self.arbitrary_issue['iid'],
+            issue.UPDATED_AT: self.arbitrary_updated.replace(microsecond=0),
+            issue.CREATED_AT: self.arbitrary_created.replace(microsecond=0),
+            issue.DUEDATE: self.arbitrary_duedate,
+            issue.DESCRIPTION: self.arbitrary_issue['description'],
+            issue.MILESTONE: self.arbitrary_issue['milestone']['title'],
+            issue.UPVOTES: 0,
+            issue.DOWNVOTES: 0,
+            issue.WORK_IN_PROGRESS: 1,
+            issue.AUTHOR: 'john_smith',
+            issue.ASSIGNEE: 'jack_smith',
+            issue.NAMESPACE: 'arbitrary_namespace',
+            issue.WEIGHT: 3,
+        }
+        actual_output = issue.to_taskwarrior()
+
+        self.assertEqual(actual_output, expected_output)
+
+    def test_work_in_progress(self):
+        arbitrary_issue_2 = self.arbitrary_issue
+        arbitrary_issue_2['work_in_progress'] = 'false'
+        self.service.import_labels_as_tags = True
+        issue = self.service.get_issue_for_record(
+            arbitrary_issue_2,
             self.arbitrary_extra
         )
 
@@ -203,7 +241,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
             'gitlabduedate': self.arbitrary_duedate,
             'gitlabupvotes': 0,
             'gitlaburl': u'example.com/issues/3',
-            'gitlabwip': 0,
+            'gitlabwip': 1,
             'gitlabweight': 3,
             'priority': 'M',
             'project': u'arbitrary_username/project',


### PR DESCRIPTION
I always ran into errors when pulling in gitlab MRs which changed their WIP status. Today I found some time to debug this and it seems to be a type error. The WIP status seems to be either 'False' or 'True' coming from the server, but the UDA is set to numeric. I changed it to string and now my issues drop in without problems. 

As far as I can see, this value is used nowhere else, so this MR shouldn't do any harm.

Oh, btw, I'm using Gitlab 10.8.2. I don't know if they ever changed their API on that, just in case...