### PR TITLE
Redmine: add verify_ssl configuration option

### DIFF
--- a/bugwarrior/docs/services/redmine.rst
+++ b/bugwarrior/docs/services/redmine.rst
@@ -25,6 +25,10 @@ You can also feel free to use any of the configuration options described in
 There are also `redmine.login`/`redmine.password` settings if your
 instance is behind basic auth.
 
+If you want to ignore verifying the SSL certificate, set::
+
+    redmine.verify_ssl = False
+
 Provided UDA Fields
 -------------------
 


### PR DESCRIPTION
Add configuration option `verify_ssl` for redmine service, that allows to ignore verifying the SSL certificate.