### PR TITLE
set allow_no_value=True so that it doesn't break on Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
  - "3.4"
  - "3.5"
  - "3.6"
+ - "3.7"
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install uuid-dev

--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -211,7 +211,7 @@ def get_config_path():
 
 
 def load_config(main_section, interactive=False):
-    config = BugwarriorConfigParser({'log.level': "INFO", 'log.file': None})
+    config = BugwarriorConfigParser({'log.level': "INFO", 'log.file': None}, allow_no_value=True)
     path = get_config_path()
     config.readfp(codecs.open(path, "r", "utf-8",))
     config.interactive = interactive


### PR DESCRIPTION
Resolves the issue where one gets the error "configparser: TypeError: option values must be strings" as in #597.