### PR TITLE
Make include_repos work the way the documentation suggests

### DIFF
--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -4,6 +4,7 @@ standard_library.install_aliases()
 from builtins import map
 from builtins import filter
 
+from urllib import quote_plus
 from configparser import NoOptionError
 import re
 import requests
@@ -433,7 +434,19 @@ class GitlabService(IssueService, ServiceClient):
 
     def issues(self):
         tmpl = '{scheme}://{host}/api/v4/projects'
-        all_repos = self._fetch_paged(tmpl)
+
+        all_repos = []
+        if self.include_repos:
+            for repo in self.include_repos:
+                indiv_tmpl = tmpl + '/' + quote_plus(repo)
+                item = self._fetch(indiv_tmpl)
+                if not item:
+                    break
+
+                all_repos += [ item ]
+        else:
+            all_repos = self._fetch_paged(tmpl)
+
         repos = list(filter(self.filter_repos, all_repos))
 
         repo_map = {}


### PR DESCRIPTION
The [documentation](https://bugwarrior.readthedocs.io/en/latest/services/gitlab.html) suggests the following, but actually seems to pull in all of the available projects on the gitlab server - and on gitlab.com, that's a lot of projects.

`If you happen to be working with a large number of projects, you may want to pull issues from only a subset of your repositories. To do that, you can use the gitlab.include_repos option.`

This change performs individual pulls for the projects listed in `include_repos` instead of paginating through the entire project list.