### PR TITLE
Support ignoring some fields in Phabricator

### DIFF
--- a/bugwarrior/docs/services/phabricator.rst
+++ b/bugwarrior/docs/services/phabricator.rst
@@ -71,6 +71,22 @@ it is undefined which one will be used. To make it explicit, you can use::
 Where ``https://YOUR_PHABRICATOR_HOST`` **must match** the corresponding json key
 in ``~/.arcrc``, which may include ``/api/`` besides your hostname.
 
+Ignoring Some Items
+...................
+
+By default, any Task or Revision relating to any of the given users or projects
+will be included.  This is likely more than you want!  You can ignore some user
+relationships with the following configuration::
+
+    phabricator.ignore_cc = True        # ignore CC field
+    phabricator.ignore_author = True    # ignore Author field
+    phabricator.ignore_owner = True     # ignore Owner field (Tasks only)
+    phabricator.ignore_reviewers = True # ignore Reviewers field (Revisions only)
+
+Note that there is no way to filter by the reviewer's response (for example, to
+exclude Revisions you have already reviewed). Phabricator does not provide the
+necessary information in the Conduit API.
+
 Provided UDA Fields
 -------------------
 

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -93,6 +93,18 @@ class PhabricatorService(IssueService):
         self.shown_project_phids = (
             self.config.get("project_phids", None, aslist))
 
+        self.ignore_cc = self.config.get('ignore_cc', default=False,
+                                          to_type=lambda x: x == "True")
+
+        self.ignore_author = self.config.get('ignore_author', default=False,
+                                             to_type=lambda x: x == "True")
+
+        self.ignore_owner = self.config.get('ignore_owner', default=False,
+                                             to_type=lambda x: x == "True")
+
+        self.ignore_reviewers = self.config.get('ignore_reviewers', default=False,
+                                                to_type=lambda x: x == "True")
+
     def issues(self):
 
         # TODO -- get a list of these from the api
@@ -133,7 +145,13 @@ class PhabricatorService(IssueService):
             if self.shown_user_phids is not None:
                 # Checking whether authorPHID, ccPHIDs, ownerPHID
                 # are intersecting with self.shown_user_phids
-                issue_relevant_to = set(issue['ccPHIDs'] + [issue['ownerPHID'], issue['authorPHID']])
+                issue_relevant_to = set()
+                if not self.ignore_cc:
+                    issue_relevant_to.update(issue['ccPHIDs'])
+                if not self.ignore_owner:
+                    issue_relevant_to.add(issue['ownerPHID'])
+                if not self.ignore_author:
+                    issue_relevant_to.add(issue['authorPHID'])
                 if len(issue_relevant_to.intersection(self.shown_user_phids)) > 0:
                     this_issue_matches = True
 
@@ -179,9 +197,15 @@ class PhabricatorService(IssueService):
                 this_diff_matches = True
 
             if self.shown_user_phids is not None:
-                # Checking whether authorPHID, ccPHIDs, ownerPHID
+                # Checking whether authorPHID, ccPHIDs, reviewers
                 # are intersecting with self.shown_user_phids
-                diff_relevant_to = set(list(diff['reviewers']) + [diff['authorPHID']])
+                diff_relevant_to = set()
+                if not self.ignore_reviewers:
+                    diff_relevant_to.update(list(diff['reviewers']))
+                if not self.ignore_cc:
+                    diff_relevant_to.update(diff['ccs'])
+                if not self.ignore_author:
+                    diff_relevant_to.add(diff['authorPHID'])
                 if len(diff_relevant_to.intersection(self.shown_user_phids)) > 0:
                     this_diff_matches = True
 


### PR DESCRIPTION
In my case, I only want to see Revisions where I'm a reviewer, so this lets me disable everything else.