### PR TITLE
Handle paths absolutes or with envvars for logging

### DIFF
--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -210,12 +210,26 @@ def get_config_path():
     return paths[0]
 
 
+def fix_logging_path(config, main_section):
+    """
+    Expand environment variables and user home (~) in the log.file and return
+    as relative path.
+    """
+    log_file = config.get(main_section, 'log.file')
+    if log_file:
+        log_file = os.path.expanduser(os.path.expandvars(log_file))
+        if os.path.isabs(log_file):
+            log_file = os.path.relpath(log_file)
+    return log_file
+
+
 def load_config(main_section, interactive=False):
     config = BugwarriorConfigParser({'log.level': "INFO", 'log.file': None}, allow_no_value=True)
     path = get_config_path()
     config.readfp(codecs.open(path, "r", "utf-8",))
     config.interactive = interactive
     config.data = BugwarriorData(get_data_path(config, main_section))
+    config.set(main_section, 'log.file', fix_logging_path(config, main_section))
     validate_config(config, main_section)
     return config
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -178,3 +178,48 @@ class TestServiceConfig(TestCase):
             self.service_config.get('somebool', to_type=config.asbool),
             True
         )
+
+
+class TestLoggingPath(TestCase):
+    def setUp(self):
+        self.config = config.BugwarriorConfigParser(allow_no_value=True)
+        self.config.add_section('general')
+        self.config.set('general', 'log.level', 'INFO')
+        self.config.set('general', 'log.file', None)
+        self.dir = os.getcwd()
+        os.chdir(os.path.expanduser('~'))
+
+    def test_log_stdout(self):
+        self.assertIsNone(config.fix_logging_path(self.config, 'general'))
+
+    def test_log_relative_path(self):
+        self.config.set('general', 'log.file', 'bugwarrior.log')
+        self.assertEqual(
+            config.fix_logging_path(self.config, 'general'),
+            'bugwarrior.log',
+        )
+
+    def test_log_absolute_path(self):
+        filename = os.path.join(os.path.expandvars('$HOME'), 'bugwarrior.log')
+        self.config.set('general', 'log.file', filename)
+        self.assertEqual(
+            config.fix_logging_path(self.config, 'general'),
+            'bugwarrior.log',
+        )
+
+    def test_log_userhome(self):
+        self.config.set('general', 'log.file', '~/bugwarrior.log')
+        self.assertEqual(
+            config.fix_logging_path(self.config, 'general'),
+            'bugwarrior.log',
+        )
+
+    def test_log_envvar(self):
+        self.config.set('general', 'log.file', '$HOME/bugwarrior.log')
+        self.assertEqual(
+            config.fix_logging_path(self.config, 'general'),
+            'bugwarrior.log',
+        )
+
+    def tearDown(self):
+        os.chdir(self.dir)


### PR DESCRIPTION
This commit allows the user to define paths for logging that are absolute or relative, or that contain environment variables or the `~` for the user home folder.

Examples:
  1. `/var/log/bugwarrior.log`
  2. `$HOME/var/log/bugwarrior.log`
  3. `~/.local/var/log/bugwarrior.log`
  4. `bugwarrior.log`