### PR TITLE
Fix jira sprint parsing

### DIFF
--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -48,8 +48,9 @@ def _parse_sprint_string(sprint):
         ViewId=1173,state=ACTIVE,name=Sprint 1,startDate=2016-09-06T16:08:07.4
         55Z,endDate=2016-09-23T16:08:00.000Z,completeDate=<null>,sequence=2322]
     """
-    entries = sprint[sprint.index('[')+1:sprint.index(']')].split(',')
-    return dict([entry.split('=') for entry in entries])
+    entries = sprint[sprint.index('[')+1:sprint.index(']')].split('=')
+    fields = sum((entry.rsplit(',', 1) for entry in entries), [])
+    return dict(zip(fields[::2], fields[1::2]))
 
 class JiraIssue(Issue):
     SUMMARY = 'jirasummary'


### PR DESCRIPTION
Jira doesn't escape commas in the value field of the sprint string so it's not safe to  just split on all commas.

In my case, I ran into a sprint with a goal that contained a bunch of commas.

Splitting on the `=` character and then using `rsplit` to only grab the last `,` is maybe a bit safer.