### PR TITLE
Fix tests on py27 due to configparser

### DIFF
--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -1,7 +1,7 @@
 from future import standard_library
 standard_library.install_aliases()
 import codecs
-from configparser import ConfigParser
+from six.moves import configparser
 import os
 import subprocess
 import sys
@@ -254,7 +254,7 @@ def get_data_path(config, main_section):
 
 
 # ConfigParser is not a new-style class, so inherit from object to fix super().
-class BugwarriorConfigParser(ConfigParser, object):
+class BugwarriorConfigParser(configparser.ConfigParser, object):
     def getint(self, section, option):
         """ Accepts both integers and empty values. """
         try:

--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -4,7 +4,7 @@ standard_library.install_aliases()
 from builtins import zip
 from builtins import object
 
-from configparser import NoOptionError, NoSectionError
+from six.moves.configparser import NoOptionError, NoSectionError
 import os
 import re
 import subprocess

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -8,7 +8,7 @@ try:
     from urllib import quote  # Python 2.X
 except ImportError:
     from urllib.parse import quote  # Python 3+
-from configparser import NoOptionError
+from six.moves.configparser import NoOptionError
 import re
 import requests
 import six

--- a/bugwarrior/services/trello.py
+++ b/bugwarrior/services/trello.py
@@ -8,7 +8,7 @@ Trello API documentation available at https://developers.trello.com/
 from __future__ import unicode_literals
 from future import standard_library
 standard_library.install_aliases()
-from configparser import NoOptionError
+from six.moves.configparser import NoOptionError
 
 from jinja2 import Template
 import requests

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -2,7 +2,7 @@ from builtins import next
 from builtins import object
 import mock
 from collections import namedtuple
-import configparser
+from six.moves import configparser
 
 from bugwarrior.services.bz import BugzillaService
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 import os
-import configparser
+from six.moves import configparser
 from unittest import TestCase
 
 import bugwarrior.config as config

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,6 +1,6 @@
 import os
 import json
-import configparser
+from six.moves import configparser
 
 from bugwarrior import data
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-import configparser as ConfigParser
+from six.moves import configparser
 
 import taskw.task
 from bugwarrior import db
@@ -55,7 +55,7 @@ class TestSynchronize(ConfigTest):
 
             return tasks
 
-        config = ConfigParser.RawConfigParser()
+        config = configparser.RawConfigParser()
         config.add_section('general')
         config.set('general', 'targets', 'my_service')
         config.set('general', 'static_fields', 'project, priority')
@@ -137,7 +137,7 @@ class TestSynchronize(ConfigTest):
 
 class TestUDAs(ConfigTest):
     def test_udas(self):
-        config = ConfigParser.RawConfigParser()
+        config = configparser.RawConfigParser()
         config.add_section('general')
         config.set('general', 'targets', 'my_service')
         config.add_section('my_service')

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,7 +1,7 @@
 from builtins import next
 import datetime
 from unittest import TestCase
-from configparser import RawConfigParser
+from six.moves.configparser import RawConfigParser
 
 import pytz
 import responses

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -1,7 +1,7 @@
 from future import standard_library
 standard_library.install_aliases()
 from builtins import next
-import configparser
+from six.moves import configparser
 import datetime
 
 import pytz

--- a/tests/test_trello.py
+++ b/tests/test_trello.py
@@ -3,7 +3,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import next
 
-import configparser
+from six.moves import configparser
 from mock import patch
 import responses
 

--- a/tests/test_youtrak.py
+++ b/tests/test_youtrak.py
@@ -1,7 +1,7 @@
 from future import standard_library
 standard_library.install_aliases()
 from builtins import next
-import configparser
+from six.moves import configparser
 import responses
 
 from bugwarrior.services import ServiceConfig


### PR DESCRIPTION
Uses the portable configparser name from six to avoid failure on py27.