### PR TITLE
Add the ability to exclude Github pull-requests

### DIFF
--- a/bugwarrior/docs/services/github.rst
+++ b/bugwarrior/docs/services/github.rst
@@ -103,6 +103,14 @@ by adding the following configuration option::
 
     github.filter_pull_requests = True
 
+Exclude Pull Requests
+++++++++++++++++++++
+
+If you want bugwarrior to not track pull requests you can disable it altogether
+and ensure bugwarrior only tracks issues.
+
+    github.exclude_pull_requests = True
+
 Get involved issues
 +++++++++++++++++++
 

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -291,6 +291,9 @@ class GithubService(IssueService):
         self.filter_pull_requests = self.config.get(
             'filter_pull_requests', default=False, to_type=asbool
         )
+        self.exclude_pull_requests = self.config.get(
+            'exclude_pull_requests', default=False, to_type=asbool
+        )
         self.involved_issues = self.config.get(
             'involved_issues', default=False, to_type=asbool
         )
@@ -421,8 +424,11 @@ class GithubService(IssueService):
         return True
 
     def include(self, issue):
-        if 'pull_request' in issue[1] and not self.filter_pull_requests:
-            return True
+        if 'pull_request' in issue[1]:
+            if self.exclude_pull_requests:
+                return False
+            if not self.filter_pull_requests:
+                return True
         return super(GithubService, self).include(issue)
 
     def issues(self):


### PR DESCRIPTION
In my workflow I only track issues and not pull requests. Pull requests usually refer to issues that I resolve so tracking both results in duplicate tasks.