### PR TITLE
jira: split priority.name for lookup

### DIFF
--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -223,7 +223,9 @@ class JiraIssue(Issue):
             value = value['name']
         except (TypeError, ):
             value = str(value)
-        return self.PRIORITY_MAP.get(value, self.origin['default_priority'])
+        # priority.name format: "1 - Critical"
+        map_key = value.strip().split()[-1]
+        return self.PRIORITY_MAP.get(map_key, self.origin['default_priority'])
 
     def get_default_description(self):
         return self.build_default_description(


### PR DESCRIPTION
The priority.name field returns something more like "1 - Critical". Split the string to get the PRIORITY_MAP key.