### PR TITLE
GitHub: Only query for user repos if an include_repos list is not specified

### DIFF
--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -432,14 +432,19 @@ class GithubService(IssueService):
             issues.update(self.get_query(self.query))
 
         if self.config.get('include_user_repos', True, asbool):
-            all_repos = self.client.get_repos(self.username)
-            assert(type(all_repos) == list)
-            repos = filter(self.filter_repos, all_repos)
+            # Only query for all repos if an explicit
+            # include_repos list is not specified.
+            if self.include_repos:
+                repos = self.include_repos
+            else:
+                all_repos = self.client.get_repos(self.username)
+                repos = filter(self.filter_repos, all_repos)
+                repos = [repo['name'] for repo in repos]
 
             for repo in repos:
                 issues.update(
                     self.get_owned_repo_issues(
-                        self.username + "/" + repo['name'])
+                        self.username + "/" + repo)
                 )
         if self.config.get('include_user_issues', True, asbool):
             issues.update(


### PR DESCRIPTION
I think this is the desired behavior.  If you have a config with only one
`include_repos` repo set, bugwarrior shouldn't bother querying for and paging
through all the repos of the user.  We can short-circuit that and assume the
repo exists.