### PR TITLE
Do not abort with ValueError when default_permission is blank

### DIFF
--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -379,6 +379,9 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
     log.info("Adding %i tasks", len(issue_updates['new']))
     for issue in issue_updates['new']:
         log.info(u"Adding task %s%s", issue['description'], notreally)
+        # Blank priority should mean *no* priority
+        if issue['priority'] == u'':
+            issue['priority'] = None
         if dry_run:
             continue
         if notify:


### PR DESCRIPTION
I use the redmine service. I have

  redmine.default_priority=

in my bugwarriorrc file, which is intended to mean "do not set an explicit priority" on tickets synced from Redmine.

I needed this change to avoid bugwarrior aborting with

  ValueError: '' is not a valid choice; choices: [None, 'H', 'M', 'L']

because the empty string needs to be mapped to None. I can't put None in the bugwarriorrc file, because it gets interpreted as a string.