### PR TITLE
jira: partition the priority list into LMH for tw

### DIFF
--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -14,6 +14,12 @@ class FakeJiraClient(object):
     def __init__(self, arbitrary_record):
         self.arbitrary_record = arbitrary_record
 
+    def priorities(self):
+        names = ["Low", "Medium", "High", "Critical"]
+        return [
+            dict(id=str(i), name=f"{i} - {name}")
+            for i, name in enumerate(names)]
+
     def search_issues(self, *args, **kwargs):
         Case = namedtuple('Case', ['raw', 'key'])
         return [Case(self.arbitrary_record, self.arbitrary_record['key'])]
@@ -121,7 +127,7 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
             record_with_goal, arbitrary_extra
         )
 
-        JIRA_PRIORITIES = "1234"
+        JIRA_PRIORITIES = [p.id for p in self.jira.priorities()]
         TASK_PRIORITIES = "LMH"
         issue.PRIORITY_MAP = {
             p: TASK_PRIORITIES[int(len(TASK_PRIORITIES)*i/len(JIRA_PRIORITIES))]

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -127,9 +127,10 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
 
         issue = self.service.get_issue_for_record(
             record_with_goal, arbitrary_extra
+
         )
 
-        JIRA_PRIORITIES = [p.id for p in self.jira.priorities()]
+        JIRA_PRIORITIES = [p.id for p in self.service.jira.priorities()]
         TASK_PRIORITIES = "LMH"
         issue.PRIORITY_MAP = {
             p: TASK_PRIORITIES[int(len(TASK_PRIORITIES)*i/len(JIRA_PRIORITIES))]

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -43,7 +43,7 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
 
     arbitrary_record = {
         'fields': {
-            'priority': '4',
+            'priority': '2',
             'summary': arbitrary_summary,
             'timeestimate': arbitrary_estimation,
             'created': '2016-06-06T06:07:08.123-0700',

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -124,7 +124,7 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
         JIRA_PRIORITIES = "1234"
         TASK_PRIORITIES = "LMH"
         issue.PRIORITY_MAP = {
-            p: TASK_PRIORITIES[int(len(TASK_PRIORITIES*i/len(JIRA_PRIORITIES))]
+            p: TASK_PRIORITIES[int(len(TASK_PRIORITIES*i/len(JIRA_PRIORITIES)))]
             for i, p in enumerate(JIRA_PRIORITIES)
         }
 

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -15,9 +15,11 @@ class FakeJiraClient(object):
         self.arbitrary_record = arbitrary_record
 
     def priorities(self):
+
+        Priority = namedtuple('Priority', ['id', 'name'])
         names = ["Low", "Medium", "High", "Critical"]
         return [
-            dict(id=str(i), name=f"{i} - {name}")
+            Priority(id=str(i), name=f"{i} - {name}")
             for i, name in enumerate(names)]
 
     def search_issues(self, *args, **kwargs):

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -124,7 +124,7 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
         JIRA_PRIORITIES = "1234"
         TASK_PRIORITIES = "LMH"
         issue.PRIORITY_MAP = {
-            p: TASK_PRIORITIES[int(len(TASK_PRIORITIES*i/len(JIRA_PRIORITIES)))]
+            p: TASK_PRIORITIES[int(len(TASK_PRIORITIES)*i/len(JIRA_PRIORITIES))]
             for i, p in enumerate(JIRA_PRIORITIES)
         }
 

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -35,7 +35,7 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
 
     arbitrary_record = {
         'fields': {
-            'priority': 'Blocker',
+            'priority': '4',
             'summary': arbitrary_summary,
             'timeestimate': arbitrary_estimation,
             'created': '2016-06-06T06:07:08.123-0700',

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -121,6 +121,13 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
             record_with_goal, arbitrary_extra
         )
 
+        JIRA_PRIORITIES = "1234"
+        TASK_PRIORITIES = "LMH"
+        issue.PRIORITY_MAP = {
+            TASK_PRIORITIES[int(len(TASK_PRIORITIES*i/len(JIRA_PRIORITIES))]
+            for i, p in enumerate(JIRA_PRIORITIES)
+        }
+
         expected_output = {
             'project': self.arbitrary_project,
             'priority': (

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -124,7 +124,7 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
         JIRA_PRIORITIES = "1234"
         TASK_PRIORITIES = "LMH"
         issue.PRIORITY_MAP = {
-            TASK_PRIORITIES[int(len(TASK_PRIORITIES*i/len(JIRA_PRIORITIES))]
+            p: TASK_PRIORITIES[int(len(TASK_PRIORITIES*i/len(JIRA_PRIORITIES))]
             for i, p in enumerate(JIRA_PRIORITIES)
         }
 


### PR DESCRIPTION
JIRA has a list of custom priorities which can be partitioned into the
LMH priority codes expected by bugwarrior.