### PR TITLE
Remove legacy_matching.

### DIFF
--- a/bugwarrior/docs/common_configuration.rst
+++ b/bugwarrior/docs/common_configuration.rst
@@ -21,9 +21,6 @@ Optional options include:
   annotations. Defaults to ``True``.
 * ``annotation_newlines``: When ``False`` strips newlines from comments in
   annotations. Defaults to ``False``.
-* ``legacy_matching``: Set to ``False`` to instruct Bugwarrior to match
-  issues using only the issue's unique identifiers (rather than matching
-  on description).
 * ``log.level``: Set to one of ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``,
   ``CRITICAL``, or ``DISABLED`` to control the logging verbosity.  By
   default, this is set to ``DEBUG``.

--- a/bugwarrior/docs/configuration.rst
+++ b/bugwarrior/docs/configuration.rst
@@ -35,13 +35,6 @@ Example Configuration
     # Setting this to False will strip newlines from comment annotations
     annotation_newlines = False
 
-    # Defines whether or not issues should be matched based upon their description.
-    # In legacy mode, we will attempt to match issues to bugs based upon the
-    # presence of the '(bw)' marker in the task description.
-    # If this is false, we will only select issues having the appropriate UDA
-    # fields defined (which is smarter, better, newer, etc..)
-    legacy_matching = False
-
     # log.level specifies the verbosity.  The default is DEBUG.
     # log.level can be one of DEBUG, INFO, WARNING, ERROR, CRITICAL, DISABLED
     #log.level = DEBUG


### PR DESCRIPTION
This is a super old feature flag that has been set to false for years.

No one should be using it due to how error-prone it was.

Let's remove it, as a bit of cleanup.