### PR TITLE
add support for cookie based auth to the jira service

### DIFF
--- a/bugwarrior/docs/services/jira.rst
+++ b/bugwarrior/docs/services/jira.rst
@@ -105,6 +105,18 @@ If the ``password`` is specified as ``@kerberos``, the service plugin will try
 to authenticate against server with kerberos. A ticket must be already present
 on the client (created by running ``kinit`` or any other method).
 
+
+Cookie auth vs. HTTP-Basic auth
++++++++++++++++++++++++++++++++
+
+If the ``use_cookies`` option is set to ``True``, the credentials are used for
+Cookie-based authentication as opposed to HTTP-Basic authenticaton. This only
+makes sense when Kerberos is not being used (see above).
+
+This is useful in situations where HTTP-Basic auth is disabled or disallowed
+for some reason.
+
+
 Provided UDA Fields
 -------------------
 

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -269,10 +269,17 @@ class JiraService(IssueService):
         default_query = 'assignee=' + self.username + \
             ' AND resolution is null'
         self.query = self.config.get('query', default_query)
+        self.use_cookies = self.config.get(
+            'use_cookies', default=False, to_type=asbool
+        )
+
         if password == '@kerberos':
             auth = dict(kerberos=True)
         else:
-            auth = dict(basic_auth=(self.username, password))
+            if self.use_cookies:
+                auth = dict(auth=(self.username, password))
+            else:
+                auth = dict(basic_auth=(self.username, password))
         self.jira = JIRA(
             options={
                 'server': self.config.get('base_uri'),


### PR DESCRIPTION
As mentioned in the documentation, this is useful when HHTP Basic auth is disabled (as is the case with the Jira instance I use).

This has been working well for me for ~4 months.