### PR TITLE
JIRA: Quote username to allow the @ sign

### DIFF
--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -266,8 +266,8 @@ class JiraService(IssueService):
         self.url = self.config.get('base_uri')
         password = self.get_password('password', self.username)
 
-        default_query = 'assignee=' + self.username + \
-            ' AND resolution is null'
+        default_query = 'assignee="' + self.username + \
+            '" AND resolution is null'
         self.query = self.config.get('query', default_query)
         if password == '@kerberos':
             auth = dict(kerberos=True)


### PR DESCRIPTION
Following error happens if the jira username contains the @ sign. Quote the username within the default query fixes this error. 
```
ERROR:bugwarrior.services:Worker for [jira_icc] failed: JiraError HTTP 400 url: https://foobar/rest/api/latest/search?jql=assignee%3Duser%40example.com+AND+resolution+is+null&startAt=0&validateQuery=True&maxResults=-1
	text: Error in the JQL Query: The character '@' is a reserved JQL character. You must enclose it in a string or use the escape '\u0040' instead. (line 1, character 30)
```