### PR TITLE
Allow user to synchronize tasks without closing tasks associated with issues that have been closed.

### DIFF
--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -49,9 +49,10 @@ def _try_load_config(main_section, interactive=False):
 @click.option('--dry-run', is_flag=True)
 @click.option('--flavor', default=None, help='The flavor to use')
 @click.option('--interactive', is_flag=True)
+@click.option('--no-close', is_flag=True)
 @click.option('--debug', is_flag=True,
               help='Do not use multiprocessing (which breaks pdb).')
-def pull(dry_run, flavor, interactive, debug):
+def pull(dry_run, flavor, interactive, no_close, debug):
     """ Pull down tasks from forges and add them to your taskwarrior tasks.
 
     Relies on configuration in bugwarriorrc
@@ -70,7 +71,13 @@ def pull(dry_run, flavor, interactive, debug):
             issue_generator = aggregate_issues(config, main_section, debug)
 
             # Stuff them in the taskwarrior db as necessary
-            synchronize(issue_generator, config, main_section, dry_run)
+            synchronize(
+                issue_generator,
+                config,
+                main_section,
+                allow_close=not no_close,
+                dry_run=dry_run
+            )
         finally:
             lockfile.release()
     except LockTimeout:


### PR DESCRIPTION
I might have a fairly unique workflow here, but a problem I run into frequently is that I'm expected to report on closed issues during a meeting a day or so after the task is closed, and new issues may have been created and assigned to me during that period that I'd like to pull into my task list. I'd like to keep those issues in my task list so I have an easy-to-access list of tasks for such meetings.  What this PR does is introduce an option allowing one to pull in and update existing issues without closing their associated tasks.