### PR TITLE
Support phabricator.only_if_assigned.

### DIFF
--- a/bugwarrior/docs/services/phabricator.rst
+++ b/bugwarrior/docs/services/phabricator.rst
@@ -95,6 +95,9 @@ Note that there is no way to filter by the reviewer's response (for example, to
 exclude Revisions you have already reviewed). Phabricator does not provide the
 necessary information in the Conduit API.
 
+Furthermore, setting `phabricator.only_if_assigned` to something other than False
+will default to ignoring the CC and Author fields as reported in phabricator.
+
 Provided UDA Fields
 -------------------
 

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -93,10 +93,13 @@ class PhabricatorService(IssueService):
         self.shown_project_phids = (
             self.config.get("project_phids", None, aslist))
 
-        self.ignore_cc = self.config.get('ignore_cc', default=False,
+        only_if_assigned = self.config.get('only_if_assigned', default=False,
+                                           to_type=lambda x: x not in [False, "False", ""])
+
+        self.ignore_cc = self.config.get('ignore_cc', default=only_if_assigned,
                                           to_type=lambda x: x == "True")
 
-        self.ignore_author = self.config.get('ignore_author', default=False,
+        self.ignore_author = self.config.get('ignore_author', default=only_if_assigned,
                                              to_type=lambda x: x == "True")
 
         self.ignore_owner = self.config.get('ignore_owner', default=False,


### PR DESCRIPTION
Fixes #705 by having a non `False` value for `phabricator.only_if_assigned`
affect the defaults for `phabricator.ignore_cc` and `phabricator.ignore_author`.