### PR TITLE
Support Bugzilla REST interface

### DIFF
--- a/bugwarrior/docs/services/bugzilla.rst
+++ b/bugwarrior/docs/services/bugzilla.rst
@@ -75,6 +75,11 @@ from your browser into the ``bugzilla.query_url`` option::
 
     bugzilla.query_url = https://bugzilla.mozilla.org/query.cgi?bug_status=ASSIGNED&email1=myname%40mozilla.com&emailassigned_to1=1&emailtype1=exact
 
+Note that versions of Python-Bugzilla newer than 2.3.0 support the Bugzilla REST interface, but prefer the XMLRPC interface if both are configured.
+To force use of the REST interface, ensure you are using a newer version of the library and add::
+
+    bugzilla.force_rest = True
+
 Provided UDA Fields
 -------------------
 

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -146,16 +146,20 @@ class BugzillaService(IssueService):
         # to pass that argument or not.
         self.advanced = asbool(self.config.get('advanced', 'no'))
 
-        url = 'https://%s/xmlrpc.cgi' % self.base_uri
+        force_rest_kwargs = {}
+        if asbool(self.config.get("force_rest", "no")):
+            force_rest_kwargs = {"force_rest": True}
+
+        url = 'https://%s' % self.base_uri
         api_key = self.config.get('api_key', default=None)
         if api_key:
             try:
-                self.bz = bugzilla.Bugzilla(url=url, api_key=api_key)
+                self.bz = bugzilla.Bugzilla(url=url, api_key=api_key, **force_rest_kwargs)
             except TypeError:
                 raise Exception("Bugzilla API keys require python-bugzilla>=2.1.0")
         else:
             password = self.get_password('password', self.username)
-            self.bz = bugzilla.Bugzilla(url=url)
+            self.bz = bugzilla.Bugzilla(url=url, **force_rest_kwargs)
             self.bz.login(self.username, password)
 
     @staticmethod


### PR DESCRIPTION
The key change here is to remove `xmlrpc.cgi` from the URL and rely on
Python-Bugzilla to figure it out.  The additional parameter allows
installations like mine to "force" REST mode.

Fixes #697.

Note that the new version of Python-Bugzilla isn't out yet!  I can confirm that, as long as `force_rest` isn't set, this continues to work with the latest Python-Bugzilla (2.3.0).