### PR TITLE
Fix parsing commas inside of templates in config

### DIFF
--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -5,6 +5,7 @@ from six.moves import configparser
 import os
 import subprocess
 import sys
+import re
 
 import six
 
@@ -28,7 +29,7 @@ def asbool(some_value):
 
 def aslist(value):
     """ Cast config values to lists of strings """
-    return [item.strip() for item in value.strip().split(',')]
+    return [item.strip() for item in re.split(",(?![^{]*})",value.strip())]
 
 
 def asint(value):


### PR DESCRIPTION
This fixes #568 

Currently the `aslist()` function does not take into account if the list separator is inside a jinja template string - this PR makes sure that settings like the following:
```
jira.add_tags = work, jira, {{jirastatus|lower|replace(' ','_')}}
```
are properly split.