### PR TITLE
Add trello keyring support

### DIFF
--- a/bugwarrior/services/trello.py
+++ b/bugwarrior/services/trello.py
@@ -89,6 +89,11 @@ class TrelloService(IssueService, ServiceClient):
         check_key('token')
         check_key('api_key')
 
+    @staticmethod
+    def get_keyring_service(service_config):
+        api_key = service_config.get('api_key')
+        return "trello://{api_key}@trello.com".format(api_key=api_key)
+
     def get_service_metadata(self):
         """
         Return extra config options to be passed to the TrelloIssue class
@@ -194,6 +199,6 @@ class TrelloService(IssueService, ServiceClient):
         key and token from the configuration
         """
         params['key'] = self.config.get('api_key'),
-        params['token'] = self.config.get('token'),
+        params['token'] = self.get_password('token', self.config),
         url = "https://api.trello.com" + url
         return self.json_response(requests.get(url, params=params))

--- a/tests/test_trello.py
+++ b/tests/test_trello.py
@@ -217,3 +217,10 @@ class TestTrelloService(ConfigTest):
         self.config.remove_option('mytrello', 'trello.api_key')
         TrelloService.validate_config(self.service_config, 'mytrello')
         die.assert_called_with("[mytrello] has no 'trello.api_key'")
+
+
+    def test_keyring_service(self):
+        """ Checks that the keyring service name """
+        keyring_service = TrelloService.get_keyring_service(self.service_config)
+        self.assertEqual("trello://XXXX@trello.com", keyring_service)
+


### PR DESCRIPTION
This adds support for `oracle:use_keyring`, `oracle:ask_password` and `oracle:eval` for the  Trello `token` field

I wasn't sure if there is any convention for the keyring service, I just used the `api_key`.
Its fine to publicly share that one [according to the Trello documentation](https://developers.trello.com/docs/api-key-security)