### PR TITLE
Add option to configure custom Gerrit Query

### DIFF
--- a/bugwarrior/docs/services/gerrit.rst
+++ b/bugwarrior/docs/services/gerrit.rst
@@ -26,6 +26,20 @@ alternative certificate authority to verify the connection.
 You can also feel free to use any of the configuration options described in
 :ref:`common_configuration_options`.
 
+Specify the Query to Use for Gathering Patchsets
+++++++++++++++++++++++++++++++++++++++++++++++++
+
+By default, the Gerrit plugin will query patchsets based on this simple
+API query
+
+    is:open+is:reviewer
+
+You may override this query string through your `bugwarriorrc` file.
+
+For example:
+
+    gerrit.query = is:open+((reviewer:self+-owner:self+-is:ignored)+OR+assignee:self)
+
 Provided UDA Fields
 -------------------
 

--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -78,6 +78,10 @@ class GerritService(IssueService, ServiceClient):
             'Accept': 'application/json',
             'Accept-Encoding': 'gzip',
         })
+        self.query_string = self.config.get(
+            'query',
+            'is:open+is:reviewer'
+        ) + '&o=MESSAGES&o=DETAILED_ACCOUNTS'
 
         if self.ssl_ca_path:
             self.session.verify = os.path.expanduser(self.ssl_ca_path)
@@ -113,9 +117,7 @@ class GerritService(IssueService, ServiceClient):
     def issues(self):
         # Construct the whole url by hand here, because otherwise requests will
         # percent-encode the ':' characters, which gerrit doesn't like.
-        url = self.url + '/a/changes/' + \
-            '?q=is:open+is:reviewer' + \
-            '&o=MESSAGES&o=DETAILED_ACCOUNTS'
+        url = self.url + '/a/changes/?q=' + self.query_string
         response = self.session.get(url)
         response.raise_for_status()
         # The response has some ")]}'" garbage prefixed.


### PR DESCRIPTION
Currently, in services such as the JIRA one, it is possible to override the query to fetch issues.

This patchset aims to add that functionality to the Gerrit service, allowing users to set a custom query string to fetch patchsets.

I have included a small change to the documentation so that the feature is clearer from a user's standpoint.