### PR TITLE
Add support for YouTrack InCloud instances

### DIFF
--- a/bugwarrior/docs/services/youtrack.rst
+++ b/bugwarrior/docs/services/youtrack.rst
@@ -42,6 +42,10 @@ If you want to ignore verifying the SSL certificate, set::
 
     youtrack.verify_ssl = False
 
+For YouTrack InCloud instances set::
+
+    youtrack.incloud_instance = True
+
 Specify the Query to Use for Gathering Issues
 +++++++++++++++++++++++++++++++++++++++++++++
 

--- a/bugwarrior/services/youtrack.py
+++ b/bugwarrior/services/youtrack.py
@@ -128,6 +128,8 @@ class YoutrackService(IssueService, ServiceClient):
             self.port = '80'
         self.port = self.config.get('port', self.port)
         self.base_url = '%s://%s:%s' % (self.scheme, self.host, self.port)
+        if self.config.get('incloud_instance', default=False, to_type=asbool):
+            self.base_url += '/youtrack'
         self.rest_url = self.base_url + '/rest'
 
         self.session = requests.Session()


### PR DESCRIPTION
The urls for YouTrack InCloud instances all have `youtrack/` prefixed to
their paths. This adds a way to include the necessary prefix to the base
url.

I needed this in order to get bugwarrior working with my company's YouTrack instance, and thought I'd share. :)