### PR TITLE
Bz: Parse dates for date type UDAs

### DIFF
--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -80,11 +80,10 @@ class BugzillaIssue(Issue):
             self.COMPONENT: self.record['component'],
         }
         if self.extra.get('needinfo_since', None) is not None:
-            task[self.NEEDINFO] = self.extra.get('needinfo_since')
+            task[self.NEEDINFO] = self.parse_date(self.extra.get('needinfo_since'))
 
-        # iff field is defined, use it, converting None to empty string.
-        if 'assigned_on' in self.extra:
-            task[self.ASSIGNED_ON] = self.extra.get('assigned_on') or ''
+        if self.extra.get('assigned_on', None) is not None:
+            task[self.ASSIGNED_ON] = self.parse_date(self.extra.get('assigned_on'))
 
         return task
 

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -125,7 +125,6 @@ class TestBugzillaService(AbstractServiceTest, ServiceTest):
 
         expected = {
             'annotations': [],
-            'bugzillaassignedon': '',
             'bugzillabugid': 1234567,
             'bugzillastatus': 'NEW',
             'bugzillasummary': 'This is the issue summary',


### PR DESCRIPTION
The date type UDAs need to be parsed as dates otherwise bugwarrior
constantly updating the tasks such as:

    bugzillaassignedon: datetime.datetime(2020, 4, 23, 12, 27, 36, tzinfo=tzutc()) -> '2020-04-23T14:27:36+00:00'