### PR TITLE
Add replace_tags option

### DIFF
--- a/bugwarrior/docs/common_configuration.rst
+++ b/bugwarrior/docs/common_configuration.rst
@@ -34,6 +34,12 @@ Optional options include:
   annotations to your tasks at all.  Default: ``True``.
 * ``merge_tags``: If ``False``, bugwarrior won't bother with adding
   tags to your tasks at all.  Default: ``True``.
+* ``replace_tags``: If ``True``, bugwarrior will delete all tags prior to
+  fetching new ones, except those listed in ``static_tags``. Only work if
+  merge_tags is ``True``. Default: ``False``.
+* ``static_tags``: A comma separated list of tags that shouldn't be *removed* by
+  bugwarrior. Use for tags that you want to keep when replace_tags is set to
+  ``True``.
 * ``static_fields``: A comma separated list of attributes that shouldn't be
   *updated* by bugwarrior.  Use for values that you want to tune manually.
   Default: ``priority``.

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -40,6 +40,35 @@ class TestMergeLeft(unittest.TestCase):
         db.merge_left('annotations', self.issue_dict, remote, hamming=True)
         self.assertEqual(len(self.issue_dict['annotations']), 1)
 
+class TestReplaceLeft(unittest.TestCase):
+    def setUp(self):
+        self.issue_dict = {'tags': ['test', 'test2'] }
+        self.remote = { 'tags': ['remote_tag1', 'remote_tag2'] }
+
+    def assertReplaced(self, local, remote, **kwargs):
+        db.replace_left('tags', local, remote, **kwargs)
+        self.assertEqual(local, remote)
+
+    def test_with_dict(self):
+        self.assertReplaced({}, self.issue_dict)
+
+    def test_with_taskw(self):
+        self.assertReplaced(taskw.task.Task({}), self.issue_dict)
+
+    def test_already_in_sync(self):
+        self.assertReplaced(self.issue_dict, self.issue_dict)
+
+    def test_replace(self):
+        self.assertReplaced(self.issue_dict, self.remote)
+
+    def test_replace_with_keeped_item(self):
+        """ When keeped_item is set, all item in this list are keeped """
+        result = {'tags': ['test', 'remote_tag1', 'remote_tag2'] }
+        print(self.issue_dict)
+        keeped_items = [ 'test' ]
+        db.replace_left('tags', self.issue_dict, self.remote, keeped_items)
+        self.assertEqual(self.issue_dict, result)
+
 
 class TestSynchronize(ConfigTest):
 


### PR DESCRIPTION
This relate to the old #131.

I added a new option, ``replace_tags`` allowing bugwarrior to delete tags before adding new ones. In my actual workflow, i use labels/tags to filter issues, and keep track of the status of each task.

In gitlab, the state of an issue can be tracked using labels (thanks to the issue board). This option allow me to sync labels (added and deleted ones), in order to have the same labels as the remote issue.

With this option i added ``static_tags``, in order to have a list of labels that bugwarrior will not delete, no matter what.

This option is False by default, and will not change the actual behavior of bugwarrior until checked in.