### PR TITLE
bugzilla: Treat api_key as a password

### DIFF
--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -150,8 +150,8 @@ class BugzillaService(IssueService):
             force_rest_kwargs = {"force_rest": True}
 
         url = 'https://%s' % self.base_uri
-        api_key = self.config.get('api_key', default=None)
-        if api_key:
+        if self.config.get('api_key'):
+            api_key = self.get_password('api_key')
             try:
                 self.bz = bugzilla.Bugzilla(url=url, api_key=api_key, **force_rest_kwargs)
             except TypeError:


### PR DESCRIPTION
This patch enables using a vault or `@oracle` to retrieve a Bugzilla api
key.

Example:

```toml
bugzilla.api_key = @oracle:eval:pass bugzilla/bugwarrior
```

Note that I have only tested `@oracle eval` locally.