### PR TITLE
mock (third-party backport) -> unittest.mock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_install:
   - task --version
   - pip install --upgrade pip
   - pip install taskw
-  - pip install mock
   - pip install responses
   - pip install PySimpleSOAP
   - pip install phabricator

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(name='bugwarrior',
           "trac": ["offtrac"],
       },
       tests_require=[
-          "Mock",
           "nose",
           "responses",
           "bugwarrior[jira]",

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,9 +1,9 @@
 from builtins import object
-import mock
 import shutil
 import os.path
 import tempfile
 import unittest
+from unittest import mock
 
 import responses
 

--- a/tests/test_activecollab.py
+++ b/tests/test_activecollab.py
@@ -2,8 +2,8 @@ from builtins import next
 from builtins import object
 import datetime
 import unittest
+from unittest import mock
 
-import mock
 import pypandoc
 import pytz
 

--- a/tests/test_bts.py
+++ b/tests/test_bts.py
@@ -1,7 +1,7 @@
 from builtins import next
 from builtins import str
 from builtins import object
-import mock
+from unittest import mock
 
 from bugwarrior.services import bts
 

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -1,6 +1,6 @@
 from builtins import next
 from builtins import object
-import mock
+from unittest import mock
 from collections import namedtuple
 from six.moves import configparser
 

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -2,11 +2,11 @@ import os.path
 import pickle
 from copy import copy
 from datetime import datetime, timedelta
+from unittest import mock
+from unittest.mock import patch
 
-import mock
 from dateutil.tz import tzutc
 from google.oauth2.credentials import Credentials
-from mock import patch
 from six.moves import configparser
 
 import bugwarrior.services.gmail as gmail

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -1,8 +1,8 @@
 from builtins import next
 from builtins import object
-
-import mock
 from collections import namedtuple
+from unittest import mock
+
 from dateutil.tz import datetime
 from dateutil.tz.tz import tzutc
 

--- a/tests/test_megaplan.py
+++ b/tests/test_megaplan.py
@@ -1,7 +1,7 @@
 from builtins import next
 from builtins import object
-import mock
 import unittest
+from unittest import mock
 
 try:
     from bugwarrior.services.mplan import MegaplanService

--- a/tests/test_pivotaltracker.py
+++ b/tests/test_pivotaltracker.py
@@ -1,10 +1,9 @@
 import datetime
 from dateutil.tz import tzutc
 from six.moves import configparser
+from unittest import mock
 
 import responses
-import mock
-import operator
 
 from .base import ServiceTest, AbstractServiceTest, ConfigTest
 from bugwarrior.config import ServiceConfig

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -1,7 +1,7 @@
 from builtins import next
 import datetime
+from unittest import mock
 
-import mock
 import dateutil
 import responses
 

--- a/tests/test_string_compat.py
+++ b/tests/test_string_compat.py
@@ -1,6 +1,6 @@
 import unittest
 import six
-from mock import MagicMock
+from unittest.mock import MagicMock
 from bugwarrior.services import Issue
 
 

--- a/tests/test_teamlab.py
+++ b/tests/test_teamlab.py
@@ -1,5 +1,6 @@
 from builtins import next
-import mock
+from unittest import mock
+
 import responses
 
 from bugwarrior.services.teamlab import TeamLabService

--- a/tests/test_trello.py
+++ b/tests/test_trello.py
@@ -2,9 +2,9 @@ from __future__ import unicode_literals, print_function
 from future import standard_library
 standard_library.install_aliases()
 from builtins import next
+from unittest.mock import patch
 
 from six.moves import configparser
-from mock import patch
 import responses
 
 from dateutil.parser import parse as parse_date


### PR DESCRIPTION
We no longer support any version of python for which this backport is
necessary.