### PR TITLE
[phab] Use diff variable iterated over

### DIFF
--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -144,7 +144,7 @@ class PhabricatorService(IssueService):
 
             project = self.target  # a sensible default
             try:
-                project = projects.get(issue['projectPHIDs'][0], project)
+                project = projects.get(diff['projectPHIDs'][0], project)
             except IndexError:
                 pass
 


### PR DESCRIPTION
This was reported to Debian in https://bugs.debian.org/886383.

I didn't test this but given that the code for diffs seems to be copy
and paste from issues, I assume this is currect.