### PR TITLE
Jira: use paginated query to get ALL results

### DIFF
--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -358,7 +358,7 @@ class JiraService(IssueService):
         )
 
     def issues(self):
-        cases = self.jira.search_issues(self.query, maxResults=-1)
+        cases = self.jira.search_issues(self.query, maxResults=None)
 
         jira_version = 5
         if self.config.has_option(self.target, 'jira.version'):


### PR DESCRIPTION
i haven't read the docs, but from reading the code it seems that `None` is the right thing to pass.  `-1` seems to
get 100 results, while omitting the parameter returns the default of `100`.

Fixes: #764