### PR TITLE
bugzilla: Implement common filters.

### DIFF
--- a/bugwarrior/docs/services/bugzilla.rst
+++ b/bugwarrior/docs/services/bugzilla.rst
@@ -44,15 +44,10 @@ still required in this case, in order to identify bugs belonging to you.
 The above example is the minimum required to import issues from
 Bugzilla.  You can also feel free to use any of the
 configuration options described in :ref:`common_configuration_options`.
-Note, however, that the filtering options, including ``only_if_assigned``
-and ``also_unassigned``, do not work
 
-There is an option to ignore bugs that you are only cc'd on::
+There is also an option to ignore bugs that you are only cc'd on::
 
     bugzilla.ignore_cc = True
-
-But this will continue to include bugs that you reported, regardless of
-whether they are assigned to you.
 
 If your bugzilla "actionable" bugs only include ON_QA, FAILS_QA, PASSES_QA, and POST::
 

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -123,6 +123,7 @@ class BugzillaService(IssueService):
         'component',
         'flags',
         'longdescs',
+        'assigned_to',
     ]
 
     def __init__(self, *args, **kw):
@@ -179,9 +180,7 @@ class BugzillaService(IssueService):
         super(BugzillaService, cls).validate_config(service_config, target)
 
     def get_owner(self, issue):
-        # NotImplemented, but we should never get called since .include() isn't
-        # used by this IssueService.
-        raise NotImplementedError
+        return issue['assigned_to']
 
     def annotations(self, tag, issue, issue_obj):
         base_url = "https://%s/show_bug.cgi?id=" % self.base_uri
@@ -268,6 +267,7 @@ class BugzillaService(IssueService):
             ) for bug in bugs
         ]
 
+        bugs = filter(self.include, bugs)
         issues = [(self.target, bug) for bug in bugs]
         log.debug(" Found %i total.", len(issues))
 


### PR DESCRIPTION
This adds support for the common configuration options
`only_if_assigned` and `also_unassigned`, which should be supported by
all services.

Resolve #243 

<s>**Note**: I haven't tested this, I just pieced it together based on [the docs](https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html).</s> (see comment below)