### PR TITLE
Be more specific in matching NoOptionError in config parser

### DIFF
--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -313,7 +313,9 @@ class ServiceConfig(object):
             if to_type:
                 return to_type(value)
             return value
-        except:
+        except configparser.NoSectionError:
+            return default
+        except configparser.NoOptionError:
             return default
 
     def _get_key(self, key):

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,6 +3,7 @@ import shutil
 import os.path
 import tempfile
 import unittest
+import configparser
 from unittest import mock
 
 import responses
@@ -88,7 +89,10 @@ class ServiceTest(ConfigTest):
                 return False
 
         def get_option(section, name):
-            return options[section][name]
+            try:
+                return options[section][name]
+            except KeyError:
+                raise configparser.NoOptionError(section, name)
 
         def get_int(section, name):
             return int(get_option(section, name))


### PR DESCRIPTION
In Python 3, ConfigParser is more exacting about the syntax it allows,
and in particular it disallows bare `%` characters.  This causes an
error for URLs containing such characters, but the bare `except` just
treated this error as a missing configuration and did not show it to the
user.