### PR TITLE
Gitlab individual priorities

### DIFF
--- a/bugwarrior/docs/configuration.rst
+++ b/bugwarrior/docs/configuration.rst
@@ -130,6 +130,12 @@ Example Configuration
     megaplan.password = secret
     megaplan.project_name = example
 
+    # Example gitlab configuration containing individual priorities
+    [gitlab_config]
+    gitlab.issue_priority = M
+    gitlab.todo_priority = M
+    gitlab.mr_priority = H
+
     # Here's an example of a jira project. The ``jira-python`` module is
     # a bit particular, and jira deployments, like Bugzilla, tend to be
     # reasonably customized. So YMMV. The ``base_uri`` must not have a

--- a/bugwarrior/docs/configuration.rst
+++ b/bugwarrior/docs/configuration.rst
@@ -132,9 +132,9 @@ Example Configuration
 
     # Example gitlab configuration containing individual priorities
     [gitlab_config]
-    gitlab.issue_priority = M
-    gitlab.todo_priority = M
-    gitlab.mr_priority = H
+    gitlab.default_issue_priority = M
+    gitlab.default_todo_priority = M
+    gitlab.default_mr_priority = H
 
     # Here's an example of a jira project. The ``jira-python`` module is
     # a bit particular, and jira deployments, like Bugzilla, tend to be

--- a/bugwarrior/docs/services/gitlab.rst
+++ b/bugwarrior/docs/services/gitlab.rst
@@ -163,6 +163,16 @@ If you would like to only pull issues and MRs that you've authored, you may set:
 
     gitlab.only_if_author = myusername
 
+Priority by type
+++++++++++++++++
+
+If you would like that your issues have a different default priority than your MRs or todo items,
+you can configure individual priorities for each::
+
+    gitlab.issue_priority = M
+    gitlab.todo_priority = M
+    gitlab.mr_priority = H
+
 Use HTTP
 ++++++++
 

--- a/bugwarrior/docs/services/gitlab.rst
+++ b/bugwarrior/docs/services/gitlab.rst
@@ -169,9 +169,9 @@ Priority by type
 If you would like that your issues have a different default priority than your MRs or todo items,
 you can configure individual priorities for each::
 
-    gitlab.issue_priority = M
-    gitlab.todo_priority = M
-    gitlab.mr_priority = H
+    gitlab.default_issue_priority = M
+    gitlab.default_todo_priority = M
+    gitlab.default_mr_priority = H
 
 Use HTTP
 ++++++++

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -124,9 +124,9 @@ class GitlabIssue(Issue):
     # Override the method from parent class
     def get_priority(self):
         default_priority_map = {
-        'todo': self.origin['todo_priority'],
-        'merge_request': self.origin['mr_priority'],
-        'issue': self.origin['issue_priority']}
+        'todo': self.origin['default_todo_priority'],
+        'merge_request': self.origin['default_mr_priority'],
+        'issue': self.origin['default_issue_priority']}
 
         type_str = self.extra['type']
         default_priority = self.origin['default_priority']
@@ -268,9 +268,9 @@ class GitlabService(IssueService, ServiceClient):
         self.include_regex = re.compile(self.include_regex) if self.include_regex else None
         self.exclude_regex = re.compile(self.exclude_regex) if self.exclude_regex else None
 
-        self.default_issue_priority = self.config.get('issue_priority', self.default_priority)
-        self.default_todo_priority = self.config.get('todo_priority', self.default_priority)
-        self.default_mr_priority = self.config.get('mr_priority', self.default_priority)
+        self.default_issue_priority = self.config.get('default_issue_priority', self.default_priority)
+        self.default_todo_priority = self.config.get('default_todo_priority', self.default_priority)
+        self.default_mr_priority = self.config.get('default_mr_priority', self.default_priority)
 
         self.import_labels_as_tags = self.config.get(
             'import_labels_as_tags', default=False, to_type=asbool
@@ -313,9 +313,9 @@ class GitlabService(IssueService, ServiceClient):
         return {
             'import_labels_as_tags': self.import_labels_as_tags,
             'label_template': self.label_template,
-            'issue_priority': self.default_issue_priority,
-            'todo_priority': self.default_todo_priority,
-            'mr_priority': self.default_mr_priority,
+            'default_issue_priority': self.default_issue_priority,
+            'default_todo_priority': self.default_todo_priority,
+            'default_mr_priority': self.default_mr_priority,
         }
 
 

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -121,6 +121,18 @@ class GitlabIssue(Issue):
     def _normalize_label_to_tag(self, label):
         return re.sub(r'[^a-zA-Z0-9]', '_', label)
 
+    # Override the method from parent class
+    def get_priority(self):
+        default_priority_map = {
+        'todo': self.origin['todo_priority'],
+        'merge_request': self.origin['mr_priority'],
+        'issue': self.origin['issue_priority']}
+
+        type_str = self.extra['type']
+        default_priority = self.origin['default_priority']
+
+        return default_priority_map.get(type_str, default_priority)
+
     def to_taskwarrior(self):
         author = self.record['author']
         milestone = self.record.get('milestone')
@@ -136,9 +148,7 @@ class GitlabIssue(Issue):
         number = (
             self.record['id'] if self.extra['type'] == 'todo'
             else self.record['iid'])
-        priority = (
-            self.origin['default_priority'] if self.extra['type'] == 'issue'
-            else 'H')
+        priority = self.get_priority()
         title = (
             'Todo from %s for %s' % (author['name'], self.extra['project'])
             if self.extra['type'] == 'todo' else self.record['title'])
@@ -258,6 +268,10 @@ class GitlabService(IssueService, ServiceClient):
         self.include_regex = re.compile(self.include_regex) if self.include_regex else None
         self.exclude_regex = re.compile(self.exclude_regex) if self.exclude_regex else None
 
+        self.default_issue_priority = self.config.get('issue_priority', self.default_priority)
+        self.default_todo_priority = self.config.get('todo_priority', self.default_priority)
+        self.default_mr_priority = self.config.get('mr_priority', self.default_priority)
+
         self.import_labels_as_tags = self.config.get(
             'import_labels_as_tags', default=False, to_type=asbool
         )
@@ -299,6 +313,9 @@ class GitlabService(IssueService, ServiceClient):
         return {
             'import_labels_as_tags': self.import_labels_as_tags,
             'label_template': self.label_template,
+            'issue_priority': self.default_issue_priority,
+            'todo_priority': self.default_todo_priority,
+            'mr_priority': self.default_mr_priority,
         }
 
 

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -226,6 +226,53 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
             'type': 'todo',
             'annotations': [],
         }
+        self.arbitrary_mr = {
+            "id": 42,
+            "iid": 3,
+            "project_id": 8,
+            "title": "Add user settings",
+            "description": "",
+            "labels": [
+                "feature"
+            ],
+            "milestone": {
+                "id": 1,
+                "title": "v1.0",
+                "description": "",
+                "due_date": self.arbitrary_duedate.date().isoformat(),
+                "state": "closed",
+                "updated_at": "2012-07-04T13:42:48Z",
+                "created_at": "2012-07-04T13:42:48Z"
+            },
+            "assignee": {
+                "id": 2,
+                "username": "jack_smith",
+                "email": "jack@example.com",
+                "name": "Jack Smith",
+                "state": "active",
+                "created_at": "2012-05-23T08:01:01Z"
+            },
+            "author": {
+                "id": 1,
+                "username": "john_smith",
+                "email": "john@example.com",
+                "name": "John Smith",
+                "state": "active",
+                "created_at": "2012-05-23T08:00:58Z"
+            },
+            "state": "opened",
+            "updated_at": self.arbitrary_updated.isoformat(),
+            "created_at": self.arbitrary_created.isoformat(),
+            "weight": 3,
+            "work_in_progress": "true"
+        }
+        self.arbitrary_mr_extra = {
+            'issue_url': 'https://gitlab.example.com/arbitrary_username/project/merge_requests/3',
+            'project': 'project',
+            'namespace': 'arbitrary_namespace',
+            'type': 'merge_request',
+            'annotations': [],
+        }
 
     def test_normalize_label_to_tag(self):
         issue = self.service.get_issue_for_record(
@@ -348,6 +395,46 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
             issue.ASSIGNEE: None, # Currently not parsed for ToDos
             issue.NAMESPACE: 'arbitrary_namespace',
             issue.WEIGHT: None, # Currently not parsed for ToDos
+        }
+        actual_output = issue.to_taskwarrior()
+
+        self.assertEqual(actual_output, expected_output)
+
+    def test_custom_mr_priority(self):
+        overrides = {
+            'gitlab.mr_priority': '',
+        }
+        service = self.get_mock_service(GitlabService, config_overrides=overrides)
+        service.import_labels_as_tags = True
+        issue = service.get_issue_for_record(
+            self.arbitrary_mr,
+            self.arbitrary_mr_extra
+        )
+        expected_output = {
+            'project': self.arbitrary_mr_extra['project'],
+            'priority': overrides['gitlab.mr_priority'],
+            'annotations': [],
+            'tags': [u'feature'],
+            'due': self.arbitrary_duedate.replace(microsecond=0),
+            'entry': self.arbitrary_created.replace(microsecond=0),
+            issue.URL: self.arbitrary_mr_extra['issue_url'],
+            issue.REPO: 'project',
+            issue.STATE: self.arbitrary_mr['state'],
+            issue.TYPE: self.arbitrary_mr_extra['type'],
+            issue.TITLE: self.arbitrary_mr['title'],
+            issue.NUMBER: str(self.arbitrary_mr['iid']),
+            issue.UPDATED_AT: self.arbitrary_updated.replace(microsecond=0),
+            issue.CREATED_AT: self.arbitrary_created.replace(microsecond=0),
+            issue.DUEDATE: self.arbitrary_duedate,
+            issue.DESCRIPTION: self.arbitrary_mr['description'],
+            issue.MILESTONE: self.arbitrary_issue['milestone']['title'],
+            issue.UPVOTES: 0,
+            issue.DOWNVOTES: 0,
+            issue.WORK_IN_PROGRESS: 1,
+            issue.AUTHOR: 'john_smith',
+            issue.ASSIGNEE: 'jack_smith',
+            issue.NAMESPACE: 'arbitrary_namespace',
+            issue.WEIGHT: 3,
         }
         actual_output = issue.to_taskwarrior()
 

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -199,6 +199,46 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
 
         self.assertEqual(actual_output, expected_output)
 
+    def test_custom_issue_priority(self):
+        overrides = {
+            'gitlab.issue_priority': 'L',
+        }
+        service = self.get_mock_service(GitlabService, config_overrides=overrides)
+        service.import_labels_as_tags = True
+        issue = service.get_issue_for_record(
+            self.arbitrary_issue,
+            self.arbitrary_extra
+        )
+        expected_output = {
+            'project': self.arbitrary_extra['project'],
+            'priority': 'L',
+            'annotations': [],
+            'tags': [u'feature'],
+            'due': self.arbitrary_duedate.replace(microsecond=0),
+            'entry': self.arbitrary_created.replace(microsecond=0),
+            issue.URL: self.arbitrary_extra['issue_url'],
+            issue.REPO: 'project',
+            issue.STATE: self.arbitrary_issue['state'],
+            issue.TYPE: self.arbitrary_extra['type'],
+            issue.TITLE: self.arbitrary_issue['title'],
+            issue.NUMBER: str(self.arbitrary_issue['iid']),
+            issue.UPDATED_AT: self.arbitrary_updated.replace(microsecond=0),
+            issue.CREATED_AT: self.arbitrary_created.replace(microsecond=0),
+            issue.DUEDATE: self.arbitrary_duedate,
+            issue.DESCRIPTION: self.arbitrary_issue['description'],
+            issue.MILESTONE: self.arbitrary_issue['milestone']['title'],
+            issue.UPVOTES: 0,
+            issue.DOWNVOTES: 0,
+            issue.WORK_IN_PROGRESS: 1,
+            issue.AUTHOR: 'john_smith',
+            issue.ASSIGNEE: 'jack_smith',
+            issue.NAMESPACE: 'arbitrary_namespace',
+            issue.WEIGHT: 3,
+        }
+        actual_output = issue.to_taskwarrior()
+
+        self.assertEqual(actual_output, expected_output)
+
     def test_work_in_progress(self):
         self.arbitrary_issue['work_in_progress'] = 'false'
         self.service.import_labels_as_tags = True

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -76,9 +76,9 @@ class TestGitlabService(ConfigTest):
         self.assertTrue(service.filter_repos(repo))
 
     def test_default_priorities(self):
-        self.config.set('myservice', 'gitlab.issue_priority', 'L')
-        self.config.set('myservice', 'gitlab.mr_priority', 'M')
-        self.config.set('myservice', 'gitlab.todo_priority', 'H')
+        self.config.set('myservice', 'gitlab.default_issue_priority', 'L')
+        self.config.set('myservice', 'gitlab.default_mr_priority', 'M')
+        self.config.set('myservice', 'gitlab.default_todo_priority', 'H')
         service = GitlabService(self.config, 'general', 'myservice')
         self.assertEqual('L', service.default_issue_priority)
         self.assertEqual('M', service.default_mr_priority)
@@ -321,7 +321,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
 
     def test_custom_issue_priority(self):
         overrides = {
-            'gitlab.issue_priority': 'L',
+            'gitlab.default_issue_priority': 'L',
         }
         service = self.get_mock_service(GitlabService, config_overrides=overrides)
         service.import_labels_as_tags = True
@@ -361,7 +361,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
 
     def test_custom_todo_priority(self):
         overrides = {
-            'gitlab.todo_priority': 'H',
+            'gitlab.default_todo_priority': 'H',
         }
         service = self.get_mock_service(GitlabService, config_overrides=overrides)
         service.import_labels_as_tags = True
@@ -371,7 +371,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
         )
         expected_output = {
             'project': self.arbitrary_todo_extra['project'],
-            'priority': overrides['gitlab.todo_priority'],
+            'priority': overrides['gitlab.default_todo_priority'],
             'annotations': [],
             'tags': [],
             'due': None, # currently not parsed for ToDos
@@ -402,7 +402,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
 
     def test_custom_mr_priority(self):
         overrides = {
-            'gitlab.mr_priority': '',
+            'gitlab.default_mr_priority': '',
         }
         service = self.get_mock_service(GitlabService, config_overrides=overrides)
         service.import_labels_as_tags = True
@@ -412,7 +412,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
         )
         expected_output = {
             'project': self.arbitrary_mr_extra['project'],
-            'priority': overrides['gitlab.mr_priority'],
+            'priority': overrides['gitlab.default_mr_priority'],
             'annotations': [],
             'tags': [u'feature'],
             'due': self.arbitrary_duedate.replace(microsecond=0),

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -75,6 +75,16 @@ class TestGitlabService(ConfigTest):
         repo = {'path_with_namespace': 'foobar/baz', 'id': 1234}
         self.assertTrue(service.filter_repos(repo))
 
+    def test_default_priorities(self):
+        self.config.set('myservice', 'gitlab.issue_priority', 'L')
+        self.config.set('myservice', 'gitlab.mr_priority', 'M')
+        self.config.set('myservice', 'gitlab.todo_priority', 'H')
+        service = GitlabService(self.config, 'general', 'myservice')
+        self.assertEqual('L', service.default_issue_priority)
+        self.assertEqual('M', service.default_mr_priority)
+        self.assertEqual('H', service.default_todo_priority)
+
+
 
 class TestGitlabIssue(AbstractServiceTest, ServiceTest):
     maxDiff = None


### PR DESCRIPTION
Allow configuring individual priorities for issues, todos and MRs

Gitlab doesn't offer any native priority definition. In the current implementation, issues are prioritized with the default priority, while all other types are hardcoded to have priority 'H'.

This PR lets users configure individual priorities for each, issues, todos and merge requests.

This implements #814

---
## ToDo's left
 - [x] move config parsing to `__init__` (https://github.com/ralphbean/bugwarrior/pull/816#discussion_r627878020)
 - [x] rename parameters to `default_[whatever]` (https://github.com/ralphbean/bugwarrior/pull/816#discussion_r627878596)
 - [x] Add tests
 - [ ] Add to changelog