### PR TITLE
[Gitlab] Use due_date from target for todos

### DIFF
--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -145,6 +145,9 @@ class GitlabIssue(Issue):
         description = (
             self.record['body'] if self.extra['type'] == 'todo'
             else self.record['description'])
+        if self.extra['type'] == 'todo':
+            target = self.record.get('target')
+            duedate = target.get('due_date')
 
         if milestone and (
                 self.extra['type'] == 'issue' or


### PR DESCRIPTION
As gitlab todos don't have their own due dates, but the targets they are created for (e.g. issues, MRs) might have a due date, I think it does make sense to add this due date to the task.

I'll create this as WIP, as I'd like to also add tests for that, using the todo test introduced in #816 