### PR TITLE
bitbucket: Enable test_fetch_issues_pagination

### DIFF
--- a/tests/test_bitbucket.py
+++ b/tests/test_bitbucket.py
@@ -124,7 +124,6 @@ class TestBitbucketIssue(AbstractServiceTest, ServiceTest):
         }
         self.assertIsNone(self.service.get_owner(('foo', issue)))
 
-    @unittest.skip('https://github.com/getsentry/responses/issues/156')
     @responses.activate
     def test_fetch_issues_pagination(self):
         self.add_response(


### PR DESCRIPTION
The underlying bug in the responses library has long since been fixed.