### PR TITLE
Update docs to suggest using static_fields to suppress descriptions

### DIFF
--- a/bugwarrior/docs/common_configuration.rst
+++ b/bugwarrior/docs/common_configuration.rst
@@ -42,7 +42,7 @@ Optional options include:
   ``True``.
 * ``static_fields``: A comma separated list of attributes that shouldn't be
   *updated* by bugwarrior.  Use for values that you want to tune manually.
-  Default: ``priority``.
+  Note that service-specific UDAs can be included here.  Default: ``priority``.
 
 In addition to the ``[general]`` section, sections may be named
 ``[flavor.myflavor]`` and may be selected using the ``--flavor`` option to

--- a/bugwarrior/docs/services/github.rst
+++ b/bugwarrior/docs/services/github.rst
@@ -160,7 +160,7 @@ Comments are synchronized as annotations.
 To limit the amount of content synchronized into TaskWarrior (which can help to avoid issues with synchronization), use
 
  * ``annotation_comments=False`` (a global configuration) to disable synchronizing comments to annotations; and
- * either ``github.body_length=0``` to disable synchronizing the Github Body UDA (or set it to a small value to limit size) or include ``githubbody`` in ``static_fields`` in the ``[general]`` section to eliminate the UDA entirely.
+ * either ``github.body_length``` to limit the size of the Github Body UDA or include ``githubbody`` in ``static_fields`` in the ``[general]`` section to eliminate the UDA entirely.
 
 Provided UDA Fields
 -------------------

--- a/bugwarrior/docs/services/github.rst
+++ b/bugwarrior/docs/services/github.rst
@@ -160,7 +160,7 @@ Comments are synchronized as annotations.
 To limit the amount of content synchronized into TaskWarrior (which can help to avoid issues with synchronization), use
 
  * ``annotation_comments=False`` (a global configuration) to disable synchronizing comments to annotations; and
- * ``github.body_length=0``` to disable synchronizing the Github Body UDA (or set it to a small value to limit size).
+ * either ``github.body_length=0``` to disable synchronizing the Github Body UDA (or set it to a small value to limit size) or include ``githubbody`` in ``static_fields`` in the ``[general]`` section to eliminate the UDA entirely.
 
 Provided UDA Fields
 -------------------

--- a/bugwarrior/docs/services/jira.rst
+++ b/bugwarrior/docs/services/jira.rst
@@ -136,7 +136,8 @@ Synchronizing Issue Content
 By default, this service synchronizes the description of the Jira issue as ``jiradescription``.
 In some cases, this is not required.
 It also risks triggering bugs in Taskwarrior around unicode encodings.
-Set ``jira.body_length=0``` to disable synchronizing the description (or set it to a small value to limit size).
+
+Set ``jira.body_length=0``` or include ``jiradescription`` in ``static_fields`` in the ``[general]`` section to disable synchronizing the description.
 
 When using API token
 ++++++++++++++++++++

--- a/bugwarrior/docs/services/jira.rst
+++ b/bugwarrior/docs/services/jira.rst
@@ -137,7 +137,7 @@ By default, this service synchronizes the description of the Jira issue as ``jir
 In some cases, this is not required.
 It also risks triggering bugs in Taskwarrior around unicode encodings.
 
-Set ``jira.body_length=0``` or include ``jiradescription`` in ``static_fields`` in the ``[general]`` section to disable synchronizing the description.
+Set ``jira.body_length``` to limit the size of the description UDA or include ``jiradescription`` in ``static_fields`` in the ``[general]`` section to eliminate the UDA entirely.
 
 When using API token
 ++++++++++++++++++++


### PR DESCRIPTION
This is simpler than setting `body_length=0`, and works for all
services.

Fixes #835 