### PR TITLE
Use abc's to enforce service consistency.

### DIFF
--- a/.github/workflows/bugwarrior.yml
+++ b/.github/workflows/bugwarrior.yml
@@ -45,7 +45,6 @@ jobs:
             pip install phabricator
             pip install codecov
             pip install pytest-cov
-            pip install nose
           run: |
             source $HOME/.cargo/env
             pip3 install .[jira,megaplan,activecollab,bts,bugzilla,trac,gmail,kanboard]

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from builtins import str
-from builtins import object
 
+import abc
 import copy
 import multiprocessing
 import time
@@ -41,7 +41,7 @@ def get_service(service_name):
     return epoint.load()
 
 
-class IssueService(object):
+class IssueService(abc.ABC):
     """ Abstract base class for each service """
     # Which class should this service instantiate for holding these issues?
     ISSUE_CLASS = None
@@ -163,6 +163,7 @@ class IssueService(object):
         return final
 
     @classmethod
+    @abc.abstractmethod
     def validate_config(cls, service_config, target):
         """ Validate generic options for a particular target """
         if service_config.has_option(target, 'only_if_assigned'):
@@ -198,6 +199,7 @@ class IssueService(object):
 
         return True
 
+    @abc.abstractmethod
     def get_owner(self, issue):
         """ Override this for filtering on tickets """
         raise NotImplementedError()
@@ -206,6 +208,7 @@ class IssueService(object):
         """ Override this for filtering on tickets """
         raise NotImplementedError()
 
+    @abc.abstractmethod
     def issues(self):
         """ Returns a list of dicts representing issues from a remote service.
 
@@ -241,8 +244,7 @@ class IssueService(object):
         raise NotImplementedError
 
 
-@six.python_2_unicode_compatible
-class Issue(object):
+class Issue(abc.ABC):
     # Set to a dictionary mapping UDA short names with type and long name.
     #
     # Example::
@@ -275,10 +277,12 @@ class Issue(object):
     def update_extra(self, extra):
         self._extra.update(extra)
 
+    @abc.abstractmethod
     def to_taskwarrior(self):
         """ Transform a foreign record into a taskwarrior dictionary."""
         raise NotImplementedError()
 
+    @abc.abstractmethod
     def get_default_description(self):
         """ Return the old-style verbose description from bugwarrior.
 
@@ -467,7 +471,7 @@ class Issue(object):
         return '<%s>' % str(self)
 
 
-class ServiceClient(object):
+class ServiceClient:
     """ Abstract class responsible for making requests to service API's. """
     @staticmethod
     def json_response(response):

--- a/bugwarrior/services/activecollab2.py
+++ b/bugwarrior/services/activecollab2.py
@@ -202,6 +202,11 @@ class ActiveCollab2Service(IssueService):
 
         super(ActiveCollab2Service, cls).validate_config(service_config, target)
 
+    def get_owner(self, issue):
+        # TODO
+        raise NotImplementedError(
+            "This service has not implemented support for 'only_if_assigned'.")
+
     def issues(self):
         # Loop through each project
         start = time.time()

--- a/bugwarrior/services/azuredevops.py
+++ b/bugwarrior/services/azuredevops.py
@@ -219,3 +219,7 @@ class AzureDevopsService(IssueService):
             if option not in service_config:
                 die(f"[{target}] has no 'ado.{option}'")
         super(AzureDevopsService, cls).validate_config(service_config, target)
+
+    def get_owner(self, issue):
+        # Issue filtering is implemented as part of issue aggregation.
+        pass

--- a/bugwarrior/services/bts.py
+++ b/bugwarrior/services/bts.py
@@ -127,6 +127,11 @@ class BTSService(IssueService, ServiceClient):
 
         IssueService.validate_config(service_config, target)
 
+    def get_owner(self, issue):
+        # TODO
+        raise NotImplementedError(
+            "This service has not implemented support for 'only_if_assigned'.")
+
     def _record_for_bug(self, bug):
         return {'number': bug.bug_num,
                 'url': 'https://bugs.debian.org/' + str(bug.bug_num),

--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -114,6 +114,11 @@ class GerritService(IssueService, ServiceClient):
 
         IssueService.validate_config(service_config, target)
 
+    def get_owner(self, issue):
+        # TODO
+        raise NotImplementedError(
+            "This service has not implemented support for 'only_if_assigned'.")
+
     def issues(self):
         # Construct the whole url by hand here, because otherwise requests will
         # percent-encode the ':' characters, which gerrit doesn't like.

--- a/bugwarrior/services/gmail.py
+++ b/bugwarrior/services/gmail.py
@@ -183,6 +183,15 @@ class GmailService(IssueService):
         issue_url = issue.get_processed_url(issue.extra['url'])
         return self.build_annotations([(sender, subj)], issue_url)
 
+    @classmethod
+    def validate_config(cls, service_config, target):
+        # There are no additional required fields.
+        super().validate_config(service_config, target)
+
+    def get_owner(self, issue):
+        raise NotImplementedError(
+            "This service has not implemented support for 'only_if_assigned'.")
+
     def issues(self):
         labels = self.get_labels()
         for thread in self.get_threads():

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -353,6 +353,11 @@ class JiraService(IssueService):
 
         IssueService.validate_config(service_config, target)
 
+    def get_owner(self, issue):
+        # TODO
+        raise NotImplementedError(
+            "This service has not implemented support for 'only_if_assigned'.")
+
     def body(self, issue):
         body = issue.record.get('fields', {}).get('description')
 

--- a/bugwarrior/services/kanboard.py
+++ b/bugwarrior/services/kanboard.py
@@ -162,6 +162,11 @@ class KanboardService(IssueService):
 
         IssueService.validate_config(service_config, target)
 
+    def get_owner(self, issue):
+        # TODO
+        raise NotImplementedError(
+            "This service has not implemented support for 'only_if_assigned'.")
+
     @staticmethod
     def get_keyring_service(service_config):
         parsed = urlparse(service_config.get("url"))

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -229,6 +229,15 @@ class PhabricatorService(IssueService):
             }
             yield self.get_issue_for_record(diff, extra)
 
+    @classmethod
+    def validate_config(cls, service_config, target):
+        # There are no additional required fields.
+        super().validate_config(service_config, target)
+
+    def get_owner(self, issue):
+        # Issue filtering is implemented as part of issue aggregation.
+        pass
+
     def issues(self):
         for issue in self.tasks():
             yield issue

--- a/bugwarrior/services/pivotaltracker.py
+++ b/bugwarrior/services/pivotaltracker.py
@@ -182,6 +182,10 @@ class PivotalTrackerService(IssueService, ServiceClient):
 
         super(PivotalTrackerService, cls).validate_config(service_config, target)
 
+    def get_owner(self, issue):
+        # Issue filtering is implemented as part of the api query.
+        pass
+
     def get_service_metadata(self):
         return {
             'import_labels_as_tags': self.import_labels_as_tags,

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -267,6 +267,10 @@ class RedMineService(IssueService):
 
         IssueService.validate_config(service_config, target)
 
+    def get_owner(self, issue):
+        # Issue filtering is implemented as part of the api query.
+        pass
+
     def issues(self):
         only_if_assigned = self.config.get('only_if_assigned', False)
         issues = self.client.find_issues(self.issue_limit, only_if_assigned)

--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -92,6 +92,11 @@ class TaigaService(IssueService, ServiceClient):
 
         IssueService.validate_config(service_config, target)
 
+    def get_owner(self, issue):
+        # TODO
+        raise NotImplementedError(
+            "This service has not implemented support for 'only_if_assigned'.")
+
     def _issues(self, userid, task_type, task_type_plural, task_type_short):
         log.debug('Getting %s' % task_type_plural)
 

--- a/bugwarrior/services/teamlab.py
+++ b/bugwarrior/services/teamlab.py
@@ -136,6 +136,11 @@ class TeamLabService(IssueService):
 
         IssueService.validate_config(service_config, target)
 
+    def get_owner(self, issue):
+        # TODO
+        raise NotImplementedError(
+            "This service has not implemented support for 'only_if_assigned'.")
+
     def issues(self):
         issues = self.client.get_task_list()
         log.debug(" Remote has %i total issues.", len(issues))

--- a/bugwarrior/services/teamwork_projects.py
+++ b/bugwarrior/services/teamwork_projects.py
@@ -151,8 +151,19 @@ class TeamworkService(IssueService):
                     text = comment["body"]
                     comment_list.append((author, text))
                 return self.build_annotations(comment_list, None)
-        return [] 
+        return []
 
+    @classmethod
+    def validate_config(cls, service_config, target):
+        for field in ['token', 'hosts']:
+            if field not in service_config:
+                die(f"[{target}] has no 'teamwork_projects.{field}'")
+        super().validate_config(service_config, target)
+
+    def get_owner(self, issue):
+        # TODO
+        raise NotImplementedError(
+            "This service has not implemented support for 'only_if_assigned'.")
 
     def issues(self):
         response = self.client.call_api("GET", "/tasks.json")#, data= { "responsible-party-ids": self.user_id })

--- a/bugwarrior/services/trello.py
+++ b/bugwarrior/services/trello.py
@@ -95,6 +95,10 @@ class TrelloService(IssueService, ServiceClient):
         check_key('token')
         check_key('api_key')
 
+    def get_owner(self, issue):
+        # Issue filtering is implemented as part of the api query.
+        pass
+
     @staticmethod
     def get_keyring_service(service_config):
         api_key = service_config.get('api_key')

--- a/bugwarrior/services/youtrack.py
+++ b/bugwarrior/services/youtrack.py
@@ -182,6 +182,11 @@ class YoutrackService(IssueService, ServiceClient):
 
         IssueService.validate_config(service_config, target)
 
+    def get_owner(self, issue):
+        # TODO
+        raise NotImplementedError(
+            "This service has not implemented support for 'only_if_assigned'.")
+
     def issues(self):
         params = {'filter': self.query, 'max': self.query_limit}
         resp = self.session.get(self.rest_url + '/issue', params=params)

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,4 +1,4 @@
-from builtins import object
+import abc
 import shutil
 import os.path
 import tempfile
@@ -12,12 +12,14 @@ from bugwarrior import config
 from bugwarrior.data import BugwarriorData
 
 
-class AbstractServiceTest(object):
+class AbstractServiceTest(abc.ABC):
     """ Ensures that certain test methods are implemented for each service. """
+    @abc.abstractmethod
     def test_to_taskwarrior(self):
         """ Test Service.to_taskwarrior(). """
         raise NotImplementedError
 
+    @abc.abstractmethod
     def test_issues(self):
         """
         Test Service.issues().

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -8,6 +8,32 @@ going to fill up your floppy disk taskwarrior backup. Actually it's not
 that long.""".replace('\n', ' ')
 
 
+class DumbIssue(services.Issue):
+    """
+    Implement the required methods but they shouldn't be called.
+    """
+    def get_default_description(self):
+        raise NotImplementedError
+
+    def to_taskwarrior(self):
+        raise NotImplementedError
+
+
+class DumbIssueService(services.IssueService):
+    """
+    Implement the required methods but they shouldn't be called.
+    """
+    def get_owner(self, issue):
+        raise NotImplementedError
+
+    def issues(self):
+        raise NotImplementedError
+
+    @classmethod
+    def validate_config(cls, service_config, target):
+        raise NotImplementedError
+
+
 class TestIssueService(unittest.TestCase):
     def setUp(self):
         super(TestIssueService, self).setUp()
@@ -15,7 +41,7 @@ class TestIssueService(unittest.TestCase):
         self.config.add_section('general')
 
     def test_build_annotations_default(self):
-        service = services.IssueService(self.config, 'general', 'test')
+        service = DumbIssueService(self.config, 'general', 'test')
 
         annotations = service.build_annotations(
             (('some_author', LONG_MESSAGE),), 'example.com')
@@ -25,7 +51,7 @@ class TestIssueService(unittest.TestCase):
 
     def test_build_annotations_limited(self):
         self.config.set('general', 'annotation_length', '20')
-        service = services.IssueService(self.config, 'general', 'test')
+        service = DumbIssueService(self.config, 'general', 'test')
 
         annotations = service.build_annotations(
             (('some_author', LONG_MESSAGE),), 'example.com')
@@ -34,7 +60,7 @@ class TestIssueService(unittest.TestCase):
 
     def test_build_annotations_limitless(self):
         self.config.set('general', 'annotation_length', '')
-        service = services.IssueService(self.config, 'general', 'test')
+        service = DumbIssueService(self.config, 'general', 'test')
 
         annotations = service.build_annotations(
             (('some_author', LONG_MESSAGE),), 'example.com')
@@ -49,8 +75,8 @@ class TestIssue(unittest.TestCase):
         self.config.add_section('general')
 
     def makeIssue(self):
-        service = services.IssueService(self.config, 'general', 'test')
-        service.ISSUE_CLASS = services.Issue
+        service = DumbIssueService(self.config, 'general', 'test')
+        service.ISSUE_CLASS = DumbIssue
         return service.get_issue_for_record(None)
 
     def test_build_default_description_default(self):

--- a/tests/test_string_compat.py
+++ b/tests/test_string_compat.py
@@ -1,7 +1,8 @@
 import unittest
 import six
 from unittest.mock import MagicMock
-from bugwarrior.services import Issue
+
+from .test_service import DumbIssue
 
 
 class StringCompatTest(unittest.TestCase):
@@ -15,7 +16,7 @@ implementation of __str__ and __repr__ methods"""
                   'default_priority': 'prio',
                   'templates': 'templates',
                   'add_tags': []}
-        issue = Issue(record, origin)
+        issue = DumbIssue(record, origin)
         issue.to_taskwarrior = MagicMock(return_value=record)
         issue.get_default_description = MagicMock(return_value='description')
         self.assertIsInstance(str(issue), six.string_types)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,6 +1,5 @@
-from bugwarrior.services import Issue
-
 from .base import ServiceTest
+from .test_service import DumbIssue
 
 
 class TestTemplates(ServiceTest):
@@ -25,7 +24,7 @@ class TestTemplates(ServiceTest):
             'add_tags': add_tags if add_tags else [],
         }
 
-        issue = Issue({}, origin)
+        issue = DumbIssue({}, origin)
         issue.to_taskwarrior = lambda: (
             self.arbitrary_issue if description is None else description
         )


### PR DESCRIPTION
As demonstrated by #838, we aren't doing a great job of ensuring new
services are fully implemented to spec. Using abstractmethod's in both
the base service and test classes is a step towards making this easier
for both maintainers and new service authors.