### PR TITLE
Use a bugwarrior mirror to generate documentation.

### DIFF
--- a/bugwarrior/README.rst
+++ b/bugwarrior/README.rst
@@ -32,8 +32,8 @@ It currently supports the following remote resources:
 Documentation
 -------------
 
-For information on how to install and use bugwarrior, read `the docs
-<https://bugwarrior.readthedocs.io>`_ on RTFD.
+For information on how to install and use bugwarrior, `read the docs
+<https://bugwarrior-docs.readthedocs.io>`_ on RTFD.
 
 Build Status
 ------------


### PR DESCRIPTION
Fix #812.

See <https://readthedocs.org/projects/bugwarrior/builds/>. I don't have
the permissions needed to set up the webhook integration currently used,
so I created a mirror of the repository at
<https://github.com/ryneeverett/bugwarrior-docs> and a corresponding
documentation site at <https://bugwarrior-docs.readthedocs.io>.