### PR TITLE
BugwarriorConfigParser default allow_no_value=True

### DIFF
--- a/bugwarrior/config.py
+++ b/bugwarrior/config.py
@@ -230,7 +230,7 @@ def fix_logging_path(config, main_section):
 
 
 def load_config(main_section, interactive=False):
-    config = BugwarriorConfigParser({'log.level': "INFO", 'log.file': None}, allow_no_value=True)
+    config = BugwarriorConfigParser({'log.level': "INFO", 'log.file': None})
     path = get_config_path()
     config.readfp(codecs.open(path, "r", "utf-8",))
     config.interactive = interactive
@@ -278,10 +278,13 @@ def get_data_path(config, main_section):
 
 # ConfigParser is not a new-style class, so inherit from object to fix super().
 class BugwarriorConfigParser(configparser.ConfigParser, object):
+    def __init__(self, *args, allow_no_value=True, **kwargs):
+        super().__init__(*args, allow_no_value=allow_no_value, **kwargs)
+
     def getint(self, section, option):
         """ Accepts both integers and empty values. """
         try:
-            return super(BugwarriorConfigParser, self).getint(section, option)
+            return super().getint(section, option)
         except ValueError:
             if self.get(section, option) == u'':
                 return None

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -3,12 +3,11 @@ from builtins import next
 from builtins import object
 from unittest import mock
 from collections import namedtuple
-from six.moves import configparser
 
+from bugwarrior.config import ServiceConfig, BugwarriorConfigParser
 from bugwarrior.services.bz import BugzillaService
 
 from .base import ConfigTest, ServiceTest, AbstractServiceTest
-from bugwarrior.config import ServiceConfig
 
 
 class FakeBugzillaLib(object):
@@ -24,7 +23,7 @@ class TestBugzillaServiceConfig(ConfigTest):
 
     def setUp(self):
         super(TestBugzillaServiceConfig, self).setUp()
-        self.config = configparser.RawConfigParser()
+        self.config = BugwarriorConfigParser()
         self.config.add_section('general')
         self.config.add_section('mybz')
         self.service_config = ServiceConfig(

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,5 +1,4 @@
 import os
-import configparser
 import logging
 from unittest import mock
 
@@ -7,6 +6,7 @@ from click.testing import CliRunner
 import pytest
 
 from bugwarrior import command
+from bugwarrior.config import BugwarriorConfigParser
 
 from .base import ConfigTest
 from .test_github import ARBITRARY_ISSUE, ARBITRARY_EXTRA
@@ -39,7 +39,7 @@ class TestPull(ConfigTest):
         super().setUp()
 
         self.runner = CliRunner()
-        self.config = configparser.RawConfigParser()
+        self.config = BugwarriorConfigParser()
 
         self.config.add_section('general')
         self.config.set('general', 'targets', 'my_service')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,8 @@
 # coding: utf-8
-from __future__ import unicode_literals
-
 import os
-from six.moves import configparser
 from unittest import TestCase
 
-import bugwarrior.config as config
+from bugwarrior import config
 
 from .base import ConfigTest
 
@@ -78,7 +75,7 @@ class TestGetDataPath(ConfigTest):
 
     def setUp(self):
         super(TestGetDataPath, self).setUp()
-        self.config = configparser.RawConfigParser()
+        self.config = config.BugwarriorConfigParser()
         self.config.add_section('general')
 
     def assertDataPath(self, expected_datapath):
@@ -182,7 +179,7 @@ class TestServiceConfig(TestCase):
 
 class TestLoggingPath(TestCase):
     def setUp(self):
-        self.config = config.BugwarriorConfigParser(allow_no_value=True)
+        self.config = config.BugwarriorConfigParser()
         self.config.add_section('general')
         self.config.set('general', 'log.level', 'INFO')
         self.config.set('general', 'log.file', None)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,6 +1,5 @@
 import os
 import json
-from six.moves import configparser
 
 from bugwarrior import data
 
@@ -10,8 +9,6 @@ from .base import ConfigTest
 class TestData(ConfigTest):
     def setUp(self):
         super(TestData, self).setUp()
-        config = configparser.RawConfigParser()
-        config.add_section('general')
         self.data = data.BugwarriorData(self.lists_path)
 
     def assert0600(self):

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -1,13 +1,9 @@
-from future import standard_library
-standard_library.install_aliases()
-from builtins import next
-from six.moves import configparser
 import datetime
 
 import pytz
 import responses
 
-from bugwarrior.config import ServiceConfig
+from bugwarrior.config import BugwarriorConfigParser, ServiceConfig
 from bugwarrior.services.gitlab import GitlabService
 
 from .base import ConfigTest, ServiceTest, AbstractServiceTest
@@ -17,7 +13,7 @@ class TestGitlabService(ConfigTest):
 
     def setUp(self):
         super(TestGitlabService, self).setUp()
-        self.config = configparser.RawConfigParser()
+        self.config = BugwarriorConfigParser()
         self.config.add_section('general')
         self.config.add_section('myservice')
         self.config.set('myservice', 'gitlab.login', 'foobar')

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -7,10 +7,9 @@ from unittest.mock import patch
 
 from dateutil.tz import tzutc
 from google.oauth2.credentials import Credentials
-from six.moves import configparser
 
-import bugwarrior.services.gmail as gmail
-from bugwarrior.config import ServiceConfig
+from bugwarrior.config import BugwarriorConfigParser, ServiceConfig
+from bugwarrior.services import gmail
 from bugwarrior.services.gmail import GmailService
 
 from .base import AbstractServiceTest, ConfigTest, ServiceTest
@@ -29,7 +28,7 @@ class TestGmailService(ConfigTest):
 
     def setUp(self):
         super(TestGmailService, self).setUp()
-        self.config = configparser.RawConfigParser()
+        self.config = BugwarriorConfigParser()
         self.config.add_section("general")
         self.config.add_section("myservice")
 

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -1,14 +1,12 @@
-from builtins import next
-from builtins import object
 from collections import namedtuple
 from unittest import mock, TestCase
-from six.moves.configparser import RawConfigParser
 
 from dateutil.tz import datetime
 from dateutil.tz.tz import tzutc
 
-from bugwarrior.config import ServiceConfig
+from bugwarrior.config import ServiceConfig, BugwarriorConfigParser
 from bugwarrior.services.jira import JiraService
+
 from .base import ServiceTest, AbstractServiceTest
 
 
@@ -27,7 +25,7 @@ class FakeJiraClient(object):
 class testJiraService(TestCase):
 
     def setUp(self):
-        self.config = RawConfigParser()
+        self.config = BugwarriorConfigParser()
         self.config.interactive = False
         self.config.add_section('general')
         self.config.add_section('myjira')

--- a/tests/test_kanboard.py
+++ b/tests/test_kanboard.py
@@ -1,10 +1,9 @@
-import configparser
 import datetime
 from unittest import mock
 
 from dateutil.tz.tz import tzutc
 
-from bugwarrior.config import ServiceConfig
+from bugwarrior.config import ServiceConfig, BugwarriorConfigParser
 from bugwarrior.services.kanboard import KanboardService
 
 from .base import AbstractServiceTest, ConfigTest, ServiceTest
@@ -13,7 +12,7 @@ from .base import AbstractServiceTest, ConfigTest, ServiceTest
 class TestKanboardServiceConfig(ConfigTest):
     def setUp(self):
         super().setUp()
-        self.config = configparser.RawConfigParser()
+        self.config = BugwarriorConfigParser()
         self.config.add_section("general")
         self.config.add_section("kb")
         self.service_config = ServiceConfig(

--- a/tests/test_pivotaltracker.py
+++ b/tests/test_pivotaltracker.py
@@ -1,14 +1,13 @@
 import datetime
-from dateutil.tz import tzutc
-from six.moves import configparser
 from unittest import mock
 
+from dateutil.tz import tzutc
 import responses
 
-from .base import ServiceTest, AbstractServiceTest, ConfigTest
-from bugwarrior.config import ServiceConfig
+from bugwarrior.config import BugwarriorConfigParser, ServiceConfig
 from bugwarrior.services.pivotaltracker import PivotalTrackerService
 
+from .base import ServiceTest, AbstractServiceTest, ConfigTest
 
 PROJECT = {
     'account_id': 100,
@@ -179,7 +178,7 @@ class TestPivotalTrackerServiceConfig(ConfigTest):
 
     def setUp(self):
         super(TestPivotalTrackerServiceConfig, self).setUp()
-        self.config = configparser.RawConfigParser()
+        self.config = BugwarriorConfigParser()
         self.config.add_section('general')
         self.config.add_section('pivotal')
         self.service_config = ServiceConfig(
@@ -187,7 +186,7 @@ class TestPivotalTrackerServiceConfig(ConfigTest):
 
     @mock.patch('bugwarrior.services.pivotaltracker.die')
     def test_validate_config(self, die):
-        self.config.set('pivotal', 'pivotaltracker.account_ids', [12345])
+        self.config.set('pivotal', 'pivotaltracker.account_ids', '12345')
         self.config.set('pivotal', 'pivotaltracker.user_id', '12345')
         self.config.set('pivotal', 'pivotaltracker.token', '12345')
         PivotalTrackerService.validate_config(self.service_config, 'pivotal')
@@ -202,21 +201,21 @@ class TestPivotalTrackerServiceConfig(ConfigTest):
 
     @mock.patch('bugwarrior.services.pivotaltracker.die')
     def test_validate_config_no_user_id(self, die):
-        self.config.set('pivotal', 'pivotaltracker.account_ids', [12345])
+        self.config.set('pivotal', 'pivotaltracker.account_ids', '12345')
         self.config.set('pivotal', 'pivotaltracker.token', '123')
         PivotalTrackerService.validate_config(self.service_config, 'pivotal')
         die.assert_called_with("[pivotal] has no 'pivotaltracker.user_id'")
 
     @mock.patch('bugwarrior.services.pivotaltracker.die')
     def test_validate_config_token(self, die):
-        self.config.set('pivotal', 'pivotaltracker.account_ids', [12345])
+        self.config.set('pivotal', 'pivotaltracker.account_ids', '12345')
         self.config.set('pivotal', 'pivotaltracker.user_id', '12345')
         PivotalTrackerService.validate_config(self.service_config, 'pivotal')
         die.assert_called_with("[pivotal] has no 'pivotaltracker.token'")
 
     @mock.patch('bugwarrior.services.pivotaltracker.die')
     def test_validate_config_invalid_endpoint(self, die):
-        self.config.set('pivotal', 'pivotaltracker.account_ids', [12345])
+        self.config.set('pivotal', 'pivotaltracker.account_ids', '12345')
         self.config.set('pivotal', 'pivotaltracker.token', '123')
         self.config.set('pivotal', 'pivotaltracker.user_id', '12345')
         self.config.set('pivotal', 'pivotaltracker.version', 'v1')

--- a/tests/test_trello.py
+++ b/tests/test_trello.py
@@ -1,17 +1,11 @@
-from __future__ import unicode_literals, print_function
-from future import standard_library
-standard_library.install_aliases()
-from builtins import next
 from unittest.mock import patch
 
-from six.moves import configparser
+from dateutil.parser import parse as parse_date
 import responses
 
-from dateutil.parser import parse as parse_date
-from dateutil.tz import tzlocal
-
-from bugwarrior.config import ServiceConfig
+from bugwarrior.config import ServiceConfig, BugwarriorConfigParser
 from bugwarrior.services.trello import TrelloService, TrelloIssue
+
 from .base import ConfigTest, ServiceTest
 
 
@@ -71,7 +65,7 @@ class TestTrelloService(ConfigTest):
 
     def setUp(self):
         super(TestTrelloService, self).setUp()
-        self.config = configparser.RawConfigParser()
+        self.config = BugwarriorConfigParser()
         self.config.add_section('general')
         self.config.add_section('mytrello')
         self.config.set('mytrello', 'trello.api_key', 'XXXX')

--- a/tests/test_youtrak.py
+++ b/tests/test_youtrak.py
@@ -1,10 +1,6 @@
-from future import standard_library
-standard_library.install_aliases()
-from builtins import next
-from six.moves import configparser
 import responses
 
-from bugwarrior.services import ServiceConfig
+from bugwarrior.config import ServiceConfig, BugwarriorConfigParser
 from bugwarrior.services.youtrack import YoutrackService
 
 from .base import ConfigTest, ServiceTest, AbstractServiceTest
@@ -13,7 +9,7 @@ from .base import ConfigTest, ServiceTest, AbstractServiceTest
 class TestYoutrackService(ConfigTest):
     def setUp(self):
         super(TestYoutrackService, self).setUp()
-        self.config = configparser.RawConfigParser()
+        self.config = BugwarriorConfigParser()
         self.config.add_section('general')
         self.config.add_section('myservice')
         self.config.set('myservice', 'youtrack.login', 'foobar')


### PR DESCRIPTION
By moving the flag into the class itself we ensure we're using it in
tests.

In the case of pivotaltracker, I found that six.moves.configparser
actually behaves differently -- the real configparser throws an
exception if you try to set a non-string value.

I took the opportunity to clean up and normalize imports in the test
files I was already messing with.