### PR TITLE
Fix traceback when enabling notifications

### DIFF
--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -495,7 +495,7 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
         updates = (len(issue_updates['new']) +
                    len(issue_updates['changed']) +
                    len(issue_updates['closed']))
-        if not main_config.notifications.only_on_new_tasks or updates > 0:
+        if not conf['notifications'].only_on_new_tasks or updates > 0:
             send_notification(
                 dict(
                     description="New: %d, Changed: %d, Completed: %d" % (

--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -505,7 +505,7 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
                     )
                 ),
                 'bw_finished',
-                conf['notificatons'],
+                conf['notifications'],
             )
 
 


### PR DESCRIPTION
Commit 1cbbcb6 introduced a regression that causes a traceback when
enabling notifications.

Fix #864