### PR TITLE
Update development environment installation.

### DIFF
--- a/.github/workflows/bugwarrior.yml
+++ b/.github/workflows/bugwarrior.yml
@@ -39,15 +39,11 @@ jobs:
               libffi-dev libssl-dev pandoc python3-pip taskwarrior
             task --version
             pip3 install --upgrade pip
-            pip install taskw
-            pip install responses
-            pip install PySimpleSOAP
-            pip install phabricator
             pip install codecov
             pip install pytest-cov
           run: |
             source $HOME/.cargo/env
-            pip3 install .[jira,activecollab,bts,bugzilla,trac,gmail,kanboard]
+            pip3 install .[all]
             pytest --cov=bugwarrior --cov-branch tests
       - name: Coverage
         uses: codecov/codecov-action@v1

--- a/bugwarrior/docs/contributing.rst
+++ b/bugwarrior/docs/contributing.rst
@@ -36,7 +36,7 @@ Next step -- get the code!
 
     (bugwarrior)$ git clone git@github.com:ralphbean/bugwarrior.git
     (bugwarrior)$ cd bugwarrior
-    (bugwarrior)$ python setup.py develop
+    (bugwarrior)$ pip install -e .[all]
     (bugwarrior)$ which bugwarrior-pull
 
 This will actually run it.. be careful and back up your task directory!

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import itertools
 from setuptools import setup, find_packages
 
 version = '1.8.0'
@@ -6,6 +7,19 @@ f = open('bugwarrior/README.rst')
 long_description = f.read().strip()
 long_description = long_description.split('split here', 1)[1]
 f.close()
+
+extras = {
+    "activecollab": ["pypandoc", "pyac>=0.1.5"],
+    "bts": ["PySimpleSOAP", "python-debianbts>=2.6.1"],
+    "bugzilla": ["python-bugzilla>=2.0.0"],
+    "gmail": ["google-api-python-client", "google-auth-oauthlib"],
+    "jira": ["jira>=0.22"],
+    "kanboard": ["kanboard"],
+    "keyring": ["keyring"],
+    "phabricator": ["phabricator"],
+    "test": ["pytest", "responses"],
+    "trac": ["offtrac"],
+}
 
 setup(name='bugwarrior',
       version=version,
@@ -43,28 +57,10 @@ setup(name='bugwarrior',
           "typing-extensions",
       ],
       extras_require={
-          "activecollab": ["pypandoc", "pyac>=0.1.5"],
-          "bts": ["PySimpleSOAP", "python-debianbts>=2.6.1"],
-          "bugzilla": ["python-bugzilla>=2.0.0"],
-          "gmail": ["google-api-python-client", "google-auth-oauthlib"],
-          "jira": ["jira>=0.22"],
-          "kanboard": ["kanboard"],
-          "keyring": ["keyring"],
-          "phabricator": ["phabricator"],
-          "trac": ["offtrac"],
+          'all': list(
+              itertools.chain.from_iterable(extras[key] for key in extras)),
+          **extras
       },
-      tests_require=[
-          "pytest",
-          "responses",
-          "bugwarrior[jira]",
-          "bugwarrior[activecollab]",
-          "bugwarrior[bts]",
-          "bugwarrior[gmail]",
-          "bugwarrior[trac]",
-          "bugwarrior[bugzilla]",
-          "bugwarrior[phabricator]",
-          "bugwarrior[kanboard]",
-      ],
       entry_points="""
       [console_scripts]
       bugwarrior-pull = bugwarrior:pull


### PR DESCRIPTION
- Running setup.py directly is out of favor where `pip install -e .`
  seems to be preferred.
- Add an `all` extra to simplify development environment installation.
- Move `tests_require` into a `tests` extra. Now that `python setup.py
  test` is deprecated `tests_require` seems to be largely abandoned as
  well.