### PR TITLE
notifications: allow empty priority

### DIFF
--- a/bugwarrior/notifications.py
+++ b/bugwarrior/notifications.py
@@ -32,7 +32,7 @@ def _get_metadata(issue):
     #         int(issue['due'])).strftime('%Y-%m-%d')
     if 'tags' in issue:
         tags = "Tags: " + ', '.join(issue['tags'])
-    if 'priority' in issue:
+    if 'priority' in issue and issue['priority']:
         priority = "Priority: " + issue['priority']
     if project != '':
         metadata += "\n" + project


### PR DESCRIPTION
I'm working towards having empty priorities for tasks. This doesn't work out-of-the-box with the current development branch, but that's another story. I had this change lying around locally for a while and I actually think, that would make sense to merge upstream.

As for taskwarrior a priority can be `None` it makes sense to also allow this here. However, concatenating strings and NoneType fails. Alternatively to my solution we could use:

```
    if 'priority' in issue:
        priority = "Priority: " + str(issue['priority'])
```

which would result in a `Priority: None` output instead.