### PR TITLE
Allow custom query strings for gitlab config

### DIFF
--- a/bugwarrior/docs/services/gitlab.rst
+++ b/bugwarrior/docs/services/gitlab.rst
@@ -173,6 +173,33 @@ you can configure individual priorities for each::
     gitlab.default_todo_priority = M
     gitlab.default_mr_priority = H
 
+
+Custom query strings
+++++++++++++++++++++
+
+The Gitlab REST API allows many more configuration options than the ones provided
+by the options explained above. If you want to further customize calls, you can set for example::
+
+    gitlab.issue_query = issues?search=foo&in=title
+    gitlab.merge_request_query = merge_requests?state=opened&scope=all&reviewer_username=myusername
+    gitlab.todo_query = todos?state=pending&action=directly_addressed
+
+
+These can be combined with the other configuration options above, but queries are only evaluated if
+the respective category (issue, merge_request, todo) is enabled.
+
+Note: Depending in the scope you are interested in, this query-based approach can be much faster
+than using the "default queries". For example, imagine that you want to query all issues assigned
+to your user.
+
+This can be achieved by leaving the ``gitlab.include_repos`` configuration value empty and
+setting ``gitlab.only_assigned`` to ``True``. This will result in querying all repos your user has
+access to, which might take a very long time.
+
+Alternatively, you could set ``gitlab.issue_query =
+issues?assignee_username=myusername&state=opened&scope=all``, which will fetch the assigned issues
+first and then only fetch the projects for which issues have been found.
+
 Use HTTP
 ++++++++
 

--- a/bugwarrior/docs/services/gitlab.rst
+++ b/bugwarrior/docs/services/gitlab.rst
@@ -133,6 +133,13 @@ to all fields on the Taskwarrior task if needed.
    See :ref:`field_templates` for more details regarding how templates
    are processed.
 
+Include Issues
+++++++++++++++
+
+Issues are included by default, if not configured otherwise. To disable querying of issues, set::
+
+    gitlab.include_issues = False
+
 Include Merge Requests
 ++++++++++++++++++++++
 

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -805,22 +805,12 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
     @responses.activate
     def test_mrs_from_query(self):
         overrides = {
+            'gitlab.include_issues': 'false',
             'gitlab.include_todos': 'false',
             'gitlab.filter_merge_requests': 'true',
             'gitlab.merge_request_query': 'merge_requests?state=opened'
         }
         service = self.get_mock_service(GitlabService, config_overrides=overrides)
-        self.add_response(
-                'https://my-git.org/api/v4/projects?simple=True&page=1&per_page=100',
-                json=[{
-                    'id': 8,
-                    'path': 'arbitrary_username/project',
-                    'web_url': 'example.com',
-                    "namespace": {
-                        "full_path": "arbitrary_username"
-                    },
-                    'path_with_namespace': 'arbitrary_username/project'
-                }])
         self.add_response(
             'https://my-git.org/api/v4/merge_requests?state=opened&per_page=100&page=1',
             json=[self.data.arbitrary_mr])
@@ -875,22 +865,12 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
     @responses.activate
     def test_todos_from_query(self):
         overrides = {
+            'gitlab.include_issues': 'false',
             'gitlab.filter_merge_requests': 'false',
             'gitlab.include_todos': 'true',
             'gitlab.todo_query': 'todos?state=pending'
         }
         service = self.get_mock_service(GitlabService, config_overrides=overrides)
-        self.add_response(
-                'https://my-git.org/api/v4/projects?simple=True&page=1&per_page=100',
-                json=[{
-                    'id': 8,
-                    'path': 'arbitrary_username/project',
-                    'web_url': 'example.com',
-                    "namespace": {
-                        "full_path": "arbitrary_username"
-                    },
-                    'path_with_namespace': 'arbitrary_username/project'
-                }])
         self.add_response(
             'https://my-git.org/api/v4/todos?state=pending&per_page=100&page=1',
             json=[self.data.arbitrary_todo])
@@ -947,6 +927,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
         self.assertEqual(todo.get_taskwarrior_record(), expected)
 
         overrides = {
+            'gitlab.include_issues': 'false',
             'gitlab.filter_merge_requests': 'false',
             'gitlab.include_todos': 'true',
             'gitlab.include_repos': 'arbitrary_namespace/project',

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -321,7 +321,7 @@ class TestGitlabClient(ServiceTest):
         self.add_response(
             'https://my-git.org/api/v4/projects/8',
             json=self.data.arbitrary_project)
-        result = self.client.get_repo(repo_id=8)
+        result = self.client.get_repo_cached(repo_id=8)
         self.assertEqual(result, self.data.arbitrary_project)
 
     @responses.activate


### PR DESCRIPTION
Ever since I started using bugwarrior, using it for our gitlab instance felt suboptimal. Especially since I started using github more and more I discovered the custom search strings for the gitlab service.

This PR aims at providing similar functionality for the Gitlab service.

To motivate my use case a bit more: I wanted to have all issues that are assigned to me on our gitlab instance in my bugwarrior syncs. Unfortunately I can see quite a lot of projects inside that gitlab instance and since filtering by assignee happens **after** every issue from every project is pulled, this took more than half an hour for me.

This is somehow related to #593 but takes a different approach at a similar problem.

While implementing the tests I noticed that the tasks created for ToDos are quite different in some places. I separated the fields that were surprising to me in 5ed972c. Since I copied the ToDo extraction from the existing implementation and adapted it only a little, I assume this is not related to something I implemented.
I noticed that yielding of merge_request and todo items is currently not covered by the tests at all, so this might be something worth fixing at another point. I also might be completely wrong, though.

Being a maintainer of one or two projects myself I know that larger refactory suggestions from external users can feel intrusive. However, I hope I made my motivation clear and my contribution is more than just a code dump in "works for me" quality.

I am also aware, that there are things missing, such as config documentation for this new feature, hence the draft status.

---

**Edit**: Looking back at the todo implementation, it is quite obvious that many of the unexpected task fields are directly hard coded in the code I copied. So, in order to keep things from diverging further I think it would not make sense to change the implementation (at least not my implementation only). It might, however, make sense to call my new function for yielding todos from the `issue` method in case of keeping the code duplication. (**Edit2**: Did in 139abdd)