### PR TITLE
gitlab: Correct filter_merge_requests behavior

### DIFF
--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -680,7 +680,7 @@ class GitlabService(IssueService):
             yield from self._get_issue_objs(issues_filtered, 'issue')
 
         # Merge requests
-        if self.config.filter_merge_requests:
+        if not self.config.filter_merge_requests:
             if self.config.merge_request_query:
                 merge_requests = self.gitlab_client.get_issues_from_query(
                     self.config.merge_request_query)

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -807,7 +807,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
         overrides = {
             'gitlab.include_issues': 'false',
             'gitlab.include_todos': 'false',
-            'gitlab.filter_merge_requests': 'true',
+            'gitlab.filter_merge_requests': 'false',
             'gitlab.merge_request_query': 'merge_requests?state=opened'
         }
         service = self.get_mock_service(GitlabService, config_overrides=overrides)
@@ -866,7 +866,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
     def test_todos_from_query(self):
         overrides = {
             'gitlab.include_issues': 'false',
-            'gitlab.filter_merge_requests': 'false',
+            'gitlab.filter_merge_requests': 'true',
             'gitlab.include_todos': 'true',
             'gitlab.todo_query': 'todos?state=pending'
         }
@@ -928,7 +928,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
 
         overrides = {
             'gitlab.include_issues': 'false',
-            'gitlab.filter_merge_requests': 'false',
+            'gitlab.filter_merge_requests': 'true',
             'gitlab.include_todos': 'true',
             'gitlab.include_repos': 'arbitrary_namespace/project',
             'gitlab.include_all_todos': 'false'


### PR DESCRIPTION
This was accidentally reversed in #876. Unsurprising since this
setting is confusingly named (#315).