### PR TITLE
filter_merge_requests -> ! include_merge_requests

### DIFF
--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -313,3 +313,17 @@ class ServiceConfig(_ServiceConfig,  # type: ignore  # (dynamic base class)
         typing_extensions.Literal['L', 'M', 'H']] = 'M'
     add_tags: ConfigList = ConfigList([])
     description_template: str = ''
+
+    @pydantic.root_validator
+    def deprecate_filter_merge_requests(cls, values):
+        if hasattr(cls, '_DEPRECATE_FILTER_MERGE_REQUESTS'):
+            if values['filter_merge_requests'] != 'Undefined':
+                if values['include_merge_requests'] != 'Undefined':
+                    raise ValueError(
+                        'filter_merge_requests and include_merge_requests are incompatible.')
+                values['include_merge_requests'] = not values['filter_merge_requests']
+                log.warning(
+                    'filter_merge_requests is deprecated in favor of include_merge_requests')
+            elif values['include_merge_requests'] == 'Undefined':
+                values['include_merge_requests'] = True
+        return values

--- a/bugwarrior/docs/services/bitbucket.rst
+++ b/bugwarrior/docs/services/bitbucket.rst
@@ -63,14 +63,13 @@ In this example, ``noisy_repository`` is the repository you would
 Please note that the API returns all lowercase names regardless of
 the case of the repository in the web interface.
 
-Filter Merge Requests
-+++++++++++++++++++++
+Include Merge Requests
+++++++++++++++++++++++
 
-Although you can filter issues using :ref:`common_configuration_options`,
-pull requests are not filtered by default.  You can filter pull requests
-by adding the following configuration option::
+Merge requests are included by default. You can exclude them by disabling
+this feature::
 
-    bitbucket.filter_merge_requests = True
+    bitbucket.include_merge_requests = False
 
 Project Owner Prefix
 ++++++++++++++++++++

--- a/bugwarrior/docs/services/gitlab.rst
+++ b/bugwarrior/docs/services/gitlab.rst
@@ -143,11 +143,10 @@ Issues are included by default, if not configured otherwise. To disable querying
 Include Merge Requests
 ++++++++++++++++++++++
 
-Although you can filter issues using :ref:`common_configuration_options`,
-merge requests are not filtered by default.  You can filter merge requests
-by adding the following configuration option::
+Merge requests are included by default. You can exclude them by disabling
+this feature::
 
-    gitlab.filter_merge_requests = True
+    bitbucket.include_merge_requests = False
 
 Include Todo Items
 ++++++++++++++++++

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -1,14 +1,19 @@
+import logging
+import typing
+
 import requests
 import typing_extensions
 
 from bugwarrior import config
 from bugwarrior.services import IssueService, Issue, ServiceClient
 
-import logging
 log = logging.getLogger(__name__)
 
 
 class BitbucketConfig(config.ServiceConfig, prefix='bitbucket'):
+    _DEPRECATE_FILTER_MERGE_REQUESTS = True
+    filter_merge_requests: typing.Union[bool, typing_extensions.Literal['Undefined']] = 'Undefined'
+
     service: typing_extensions.Literal['bitbucket']
 
     username: str
@@ -20,7 +25,7 @@ class BitbucketConfig(config.ServiceConfig, prefix='bitbucket'):
 
     include_repos: config.ConfigList = config.ConfigList([])
     exclude_repos: config.ConfigList = config.ConfigList([])
-    filter_merge_requests: bool = False
+    include_merge_requests: typing.Union[bool, typing_extensions.Literal['Undefined']] = 'Undefined'
     project_owner_prefix: bool = False
 
 
@@ -211,7 +216,7 @@ class BitbucketService(IssueService, ServiceClient):
             issue_obj.update_extra(extras)
             yield issue_obj
 
-        if not self.config.filter_merge_requests:
+        if self.config.include_merge_requests:
             pull_requests = sum(
                 (self.fetch_pull_requests(repo) for repo in repo_tags), [])
             log.debug(" Found %i total.", len(pull_requests))

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -19,6 +19,9 @@ DefaultPriority = typing.Optional[
 
 
 class GitlabConfig(config.ServiceConfig, prefix='gitlab'):
+    _DEPRECATE_FILTER_MERGE_REQUESTS = True
+    filter_merge_requests: typing.Union[bool, typing_extensions.Literal['Undefined']] = 'Undefined'
+
     service: typing_extensions.Literal['gitlab']
     login: str
     token: str
@@ -32,7 +35,7 @@ class GitlabConfig(config.ServiceConfig, prefix='gitlab'):
     owned: bool = False
     import_labels_as_tags: bool = False
     label_template: str = '{{label}}'
-    filter_merge_requests: bool = False
+    include_merge_requests: typing.Union[bool, typing_extensions.Literal['Undefined']] = 'Undefined'
     include_issues: bool = True
     include_todos: bool = False
     include_all_todos: bool = True
@@ -680,7 +683,7 @@ class GitlabService(IssueService):
             yield from self._get_issue_objs(issues_filtered, 'issue')
 
         # Merge requests
-        if not self.config.filter_merge_requests:
+        if self.config.include_merge_requests:
             if self.config.merge_request_query:
                 merge_requests = self.gitlab_client.get_issues_from_query(
                     self.config.merge_request_query)

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -807,7 +807,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
         overrides = {
             'gitlab.include_issues': 'false',
             'gitlab.include_todos': 'false',
-            'gitlab.filter_merge_requests': 'false',
+            'gitlab.include_merge_requests': 'true',
             'gitlab.merge_request_query': 'merge_requests?state=opened'
         }
         service = self.get_mock_service(GitlabService, config_overrides=overrides)
@@ -866,7 +866,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
     def test_todos_from_query(self):
         overrides = {
             'gitlab.include_issues': 'false',
-            'gitlab.filter_merge_requests': 'true',
+            'gitlab.include_merge_requests': 'false',
             'gitlab.include_todos': 'true',
             'gitlab.todo_query': 'todos?state=pending'
         }
@@ -928,7 +928,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
 
         overrides = {
             'gitlab.include_issues': 'false',
-            'gitlab.filter_merge_requests': 'true',
+            'gitlab.include_merge_requests': 'false',
             'gitlab.include_todos': 'true',
             'gitlab.include_repos': 'arbitrary_namespace/project',
             'gitlab.include_all_todos': 'false'


### PR DESCRIPTION
Deprecate the confusing and inconsistent filter_merge_requests options
in gitlab and bitbucket in favor of an inverse include_merge_requests
field.

Fix #315. I've basically implemented @mathstuf's suggestion.

cc @fmauch 