### PR TITLE
github: fetch assigned issues from all repos

### DIFF
--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -93,11 +93,11 @@ class GithubClient(ServiceClient):
     def get_directly_assigned_issues(self):
         """ Returns all issues assigned to authenticated user.
 
-        This will return all issues assigned to the authenticated user
-        regardless of whether the user owns the repositories in which the
-        issues exist.
+        List issues assigned to the authenticated user across all visible
+        repositories including owned repositories, member repositories, and
+        organization repositories.
         """
-        url = self._api_url("/user/issues?per_page=100")
+        url = self._api_url("/issues?per_page=100")
         return self._getter(url)
 
     def get_comments(self, username, repo, number):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -114,7 +114,7 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
             json=[ARBITRARY_ISSUE])
 
         self.add_response(
-            'https://api.github.com/user/issues?per_page=100',
+            'https://api.github.com/issues?per_page=100',
             json=[ARBITRARY_ISSUE])
 
         self.add_response(


### PR DESCRIPTION
Fix #375.

I'm guessing the semantics of this api endpoint have changed since we started
using it as a lot of these different repository management schemes didn't yet
exist.

Per the documentation for the relevant "/user/issues" api assigned issues will
only be pulled if you are the owner or a member.
<https://docs.github.com/en/rest/reference/issues#list-user-account-issues-assigned-to-the-authenticated-user>

The "/issues" api broadens this to include all "visible" issues, which I would
assume includes all public repositories. I believe the documentation is
unclear on this simply because they primarily have the enterprise user
in mind, for which public repos are irrelevant.
<https://docs.github.com/en/rest/reference/issues#list-user-account-issues-assigned-to-the-authenticated-user>