### PR TITLE
Allow empty default_priority. Resolve #426.

### DIFF
--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -308,9 +308,7 @@ class ServiceConfig(_ServiceConfig,  # type: ignore  # (dynamic base class)
     # Optional fields shared by all services.
     only_if_assigned: str = ''
     also_unassigned: bool = False
-    # Although upstream supports it, pydantic has problems with Literal[None].
-    default_priority: typing.Optional[
-        typing_extensions.Literal['L', 'M', 'H']] = 'M'
+    default_priority: typing_extensions.Literal['', 'L', 'M', 'H'] = 'M'
     add_tags: ConfigList = ConfigList([])
     description_template: str = ''
 

--- a/bugwarrior/docs/common_configuration.rst
+++ b/bugwarrior/docs/common_configuration.rst
@@ -70,7 +70,7 @@ The following options are supported:
 * ``SERVICE.also_unassigned``: If set to ``True`` and ``only_if_assigned`` is
   set, then also create tasks for issues that are not assigned to anybody.
   Defaults to ``False``.
-* ``SERVICE.default_priority``: Assign this priority ('L', 'M', or 'H') to
+* ``SERVICE.default_priority``: Assign this priority ('L', 'M', 'H', or '') to
   newly-imported issues. Defaults to ``M``.
 * ``SERVICE.add_tags``: A comma-separated list of tags to add to an issue.  In
   most cases, plain strings will suffice, but you can also specify

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -13,9 +13,7 @@ from bugwarrior.services import IssueService, Issue, ServiceClient
 import logging
 log = logging.getLogger(__name__)
 
-# Although upstream supports it, pydantic has problems with Literal[None].
-DefaultPriority = typing.Optional[
-    typing_extensions.Literal['L', 'M', 'H', 'unassigned']]
+DefaultPriority = typing_extensions.Literal['', 'L', 'M', 'H', 'unassigned']
 
 
 class GitlabConfig(config.ServiceConfig, prefix='gitlab'):
@@ -40,9 +38,9 @@ class GitlabConfig(config.ServiceConfig, prefix='gitlab'):
     include_todos: bool = False
     include_all_todos: bool = True
     only_if_author: str = ''
-    default_issue_priority: DefaultPriority = 'M'
-    default_todo_priority: DefaultPriority = 'M'
-    default_mr_priority: DefaultPriority = 'M'
+    default_issue_priority: DefaultPriority = 'unassigned'
+    default_todo_priority: DefaultPriority = 'unassigned'
+    default_mr_priority: DefaultPriority = 'unassigned'
     use_https: bool = True
     verify_ssl: bool = True
     project_owner_prefix: bool = False

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -671,7 +671,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
 
     def test_custom_mr_priority(self):
         overrides = {
-            'gitlab.default_mr_priority': None,
+            'gitlab.default_mr_priority': '',
             'gitlab.import_labels_as_tags': True,
         }
         service = self.get_mock_service(GitlabService, config_overrides=overrides)


### PR DESCRIPTION
Contrary to my apparent previous assumptions, configparser returns an
empty string rather than None when encountering an empty assignment,
making this a fairly trivial solution.