### PR TITLE
Fix priority property from redmine issues

### DIFF
--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -203,7 +203,7 @@ class RedMineIssue(Issue):
 
     def get_priority(self):
         return self.PRIORITY_MAP.get(
-            self.record.get('priority', {}).get('Name'),
+            self.record.get('priority', {}).get('name'),
             self.origin['default_priority']
         )
 

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -37,7 +37,7 @@ class TestRedmineIssue(AbstractServiceTest, ServiceTest):
         "id": 363901,
         "priority": {
             "id": 4,
-            "name": "Normal"
+            "name": "High"
         },
         "project": {
             "id": 27375,
@@ -67,7 +67,7 @@ class TestRedmineIssue(AbstractServiceTest, ServiceTest):
         expected_output = {
             'annotations': [],
             'project': issue.get_project_name(),
-            'priority': self.service.config.default_priority,
+            'priority': 'H',
             issue.DUEDATE: None,
             issue.ASSIGNED_TO: self.arbitrary_issue['assigned_to']['name'],
             issue.AUTHOR: self.arbitrary_issue['author']['name'],
@@ -107,7 +107,7 @@ class TestRedmineIssue(AbstractServiceTest, ServiceTest):
             issue.DUEDATE: None,
             'description':
                 '(bw)Is#363901 - Biscuits .. https://something/issues/363901',
-            'priority': 'M',
+            'priority': 'H',
             'project': 'boiledcabbageyum',
             'redmineid': 363901,
             'redmineprojectname': 'Boiled Cabbage - Yum',


### PR DESCRIPTION
Priorities could not be pulled from a redmine server until I lowercased the `name` property.
I then changed to a non-default priority in tests to ensure the result is as expected.