### PR TITLE
Merge the union of tags.

### DIFF
--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -337,31 +337,37 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
                 continue
             else:
                 raise
+
+        # We received this issue from The Internet, but we're not sure what
+        # kind of encoding the service providers may have handed us. Let's try
+        # and decode all byte strings from UTF8 off the bat.  If we encounter
+        # other encodings in the wild in the future, we can revise the handling
+        # here. https://github.com/ralphbean/bugwarrior/issues/350
+        for key in issue_dict.keys():
+            if isinstance(issue_dict[key], bytes):
+                try:
+                    issue_dict[key] = issue_dict[key].decode('utf-8')
+                except UnicodeDecodeError:
+                    log.warn("Failed to interpret %r as utf-8" % key)
+
+        # Blank priority should mean *no* priority
+        if issue_dict['priority'] == '':
+            issue_dict['priority'] = None
+
+        # De-duplicate issues coming in
+        unique_identifier = make_unique_identifier(key_list, issue)
+        if unique_identifier in seen:
+            log.debug("Skipping.  Seen %s of %r" % (unique_identifier, issue))
+            continue
+        seen.append(unique_identifier)
+
         try:
-            # We received this issue from The Internet, but we're not sure what
-            # kind of encoding the service providers may have handed us. Let's try
-            # and decode all byte strings from UTF8 off the bat.  If we encounter
-            # other encodings in the wild in the future, we can revise the handling
-            # here. https://github.com/ralphbean/bugwarrior/issues/350
-            for key in issue_dict.keys():
-                if isinstance(issue_dict[key], bytes):
-                    try:
-                        issue_dict[key] = issue_dict[key].decode('utf-8')
-                    except UnicodeDecodeError:
-                        log.warn("Failed to interpret %r as utf-8" % key)
-
-            # Blank priority should mean *no* priority
-            if issue_dict['priority'] == '':
-                issue_dict['priority'] = None
-
-            # De-duplicate issues coming in
-            unique_identifier = make_unique_identifier(key_list, issue)
-            if unique_identifier in seen:
-                log.debug("Skipping.  Seen %s of %r" % (unique_identifier, issue))
-                continue
-            seen.append(unique_identifier)
-
             existing_taskwarrior_uuid = find_taskwarrior_uuid(tw, key_list, issue)
+        except MultipleMatches as e:
+            log.exception("Multiple matches: %s", str(e))
+        except NotFound:  # Create new task
+            issue_updates['new'].append(issue_dict)
+        else:  # Update existing task.
             seen_uuids.add(existing_taskwarrior_uuid)
             _, task = tw.get_task(uuid=existing_taskwarrior_uuid)
 
@@ -395,11 +401,6 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
                 issue_updates['changed'].append(task)
             else:
                 issue_updates['existing'].append(task)
-
-        except MultipleMatches as e:
-            log.exception("Multiple matches: %s", str(e))
-        except NotFound:
-            issue_updates['new'].append(issue_dict)
 
     notreally = ' (not really)' if dry_run else ''
     # Add new issues

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -81,7 +81,7 @@ class TestSynchronize(ConfigTest):
                     del task['modified']
                     del task['entry']
                     del task['uuid']
-
+                    task['tags'] = sorted(task['tags'])
             return tasks
 
         def get_tasks(tw):
@@ -108,7 +108,10 @@ class TestSynchronize(ConfigTest):
             'githubtype': 'issue',
             'githuburl': 'https://example.com',
             'priority': 'M',
+            'tags': ['foo'],
         }
+        duplicate_issue = copy.deepcopy(issue)
+        duplicate_issue['tags'] = ['bar']
 
         # TEST NEW ISSUE AND EXISTING ISSUE.
         for _ in range(2):
@@ -116,7 +119,7 @@ class TestSynchronize(ConfigTest):
             # These should be de-duplicated in db.synchronize before
             # writing out to taskwarrior.
             # https://github.com/ralphbean/bugwarrior/issues/601
-            issue_generator = iter((issue, issue,))
+            issue_generator = iter((issue, duplicate_issue,))
             db.synchronize(issue_generator, bwconfig, 'general')
 
             self.assertEqual(get_tasks(tw), {
@@ -129,7 +132,8 @@ class TestSynchronize(ConfigTest):
                     'githuburl': 'https://example.com',
                     'githubtype': 'issue',
                     'id': 1,
-                    'urgency': 4.9,
+                    'tags': ['bar', 'foo'],
+                    'urgency': 5.8,
                 }]})
 
         # TEST CHANGED ISSUE.
@@ -150,7 +154,8 @@ class TestSynchronize(ConfigTest):
                 'githuburl': 'https://example.com',
                 'githubtype': 'issue',
                 'id': 1,
-                'urgency': 4.9,
+                'tags': ['bar', 'foo'],
+                'urgency': 5.8,
             }]})
 
         # TEST CLOSED ISSUE.
@@ -169,7 +174,8 @@ class TestSynchronize(ConfigTest):
                 'id': 0,
                 'priority': 'M',
                 'status': 'completed',
-                'urgency': 4.9,
+                'tags': ['bar', 'foo'],
+                'urgency': 5.8,
             }],
             'pending': []})
 
@@ -192,7 +198,8 @@ class TestSynchronize(ConfigTest):
                 'githuburl': 'https://example.com',
                 'githubtype': 'issue',
                 'id': 1,
-                'urgency': 4.9,
+                'tags': ['bar', 'foo'],
+                'urgency': 5.8,
             }]})
 
 


### PR DESCRIPTION
Resolve #449. 

When multiple targets pull in the same issue, the tags added to
taskwarrior should be a union of those of each target.