### PR TITLE
gitlab: When failing to connect do not pass

### DIFF
--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -256,6 +256,7 @@ class GitlabClient(ServiceClient):
         try:
             result = self._fetch_paged(query)
         except ConnectionError as err:
+            # ConnectionError inherits from OSError and the service should fail without internet.
             raise ConnectionError(err)
         except OSError:
             # Projects may have this API disabled.
@@ -275,6 +276,7 @@ class GitlabClient(ServiceClient):
         try:
             fetched_todos = self._fetch_paged(query)
         except ConnectionError as err:
+            # ConnectionError inherits from OSError and the service should fail without internet.
             raise ConnectionError(err)
         except OSError:
             # Older gitlab versions do not have todo items.

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -255,6 +255,8 @@ class GitlabClient(ServiceClient):
         result = []
         try:
             result = self._fetch_paged(query)
+        except ConnectionError as err:
+            raise ConnectionError(err)
         except OSError:
             # Projects may have this API disabled.
             pass
@@ -272,6 +274,8 @@ class GitlabClient(ServiceClient):
         todos = []
         try:
             fetched_todos = self._fetch_paged(query)
+        except ConnectionError as err:
+            raise ConnectionError(err)
         except OSError:
             # Older gitlab versions do not have todo items.
             return []


### PR DESCRIPTION
With query-based fetching it is possible to end up only in paths
that catch connection errors. While catching OSErrors there might be
a valid strategy given the points documented, this also catches failed
connection attempts, as ConnectionRefusedError inherits from OSError.

Without this, it is possible that tasks get closed when connection to a gitlab instance cannot be established (Though internet connection is available, e.g. the gitlab instance is behind a non-connected VPN.).