### PR TITLE
Fix error in legacy cli deprecation warning.

### DIFF
--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -48,12 +48,12 @@ def _legacy_cli_deprecation_warning(subcommand_callback):
     @functools.wraps(subcommand_callback)
     @click.pass_context
     def wrapped_subcommand_callback(ctx, *args, **kwargs):
-        if ctx.command_path != 'cli':
-            old_command = f'bugwarrior-{ctx.command_path}'
-            new_command = f'bugwarrior {ctx.command_path}'
+        if ctx.find_root().command_path != 'bugwarrior':
+            old_command = ctx.command_path
+            new_command = ctx.command_path.replace('-', ' ')
             log.warning(
                 f'Deprecation Warning: `{old_command}` is deprecated and will '
-                'be removed in a future version of bugwarrior. Please use'
+                'be removed in a future version of bugwarrior. Please use '
                 f'`{new_command}` instead.')
         return ctx.invoke(subcommand_callback, *args, **kwargs)
     return wrapped_subcommand_callback

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -185,9 +185,3 @@ class TestPull(ConfigTest):
         self.assertIn('Adding 1 tasks', logs)
         self.assertIn('Updating 0 tasks', logs)
         self.assertIn('Closing 0 tasks', logs)
-
-        self.assertIn(
-            'Deprecation Warning: `bugwarrior-pull` is deprecated and will be '
-            'removed in a future version of bugwarrior. Please use`bugwarrior '
-            'pull` instead.',
-            logs)


### PR DESCRIPTION
I hadn't properly tested subcommands which give a false positive.

The testing harness doesn't see the root command -- which is the reason
I poorly implemented the warning in the first place -- so I'm removing
the assertion. Under manual testing the correct warnings are logged.