### PR TITLE
Per-service static_fields. Resolve #659.

### DIFF
--- a/bugwarrior/collect.py
+++ b/bugwarrior/collect.py
@@ -94,7 +94,9 @@ def aggregate_issues(conf, main_section, debug):
     while currently_running > 0:
         issue = queue.get(True)
         try:
-            yield TaskConstructor(issue).get_taskwarrior_record()
+            record = TaskConstructor(issue).get_taskwarrior_record()
+            record['target'] = issue.config.target
+            yield record
         except AttributeError:
             if isinstance(issue, tuple):
                 currently_running -= 1

--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -350,6 +350,7 @@ class ServiceConfig(_ServiceConfig):  # type: ignore  # (dynamic base class)
     also_unassigned: bool = False
     default_priority: typing.Literal['', 'L', 'M', 'H'] = 'M'
     add_tags: ConfigList = ConfigList([])
+    static_fields = ConfigList([])
 
     @pydantic.v1.root_validator
     def compute_templates(cls, values):

--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -1,3 +1,4 @@
+import itertools
 import json
 import re
 import subprocess
@@ -319,6 +320,9 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
         if issue['priority'] == '':
             issue['priority'] = None
 
+        # Target was only tacked on to pass configuration to this function.
+        service_config = conf[issue.pop('target')]
+
         try:
             existing_taskwarrior_uuid = find_taskwarrior_uuid(tw, key_list, issue)
         except MultipleMatches as e:
@@ -336,7 +340,8 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
 
             # Drop static fields from the upstream issue.  We don't want to
             # overwrite local changes to fields we declare static.
-            for field in main_config.static_fields:
+            for field in itertools.chain(main_config.static_fields,
+                                         service_config.static_fields):
                 if field in issue:
                     del issue[field]
 

--- a/bugwarrior/docs/common_configuration.rst
+++ b/bugwarrior/docs/common_configuration.rst
@@ -76,9 +76,8 @@ Optional options and their defaults include:
     # that you want to keep when replace_tags is set to true.
     static_tags =
 
-    # A list of attributes that shouldn't be *updated* by bugwarrior.  Use for
-    # values that you want to tune manually. Note that service-specific UDAs
-    # can be included here.
+    # A list of attributes that shouldn't be *updated* by bugwarrior for any services.
+    # Use for values that you want to tune manually.
     static_fields = priority
 
 In addition to the ``[general]`` section, sections may be named
@@ -113,6 +112,8 @@ The following options are supported:
 * ``add_tags``: A list of tags to add to an issue.  In
   most cases, plain strings will suffice, but you can also specify
   templates.  See the section `Field Templates`_ for more information.
+* ``static_fields``: A comma separated list of attributes that shouldn't be
+  *updated* by bugwarrior. Use for values that you want to tune manually.
 
 .. _field_templates:
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -111,6 +111,7 @@ class TestSynchronize(ConfigTest):
             'githuburl': 'https://example.com',
             'priority': 'M',
             'tags': ['foo'],
+            'target': 'my_service',
         }
         duplicate_issue = copy.deepcopy(issue)
         duplicate_issue['tags'] = ['bar']


### PR DESCRIPTION
Add a static_fields option to Common Service Configuration Options. This
enables users to differ behavior of core UDA names (e.g., "description")
amongst services.

The tests fail because we're currently able to test `db.synchronize` using regular dicts as issues whereas in a real bugwarrior pull these are `Issue` instances. This PR is awaiting a much-needed refactor of `db.synchronize` which will break this monstrous function into more testable components.