### PR TITLE
Deprecate project_name. Fix #781.

### DIFF
--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -325,3 +325,10 @@ class ServiceConfig(_ServiceConfig,  # type: ignore  # (dynamic base class)
             elif values['include_merge_requests'] == 'Undefined':
                 values['include_merge_requests'] = True
         return values
+
+    @pydantic.root_validator
+    def deprecate_project_name(cls, values):
+        if hasattr(cls, '_DEPRECATE_PROJECT_NAME'):
+            if values['project_name'] != '':
+                log.warning('project_name is deprecated in favor of project_template')
+        return values

--- a/bugwarrior/docs/example-bugwarriorrc
+++ b/bugwarrior/docs/example-bugwarriorrc
@@ -167,14 +167,12 @@ service = teamlab
 teamlab.hostname = teamlab.example.com
 teamlab.login = alice
 teamlab.password = secret
-teamlab.project_name = example_teamlab
 
 # Here's an example of a redmine target.
 [my_redmine]
 service = redmine
 redmine.url = http://redmine.example.org/
 redmine.key = c0c4c014cafebabe
-redmine.project_name = redmine
 redmine.add_tags = chiliproject
 
 [activecollab]

--- a/bugwarrior/docs/services/redmine.rst
+++ b/bugwarrior/docs/services/redmine.rst
@@ -15,7 +15,6 @@ Here's an example of a Redmine target::
     service = redmine
     redmine.url = http://redmine.example.org/
     redmine.key = c0c4c014cafebabe
-    redmine.project_name = redmine
     redmine.issue_limit = 100
 
 You can also feel free to use any of the configuration options described in

--- a/bugwarrior/docs/services/teamlab.rst
+++ b/bugwarrior/docs/services/teamlab.rst
@@ -19,16 +19,6 @@ The above example is the minimum required to import issues from
 Teamlab. You can also feel free to use any of the
 configuration options described in :ref:`common_configuration_options`.
 
-Service Features
-----------------
-
-Project Name
-++++++++++++
-
-By default the project name is set to the hostname. To set a different name::
-
-    teamlab.project_name = example_teamlab
-
 
 Provided UDA Fields
 -------------------

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -12,11 +12,13 @@ log = logging.getLogger(__name__)
 
 
 class RedMineConfig(config.ServiceConfig, prefix='redmine'):
+    _DEPRECATE_PROJECT_NAME = True
+    project_name: str = ''
+
     service: typing_extensions.Literal['redmine']
     url: config.StrippedTrailingSlashUrl
     key: str
 
-    project_name: str = ''
     issue_limit: int = 100
     query: str = ''
     login: str = ''

--- a/bugwarrior/services/teamlab.py
+++ b/bugwarrior/services/teamlab.py
@@ -9,12 +9,13 @@ log = logging.getLogger(__name__)
 
 
 class TeamLabConfig(config.ServiceConfig, prefix='teamlab'):
+    _DEPRECATE_PROJECT_NAME = True
+    project_name: str = ''
+
     service: typing_extensions.Literal['teamlab']
     hostname: str
     login: str
     password: str
-
-    project_name: str = ''
 
 
 class TeamLabClient(ServiceClient):

--- a/bugwarrior/services/versionone.py
+++ b/bugwarrior/services/versionone.py
@@ -9,13 +9,15 @@ from bugwarrior.services import IssueService, Issue, LOCAL_TIMEZONE
 
 
 class VersionOneConfig(config.ServiceConfig, prefix='versionone'):
+    _DEPRECATE_PROJECT_NAME = True
+    project_name: str = ''
+
     service: typing_extensions.Literal['versionone']
     base_uri: pydantic.AnyUrl
     username: str
 
     password: str = ''
     timebox_name: str = ''
-    project_name: str = ''
     timezone: str = LOCAL_TIMEZONE
 
 

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -173,3 +173,15 @@ class TestValidation(ConfigTest):
         self.config.set('my_gitlab', 'gitlab.include_merge_requests', 'true')
         self.assertValidationError(
             '[my_gitlab]  <- filter_merge_requests and include_merge_requests are incompatible.')
+
+    def test_deprecated_project_name(self):
+        """ We're just testing that deprecation doesn't break validation. """
+        self.config.set('general', 'targets', 'my_service, my_kan, my_gitlab, my_redmine')
+        self.config.add_section('my_redmine')
+        self.config.set('my_redmine', 'service', 'redmine')
+        self.config.set('my_redmine', 'redmine.url', 'https://example.com')
+        self.config.set('my_redmine', 'redmine.key', 'mykey')
+        self.validate()
+
+        self.config.set('my_redmine', 'redmine.project_name', 'myproject')
+        self.validate()

--- a/tests/test_teamlab.py
+++ b/tests/test_teamlab.py
@@ -13,7 +13,7 @@ class TestTeamlabIssue(AbstractServiceTest, ServiceTest):
         'teamlab.hostname': 'something',
         'teamlab.login': 'alkjdsf',
         'teamlab.password': 'lkjklj',
-        'teamlab.project_name': 'abcdef',
+        'teamlab.project_template': 'abcdef',
     }
     arbitrary_issue = {
         'title': 'Hello',
@@ -37,7 +37,7 @@ class TestTeamlabIssue(AbstractServiceTest, ServiceTest):
         issue = self.service.get_issue_for_record(self.arbitrary_issue)
 
         expected_output = {
-            'project': self.SERVICE_CONFIG['teamlab.project_name'],
+            'project': self.SERVICE_CONFIG['teamlab.hostname'],
             'priority': self.service.config.default_priority,
             issue.TITLE: self.arbitrary_issue['title'],
             issue.FOREIGN_ID: self.arbitrary_issue['id'],


### PR DESCRIPTION
Field templates can always be used instead.