### PR TITLE
teamwork_projects: Implement only_if_assigned.

### DIFF
--- a/bugwarrior/services/teamwork_projects.py
+++ b/bugwarrior/services/teamwork_projects.py
@@ -71,11 +71,10 @@ class TeamworkIssue(Issue):
         "high": "H"
     }
 
-    def get_owner(self, issue):
-        if issue:
-            if self.record.get("responsible-party-ids", ""):
-                if self.user_id in self.record.get("responsible-party-ids", ""):
-                    return self.name
+    def get_owner(self):
+        if (self.record.get("responsible-party-ids", "") and
+                self.user_id in self.record.get("responsible-party-ids", "")):
+            return self.name
 
     def get_author(self, issue):
         if issue:
@@ -152,9 +151,7 @@ class TeamworkService(IssueService):
         return []
 
     def get_owner(self, issue):
-        # TODO
-        raise NotImplementedError(
-            "This service has not implemented support for 'only_if_assigned'.")
+        return issue.get_owner()
 
     def issues(self):
         response = self.client.call_api("GET", "/tasks.json")

--- a/tests/test_teamwork_projects.py
+++ b/tests/test_teamwork_projects.py
@@ -137,5 +137,5 @@ class TestTeamworkIssue(AbstractServiceTest, ServiceTest):
         issue.user_id = "5"
         issue.name = "Greg McCoy"
         self.assertEqual(issue.get_taskwarrior_record(), expected_data)
-        self.assertEqual(issue.get_owner(issue), "Greg McCoy")
+        self.assertEqual(issue.get_owner(), "Greg McCoy")
         self.assertEqual(issue.get_author(issue), "Greg McCoy")


### PR DESCRIPTION
Progress on #838.

It appears the get_owner method was accidentally immplemented on the
issue rather than the service class.