### PR TITLE
Ensure consistency between services and docs.

### DIFF
--- a/bugwarrior/README.rst
+++ b/bugwarrior/README.rst
@@ -7,26 +7,31 @@ bugwarrior - Pull tickets from github, bitbucket, bugzilla, jira, trac, and othe
 
 It currently supports the following remote resources:
 
- - `activecollab <https://www.activecollab.com>`_ (2.x and 4.x)
- - `bitbucket <https://bitbucket.org>`_
- - `bugzilla <https://www.bugzilla.org/>`_
- - `Debian BTS <https://bugs.debian.org/>`_
- - `gerrit <https://www.gerritcodereview.com/>`_
- - `github <https://github.com>`_ (api v3)
- - `gitlab <https://gitlab.com>`_ (api v3)
- - `gmail <https://www.google.com/gmail/about/>`_
- - `jira <https://www.atlassian.com/software/jira/overview>`_
- - `kanboard <https://kanboard.org/>`_
- - `pagure <https://pagure.io/>`_
- - `phabricator <http://phabricator.org/>`_
- - `Pivotal Tracker <https://www.pivotaltracker.com/>`_
- - `redmine <https://www.redmine.org/>`_
- - `taiga <https://taiga.io>`_
- - `teamlab <https://www.teamlab.com/>`_
- - `trac <https://trac.edgewall.org/>`_
- - `trello <https://trello.com/>`_
- - `versionone <http://www.versionone.com/>`_
- - `youtrack <https://www.jetbrains.com/youtrack/>`_
+.. class:: services
+
+- `ActiveCollab 2 <https://www.activecollab.com>`_
+- `ActiveCollab 4 <https://www.activecollab.com>`_
+- `Azure DevOps <https://azure.microsoft.com/en-us/services/devops/>`_
+- `Bitbucket <https://bitbucket.org>`_
+- `Bugzilla <https://www.bugzilla.org/>`_
+- `Debian Bug Tracking System (BTS) <https://bugs.debian.org/>`_
+- `Gerrit <https://www.gerritcodereview.com/>`_
+- `Github <https://github.com>`_
+- `Gitlab <https://gitlab.com>`_
+- `Gmail <https://www.google.com/gmail/about/>`_
+- `Jira <https://www.atlassian.com/software/jira/overview>`_
+- `Kanboard <https://kanboard.org/>`_
+- `Pagure <https://pagure.io/>`_
+- `Phabricator <http://phabricator.org/>`_
+- `Pivotal Tracker <https://www.pivotaltracker.com/>`_
+- `Redmine <https://www.redmine.org/>`_
+- `Taiga <https://taiga.io>`_
+- `Teamlab <https://www.teamlab.com/>`_
+- `Teamwork Projects <https://www.teamwork.com/>`_
+- `Trac <https://trac.edgewall.org/>`_
+- `Trello <https://trello.com/>`_
+- `VersionOne <http://www.versionone.com/>`_
+- `YouTrack <https://www.jetbrains.com/youtrack/>`_
 
 Documentation
 -------------

--- a/bugwarrior/docs/services/teamwork_projects.rst
+++ b/bugwarrior/docs/services/teamwork_projects.rst
@@ -1,4 +1,4 @@
-Teamworks Project
+Teamwork Projects
 =================
 
 You can import tasks from Teamwork Projects using

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(name='bugwarrior',
       trello=bugwarrior.services.trello:TrelloService
       youtrack=bugwarrior.services.youtrack:YoutrackService
       gmail=bugwarrior.services.gmail:GmailService
-      teamworks_projects=bugwarrior.services.teamworks_projects:TeamworksService
+      teamwork_projects=bugwarrior.services.teamwork_projects:TeamworkService
       pivotaltracker=bugwarrior.services.pivotaltracker:PivotalTrackerService
       azuredevops=bugwarrior.services.azuredevops:AzureDevopsService
       """,

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,5 +1,9 @@
+import docutils.core
+import glob
 import os.path
 import pathlib
+import pkg_resources
+import re
 import subprocess
 import tempfile
 import unittest
@@ -8,21 +12,67 @@ from bugwarrior import config
 
 from .base import ConfigTest
 
-DOCS_PATH = str(pathlib.Path(__file__).parent / '../bugwarrior/docs')
+DOCS_PATH = pathlib.Path(__file__).parent / '../bugwarrior/docs'
+
+
+class ReadmeTest(unittest.TestCase):
+    def test_service_list(self):
+
+        # GET README LISTED SERVICES
+        def is_services(node):
+            try:
+                return 'services' in node.attributes['classes']
+            except AttributeError:  # not all nodes have attributes
+                return False
+
+        with open('README.rst', 'r') as f:
+            readme = f.read()
+
+        readme_document = docutils.core.publish_doctree(readme)
+        service_list_search = readme_document.traverse(condition=is_services)
+        self.assertEqual(len(service_list_search), 1)
+        service_list_element = service_list_search.pop()
+        readme_listed_services = set(
+            list_item.astext() for list_item in service_list_element.children)
+
+        # GET TITLES FROM SERVICE DOCUMENTATION FILES
+        documented_services = set()
+        for service in glob.iglob(str(DOCS_PATH / 'services' / '*.rst')):
+            with open(service, 'r') as f:
+                firstline = f.readline().strip()
+                # ignore directives or empty lines
+                while firstline.startswith('.. _') or firstline == '':
+                    firstline = f.readline().strip()
+                documented_services.add(firstline)
+
+        self.assertEqual(documented_services,  readme_listed_services)
 
 
 class DocsTest(unittest.TestCase):
     def test_docs_build_without_warning(self):
         with tempfile.TemporaryDirectory() as buildDir:
             subprocess.run(
-                ['sphinx-build', '-n', '-W', '-v', DOCS_PATH, buildDir],
+                ['sphinx-build', '-n', '-W', '-v', str(DOCS_PATH), buildDir],
                 check=True)
 
     def test_manpage_build_without_warning(self):
         with tempfile.TemporaryDirectory() as buildDir:
             subprocess.run(
-                ['sphinx-build', '-b', 'man', '-n', '-W', '-v', DOCS_PATH, buildDir],
+                ['sphinx-build', '-b', 'man', '-n', '-W', '-v', str(DOCS_PATH), buildDir],
                 check=True)
+
+    def test_registered_services_are_documented(self):
+        registered_services = set(
+            e.name for e in
+            pkg_resources.iter_entry_points(group='bugwarrior.service'))
+
+        documented_services = set()
+        services_paths = os.listdir(DOCS_PATH / 'services')
+        for p in services_paths:
+            if re.match(r'.*\.rst$', p):
+                documented_services.add(re.sub(r'\.rst$', '', p))
+
+        self.assertEqual(registered_services, documented_services)
 
 
 class ExampleBugwarriorrcTest(ConfigTest):


### PR DESCRIPTION
Fix #936.

I additionally discovered that Teamwork Projects was not listed on the
README and was probably broken since the entrypoint contained typos.