### PR TITLE
config: Allow extra sections. Fix #874.

### DIFF
--- a/bugwarrior/config/load.py
+++ b/bugwarrior/config/load.py
@@ -2,7 +2,6 @@ import codecs
 import configparser
 import logging
 import os
-import re
 
 from . import data, schema
 
@@ -53,19 +52,10 @@ def get_config_path():
     return paths[0]
 
 
-def remove_inactive_flavors(rawconfig, main_section):
-    if main_section != 'general':
-        rawconfig.remove_section('general')
-    for section in rawconfig.sections():
-        if re.match('^flavor\\..*', section) and main_section != section:
-            rawconfig.remove_section(section)
-
-
 def load_config(main_section, interactive, quiet):
     configpath = get_config_path()
     rawconfig = BugwarriorConfigParser()
     rawconfig.readfp(codecs.open(configpath, "r", "utf-8",))
-    remove_inactive_flavors(rawconfig, main_section)
     config = schema.validate_config(rawconfig, main_section, configpath)
     main_config = config[main_section]
     main_config.interactive = str(interactive)

--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -158,7 +158,9 @@ class Notifications(pydantic.BaseModel):
 
 
 class SchemaBase(pydantic.BaseSettings):
-    Config = PydanticConfig
+    class Config(PydanticConfig):
+        # Allow extra top-level sections so all targets don't have to be selected.
+        extra = 'ignore'
 
     DEFAULT: dict  # configparser feature
 
@@ -192,13 +194,7 @@ class ValidationErrorEnhancedMessages(list):
     def display_error(self, e, error, model):
         if e['type'] == 'value_error.extra':
             e['msg'] = 'unrecognized option'
-            if len(e['loc']) == 1:  # Error is in section
-                if e['loc'][0] not in self.targets:
-                    e['msg'] = (
-                        f"Unrecognized section '{e['loc'][0]}'. Did you forget"
-                        f" to add it to 'targets' in the [{self.main_section}]"
-                        " section?")
-            elif len(e['loc']) == 2:  # Error is in option
+            if len(e['loc']) == 2:  # Error is in option
                 option = e['loc'][-1].split('.').pop()
                 try:
                     scoped = f"{model._PREFIX}.{option}"

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -118,13 +118,6 @@ class TestValidation(ConfigTest):
             "[my_service]\nfake.also_unassigned  <- "
             "expected prefix 'github': did you mean 'github.also_unassigned'?")
 
-    def test_main_section_missing_targets_value(self):
-        self.config.set('general', 'targets', '')
-
-        self.assertValidationError(
-            "[my_service]  <- Unrecognized section 'my_service'. Did you "
-            "forget to add it to 'targets' in the [general] section?")
-
     def test_extra_field(self):
         """ Undeclared fields are forbidden. """
         self.config.set('my_service', 'github.undeclared_field', 'extra')


### PR DESCRIPTION
Sometimes it is nice to remove sections from targets without removing
them entirely. Strict validation of the section names prevents this.