### PR TITLE
github: remove basic auth support. Resolve #906.

### DIFF
--- a/bugwarrior/docs/example-bugwarriorrc
+++ b/bugwarrior/docs/example-bugwarriorrc
@@ -96,7 +96,7 @@ github.include_repos = project_foo,project_foz
 # - 'github.username' is the github entity you want to pull
 #   issues for.  It could be you, or some other user entirely.
 github.login = ralphbean
-github.password = OMG_LULZ
+github.token = 123456
 
 
 # Here's an example of a trac target.

--- a/bugwarrior/docs/services/github.rst
+++ b/bugwarrior/docs/services/github.rst
@@ -12,7 +12,7 @@ Here's an example of a Github target::
     [my_issue_tracker]
     service = github
     github.login = ralphbean
-    github.password = OMG_LULZ
+    github.token = 123456
     github.username = ralphbean
 
 The above example is the minimum required to import issues from
@@ -21,10 +21,9 @@ configuration options described in :ref:`common_configuration_options`
 or described in `Service Features`_ below.
 
 ``github.login`` is used to specify what account bugwarrior should use to login
-to github, combined with ``github.password``.
+to github, combined with ``github.token``.
 
-If two-factor authentication is used, ``github.token`` must be given rather
-than ``github.password``. To get a token, go to the "Personal access tokens" section of
+To get a token, go to the "Personal access tokens" section of
 your profile settings. Only the ``public_repo`` scope is required, but access
 to private repos can be gained with ``repo`` as well.
 

--- a/tests/config/test_data.py
+++ b/tests/config/test_data.py
@@ -48,7 +48,7 @@ class TestGetDataPath(ConfigTest):
         rawconfig.add_section('my_service')
         rawconfig.set('my_service', 'service', 'github')
         rawconfig.set('my_service', 'github.login', 'ralphbean')
-        rawconfig.set('my_service', 'github.password', 'abc123')
+        rawconfig.set('my_service', 'github.token', 'abc123')
         rawconfig.set('my_service', 'github.username', 'ralphbean')
         self.config = schema.validate_config(
             rawconfig, 'general', 'configpath')

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -65,7 +65,7 @@ class TestValidation(ConfigTest):
         self.config.set('my_service', 'service', 'github')
         self.config.set('my_service', 'github.login', 'ralph')
         self.config.set('my_service', 'github.username', 'ralph')
-        self.config.set('my_service', 'github.password', 'abc123')
+        self.config.set('my_service', 'github.token', 'abc123')
         self.config.add_section('my_kan')
         self.config.set('my_kan', 'service', 'kanboard')
         self.config.set(
@@ -134,11 +134,11 @@ class TestValidation(ConfigTest):
             'github.undeclared_field  <- unrecognized option')
 
     def test_root_validator(self):
-        self.config.remove_option('my_service', 'github.password')
+        self.config.remove_option('my_service', 'github.username')
 
         self.assertValidationError(
-            '[my_service]  <- section requires one of:'
-            '\ngithub.token\ngithub.password')
+            '[my_service]  <- '
+            'section requires one of:\ngithub.username\ngithub.query')
 
     def test_no_scheme_url_validator_default(self):
         conf = self.validate()

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -45,7 +45,7 @@ class TestPull(ConfigTest):
         self.config.add_section('my_service')
         self.config.set('my_service', 'service', 'github')
         self.config.set('my_service', 'github.login', 'ralphbean')
-        self.config.set('my_service', 'github.password', 'abc123')
+        self.config.set('my_service', 'github.token', 'abc123')
         self.config.set('my_service', 'github.username', 'ralphbean')
 
         self.write_rc(self.config)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -96,7 +96,7 @@ class TestSynchronize(ConfigTest):
         self.config.set('my_service', 'service', 'github')
         self.config.set('my_service', 'github.login', 'ralphbean')
         self.config.set('my_service', 'github.username', 'ralphbean')
-        self.config.set('my_service', 'github.password', 'abc123')
+        self.config.set('my_service', 'github.token', 'abc123')
         bwconfig = self.validate()
 
         tw = taskw.TaskWarrior(self.taskrc)
@@ -212,7 +212,7 @@ class TestUDAs(ConfigTest):
         self.config.set('my_service', 'service', 'github')
         self.config.set('my_service', 'github.login', 'ralphbean')
         self.config.set('my_service', 'github.username', 'ralphbean')
-        self.config.set('my_service', 'github.password', 'abc123')
+        self.config.set('my_service', 'github.token', 'abc123')
         self.config.set('my_service', 'service', 'github')
 
         conf = self.validate()

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -47,7 +47,7 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
         'service': 'github',
         'github.login': 'arbitrary_login',
-        'github.password': 'arbitrary_password',
+        'github.token': 'arbitrary_token',
         'github.username': 'arbitrary_username',
     }
 
@@ -157,7 +157,7 @@ class TestGithubIssueQuery(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
         'service': 'github',
         'github.login': 'arbitrary_login',
-        'github.password': 'arbitrary_password',
+        'github.token': 'arbitrary_token',
         'github.username': 'arbitrary_username',
         'github.query': 'is:open reviewer:octocat',
         'github.include_user_repos': 'False',
@@ -216,14 +216,13 @@ class TestGithubService(ServiceTest):
         'service': 'github',
         'github.login': 'tintin',
         'github.username': 'milou',
-        'github.password': 't0ps3cr3t',
+        'github.token': 't0ps3cr3t',
 
     }
 
     def test_token_authorization_header(self):
         service = self.get_mock_service(GithubService)
         service = self.get_mock_service(GithubService, config_overrides={
-            'github.password': '',
             'github.token': '@oracle:eval:echo 1234567890ABCDEF'})
         self.assertEqual(service.client.session.headers['Authorization'],
                          "token 1234567890ABCDEF")


### PR DESCRIPTION
Github seems to have finally removed password support for API access, so
we'll require github.token while giving a warning when github.password
is still defined.