### PR TITLE
Decrement currently_running one time. Fix #897.

### DIFF
--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -445,7 +445,7 @@ def _aggregate_issues(conf, main_section, target, queue):
             queue.put(issue)
             issue_count += 1
     except SystemExit as e:
-        log.critical(str(e))
+        log.critical(f"Worker for [{target}] exited: {e}")
         queue.put((SERVICE_FINISHED_ERROR, (target, e)))
     except BaseException as e:
         if hasattr(e, 'request') and e.request:
@@ -454,13 +454,14 @@ def _aggregate_issues(conf, main_section, target, queue):
             # to it, and we need to remove them, as there can be unpickleable
             # methods. There is no one left to call these hooks anyway.
             e.request.hooks = {}
-        log.exception("Worker for [%s] failed: %s" % (target, e))
+        log.exception(f"Worker for [{target}] failed: {e}")
         queue.put((SERVICE_FINISHED_ERROR, (target, e)))
     else:
+        log.debug(f"Worker for [{target}] finished ok.")
         queue.put((SERVICE_FINISHED_OK, (target, issue_count, )))
     finally:
         duration = time.time() - start
-        log.info("Done with [%s] in %fs" % (target, duration))
+        log.info(f"Done with [{target}] in {duration}.")
 
 
 def aggregate_issues(conf, main_section, debug):
@@ -495,13 +496,12 @@ def aggregate_issues(conf, main_section, debug):
     while currently_running > 0:
         issue = queue.get(True)
         if isinstance(issue, tuple):
+            currently_running -= 1
             completion_type, args = issue
             if completion_type == SERVICE_FINISHED_ERROR:
                 target, e = args
-                log.exception(f"Aborted {target} due to critical error.")
-                currently_running -= 1
+                log.error(f"Aborted [{target}] due to critical error.")
                 yield ('SERVICE FAILED', target)
-            currently_running -= 1
             continue
         yield issue
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -90,7 +90,7 @@ class TestPull(ConfigTest):
         self.assertNotEqual(self.caplog.records, [])
         self.assertEqual(len(self.caplog.records), 1)
         self.assertEqual(self.caplog.records[0].message,
-                         "Aborted my_service due to critical error.")
+                         "Aborted [my_service] due to critical error.")
 
     @mock.patch(
         'bugwarrior.services.github.GithubService.issues',
@@ -122,7 +122,7 @@ class TestPull(ConfigTest):
 
         logs = [rec.message for rec in self.caplog.records]
         self.assertIn(
-            'Aborted my_broken_service due to critical error.', logs)
+            'Aborted [my_broken_service] due to critical error.', logs)
         self.assertIn('Adding 0 tasks', logs)
 
     @mock.patch(
@@ -162,7 +162,7 @@ class TestPull(ConfigTest):
         logs = [rec.message for rec in self.caplog.records]
 
         # Make sure my_broken_service failed while my_service succeeded.
-        self.assertIn('Aborted my_broken_service due to critical error.', logs)
+        self.assertIn('Aborted [my_broken_service] due to critical error.', logs)
         self.assertNotIn('Aborted my_service due to critical error.', logs)
 
         # Assert that issues weren't closed or marked complete.


### PR DESCRIPTION
Unfortunately this was pointed out by @fmauch but it appears that I
accidentally reverted it when rebasing #825.

> The currently_running -= 1 will also be reached once yield is called,
> as the generator simply continues directly after the yield statement
> (as far as I understood generators).

https://github.com/ralphbean/bugwarrior/pull/825#discussion_r659296257

This explains the situation of #897:

> We hit the line log.exception("Worker for [%s] failed: %s" % (target, e))
> but then somehow miss the line log.exception(f"Aborted {target} due to
> critical error."

https://github.com/ralphbean/bugwarrior/issues/897#issuecomment-1096838119

Because the decrement was occurring twice for a previous service, the
`while currently_running > 0` loop was ending before getting  to the
`SERVICE_FINISHED_ERROR` in the queue.

Also, improve logging consistency in this section.