### PR TITLE
Handle redmine not returning estimated hours.

### DIFF
--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -175,14 +175,12 @@ class RedMineIssue(Issue):
             updated_on = self.parse_date(updated_on).replace(microsecond=0)
         if created_on:
             created_on = self.parse_date(created_on).replace(microsecond=0)
-        if not spent_hours:
-            spent_hours = 0
-        spent_hours = str(spent_hours) + ' hours'
-        spent_hours = self.get_converted_hours(spent_hours)
-        if not estimated_hours:
-            estimated_hours = 0
-        estimated_hours = str(estimated_hours) + ' hours'
-        estimated_hours = self.get_converted_hours(estimated_hours)
+        if spent_hours or spent_hours == 0.0:
+            spent_hours = str(spent_hours) + ' hours'
+            spent_hours = self.get_converted_hours(spent_hours)
+        if estimated_hours or estimated_hours == 0.0:
+            estimated_hours = str(estimated_hours) + ' hours'
+            estimated_hours = self.get_converted_hours(estimated_hours)
         if category:
             category = category['name']
         if assigned_to:

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -175,12 +175,14 @@ class RedMineIssue(Issue):
             updated_on = self.parse_date(updated_on).replace(microsecond=0)
         if created_on:
             created_on = self.parse_date(created_on).replace(microsecond=0)
-        if spent_hours:
-            spent_hours = str(spent_hours) + ' hours'
-            spent_hours = self.get_converted_hours(spent_hours)
-        if estimated_hours:
-            estimated_hours = str(estimated_hours) + ' hours'
-            estimated_hours = self.get_converted_hours(estimated_hours)
+        if not spent_hours:
+            spent_hours = 0
+        spent_hours = str(spent_hours) + ' hours'
+        spent_hours = self.get_converted_hours(spent_hours)
+        if not estimated_hours:
+            estimated_hours = 0
+        estimated_hours = str(estimated_hours) + ' hours'
+        estimated_hours = self.get_converted_hours(estimated_hours)
         if category:
             category = category['name']
         if assigned_to:


### PR DESCRIPTION
In our setup the estimated_hours and spent_hours fields might be empty, this trigger an exception in taskwarrior that it cannot convert 0.0 to a duration.

ERROR:bugwarrior.db:Unable to add task: b"The duration value '0.0' is not supported." Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/bugwarrior/db.py", line 439, in synchronize
    new_task = tw.task_add(**issue)
  File "/usr/lib/python3.10/site-packages/taskw/warrior.py", line 704, in task_add
    stdout, stderr = self._execute('add', *args)
  File "/usr/lib/python3.10/site-packages/taskw/warrior.py", line 498, in _execute

The command line for taskwarrior invocation is:

[b'task'
...
b'rc.uda.redminespenthours.type=duration', b'rc.uda.redminespenthours.label="Redmine Spent Hours"', b'rc.uda.redmineestimatedhours.type=duration', ...
b'redminespenthours:"0.0"'
]

The patch makes sure that the value is formatted correctly for the duration type