### PR TITLE
Replace LOCAL_TIMEZONE constant with empty string

### DIFF
--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -24,10 +24,6 @@ log = logging.getLogger(__name__)
 SERVICE_FINISHED_OK = 0
 SERVICE_FINISHED_ERROR = 1
 
-# Used by `parse_date` as a timezone when you would like a naive
-# date string to be parsed as if it were in your local timezone
-LOCAL_TIMEZONE = 'LOCAL_TIMEZONE'
-
 
 def get_service(service_name):
     epoint = iter_entry_points(group='bugwarrior.service', name=service_name)
@@ -314,7 +310,7 @@ class Issue(abc.ABC):
         if date:
             date = parse_date(date)
             if not date.tzinfo:
-                if timezone == LOCAL_TIMEZONE:
+                if timezone == '':
                     tzinfo = tzlocal()
                 else:
                     tzinfo = pytz.timezone(timezone)

--- a/bugwarrior/services/versionone.py
+++ b/bugwarrior/services/versionone.py
@@ -5,7 +5,7 @@ from v1pysdk.none_deref import NoneDeref
 from urllib import parse
 
 from bugwarrior import config
-from bugwarrior.services import IssueService, Issue, LOCAL_TIMEZONE
+from bugwarrior.services import IssueService, Issue
 
 
 class VersionOneConfig(config.ServiceConfig, prefix='versionone'):
@@ -18,7 +18,7 @@ class VersionOneConfig(config.ServiceConfig, prefix='versionone'):
 
     password: str = ''
     timebox_name: str = ''
-    timezone: str = LOCAL_TIMEZONE
+    timezone: str = ''
 
 
 class VersionOneIssue(Issue):


### PR DESCRIPTION
The constant is only used in the VersionOne service and an empty string serves just as well. If an empty string were passed in this parameter previously you'd get an exception, so we aren't masking any useful behavior:

```py
>>> pytz.timezone('')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "python3.10/site-packages/pytz/__init__.py", line 188, in timezone
    raise UnknownTimeZoneError(zone)
pytz.exceptions.UnknownTimeZoneError: ''
```