### PR TITLE
pull: fix "--interactive" flag

### DIFF
--- a/bugwarrior/config/load.py
+++ b/bugwarrior/config/load.py
@@ -58,7 +58,7 @@ def load_config(main_section, interactive, quiet):
     rawconfig.readfp(codecs.open(configpath, "r", "utf-8",))
     config = schema.validate_config(rawconfig, main_section, configpath)
     main_config = config[main_section]
-    main_config.interactive = str(interactive)
+    main_config.interactive = interactive
     main_config.data = data.BugwarriorData(
         data.get_data_path(config[main_section].taskrc))
     configure_logging(main_config.log__file,


### PR DESCRIPTION
The string value was truthy even when it was "False". Whoops.

It would be nice to have a regression test for this but it's not obvious how to do that. However, I do plan to start mutating these values on the configuration before validation in an upcoming pull request, which would have caught this because it's the wrong type.