### PR TITLE
config: don't mutate main section fields

### DIFF
--- a/bugwarrior/config/load.py
+++ b/bugwarrior/config/load.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     import tomli as tomllib  # backport
 
-from . import data, schema
+from . import schema
 
 # The name of the environment variable that can be used to ovewrite the path
 # to the bugwarriorrc file
@@ -101,16 +101,13 @@ def parse_file(configpath: str) -> dict:
     return config
 
 
-def load_config(main_section, interactive, quiet):
+def load_config(main_section, interactive, quiet) -> dict:
     configpath = get_config_path()
     rawconfig = parse_file(configpath)
+    rawconfig[main_section]['interactive'] = interactive
     config = schema.validate_config(rawconfig, main_section, configpath)
-    main_config = config[main_section]
-    main_config.interactive = interactive
-    main_config.data = data.BugwarriorData(
-        data.get_data_path(main_config.taskrc))
-    configure_logging(main_config.log_file,
-                      'WARNING' if quiet else main_config.log_level)
+    configure_logging(config[main_section].log_file,
+                      'WARNING' if quiet else config[main_section].log_level)
     return config
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -8,7 +8,7 @@ import pytest
 import responses
 
 from bugwarrior import config
-from bugwarrior.config import data, schema
+from bugwarrior.config import schema
 
 
 class AbstractServiceTest(abc.ABC):
@@ -63,10 +63,9 @@ class ConfigTest(unittest.TestCase):
         self.caplog = caplog
 
     def validate(self):
-        conf = schema.validate_config(self.config, 'general', 'configpath')
-        conf['general'].data = data.BugwarriorData(self.lists_path)
-        conf['general'].interactive = False
-        return conf
+        self.config['general'] = self.config.get('general', {})
+        self.config['general']['interactive'] = False
+        return schema.validate_config(self.config, 'general', 'configpath')
 
     def assertValidationError(self, expected):
 
@@ -110,7 +109,6 @@ class ServiceTest(ConfigTest):
 
         service_config = service_class.CONFIG_SCHEMA(**options[section])
         main_config = schema.MainSectionConfig(**options['general'])
-        main_config.data = data.BugwarriorData(self.lists_path)
 
         return service_class(service_config, main_config, section)
 

--- a/tests/config/test_data.py
+++ b/tests/config/test_data.py
@@ -43,7 +43,7 @@ class TestGetDataPath(ConfigTest):
     def setUp(self):
         super().setUp()
         rawconfig = {
-            'general': {'targets': ['my_service']},
+            'general': {'targets': ['my_service'], 'interactive': False},
             'my_service': {
                 'service': 'github',
                 'login': 'ralphbean',

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -87,7 +87,11 @@ class TestValidation(ConfigTest):
     def test_main_section_required(self):
         del self.config['general']
 
-        self.assertValidationError("No section: 'general'")
+        with self.assertRaises(SystemExit):
+            schema.validate_config(self.config, 'general', 'configpath')
+
+        self.assertEqual(len(self.caplog.records), 1)
+        self.assertIn("No section: 'general'", self.caplog.records[0].message)
 
     def test_main_section_missing_targets_option(self):
         del self.config['general']['targets']


### PR DESCRIPTION
<s>Based on #973.</s>

- Add `general.interactive` value before validation.
- Compute `general.data` within the model.

This has a couple advantages:

- Disallowing model mutation kills a class of potential bugs.
- The `interactive` field is now validated, which would have avoided the
  bug fixed in ralphbean#974.