### PR TITLE
Add target to service config

### DIFF
--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -216,6 +216,17 @@ def raise_validation_error(msg, config_path, no_errors=1):
     sys.exit(1)
 
 
+def get_target_validator(targets):
+
+    @pydantic.root_validator(pre=True, allow_reuse=True)
+    def compute_target(cls, values):
+        for target in targets:
+            values[target]['target'] = target
+        return values
+
+    return compute_target
+
+
 def validate_config(config: dict, main_section: str, config_path: str) -> dict:
     # Pre-validate the minimum requirements to build our pydantic models.
     try:
@@ -247,6 +258,7 @@ def validate_config(config: dict, main_section: str, config_path: str) -> dict:
     bugwarrior_config_model = pydantic.create_model(
         'bugwarriorrc',
         __base__=SchemaBase,
+        __validators__={'compute_target': get_target_validator(targets)},
         general=(MainSectionConfig, ...),
         flavor={flavor: (MainSectionConfig, ...)
                 for flavor in config.get('flavor', {}).values()},
@@ -275,8 +287,9 @@ class ServiceConfig(_ServiceConfig):  # type: ignore  # (dynamic base class)
     """ Base class for service configurations. """
     Config = PydanticConfig
 
-    # added during validation (computed field support will land in pydantic-2)
+    # Added during validation (computed field support will land in pydantic-2)
     templates: dict = {}
+    target: typing.Optional[str] = None
 
     # Optional fields shared by all services.
     only_if_assigned: str = ''

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -42,12 +42,11 @@ class IssueService(abc.ABC):
     # Which class defines this service's configuration options?
     CONFIG_SCHEMA = None
 
-    def __init__(self, config, main_config, target):
+    def __init__(self, config, main_config):
         self.config = config
         self.main_config = main_config
-        self.target = target
 
-        log.info("Working on [%s]", self.target)
+        log.info("Working on [%s]", self.config.target)
 
     def get_password(self, key, login='nousername'):
         password = getattr(self.config, key)
@@ -67,7 +66,7 @@ class IssueService(abc.ABC):
             'default_priority': self.config.default_priority,
             'description_length': self.main_config.description_length,
             'templates': self.config.templates,
-            'target': self.target,
+            'target': self.config.target,
             'shorten': self.main_config.shorten,
             'inline_links': self.main_config.inline_links,
             'add_tags': self.config.add_tags,
@@ -419,7 +418,7 @@ def _aggregate_issues(conf, main_section, target, queue):
 
     try:
         service = get_service(conf[target].service)(
-            conf[target], conf[main_section], target)
+            conf[target], conf[main_section])
         issue_count = 0
         for issue in service.issues():
             queue.put(issue)

--- a/bugwarrior/services/activecollab2.py
+++ b/bugwarrior/services/activecollab2.py
@@ -202,7 +202,7 @@ class ActiveCollab2Service(IssueService):
                                           self.config.key,
                                           self.config.user_id,
                                           self.config.projects,
-                                          self.target)
+                                          self.config.target)
 
     def get_owner(self, issue):
         # TODO

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -275,7 +275,7 @@ class BugzillaService(IssueService):
         ]
 
         bugs = filter(self.include, bugs)
-        issues = [(self.target, bug) for bug in bugs]
+        issues = [(self.config.target, bug) for bug in bugs]
         log.debug(" Found %i total.", len(issues))
 
         # Build a url for each issue

--- a/bugwarrior/services/gmail.py
+++ b/bugwarrior/services/gmail.py
@@ -125,7 +125,7 @@ class GmailService(IssueService):
 
         credentials_name = clean_filename(
             self.config.login_name if self.config.login_name != 'me'
-            else self.target)
+            else self.config.target)
         self.credentials_path = os.path.join(
             self.main_config.data.path,
             'gmail_credentials_%s.pickle' % (credentials_name,))
@@ -146,7 +146,7 @@ class GmailService(IssueService):
             Credentials, the obtained credential.
         """
         with self.AUTHENTICATION_LOCK:
-            log.info('Starting authentication for %s', self.target)
+            log.info('Starting authentication for %s', self.config.target)
             credentials = None
             # The self.credentials_path file stores the user's access and refresh
             # tokens as a pickle, and is created automatically when the

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -145,7 +145,7 @@ class PhabricatorService(IssueService):
 
         for phid, task in tasks:
 
-            project = self.target  # a sensible default
+            project = self.config.target  # a sensible default
 
             this_task_matches = False
 
@@ -198,7 +198,7 @@ class PhabricatorService(IssueService):
 
         for diff in diffs:
 
-            project = self.target  # a sensible default
+            project = self.config.target  # a sensible default
 
             this_diff_matches = False
 

--- a/bugwarrior/services/trac.py
+++ b/bugwarrior/services/trac.py
@@ -137,7 +137,7 @@ class TracService(IssueService):
         if self.trac:
             tickets = self.trac.query_tickets('status!=closed&max=0')
             tickets = list(map(self.trac.get_ticket, tickets))
-            issues = [(self.target, ticket[3]) for ticket in tickets]
+            issues = [(self.config.target, ticket[3]) for ticket in tickets]
             for i in range(len(issues)):
                 issues[i][1]['url'] = "%s/ticket/%i" % (base_url, tickets[i][0])
                 issues[i][1]['number'] = tickets[i][0]
@@ -155,7 +155,7 @@ class TracService(IssueService):
             # strip Trac's bogus BOM
             text = resp.text[1:].lstrip('\ufeff')
             tickets = list(csv.DictReader(StringIO.StringIO(text.encode('utf-8'))))
-            issues = [(self.target, ticket) for ticket in tickets]
+            issues = [(self.config.target, ticket) for ticket in tickets]
             for i in range(len(issues)):
                 issues[i][1]['url'] = "%s/ticket/%s" % (base_url, tickets[i]['id'])
                 issues[i][1]['number'] = int(tickets[i]['id'])

--- a/tests/base.py
+++ b/tests/base.py
@@ -101,7 +101,7 @@ class ServiceTest(ConfigTest):
     ):
         options = {
             'general': {**self.GENERAL_CONFIG, 'targets': [section]},
-            section: self.SERVICE_CONFIG.copy(),
+            section: {**self.SERVICE_CONFIG.copy(), 'target': section},
         }
         if config_overrides:
             options[section].update(config_overrides)
@@ -112,7 +112,7 @@ class ServiceTest(ConfigTest):
         main_config = schema.MainSectionConfig(**options['general'])
         main_config.data = data.BugwarriorData(self.lists_path)
 
-        return service_class(service_config, main_config, section)
+        return service_class(service_config, main_config)
 
     @staticmethod
     def add_response(url, method='GET', **kwargs):

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -94,7 +94,7 @@ class TestNextcloudDeckIssue(AbstractServiceTest, ServiceTest):
     @property
     def service(self):
         conf = self.validate()
-        service = NextcloudDeckService(conf['deck'], conf['general'], 'deck')
+        service = NextcloudDeckService(conf['deck'], conf['general'])
         service.client = mock.MagicMock(spec=NextcloudDeckClient)
         service.client.get_boards = mock.MagicMock(
             return_value=[{'id': 5, 'title': 'testboard'}])

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -493,7 +493,7 @@ class TestGitlabService(ConfigTest):
     @property
     def service(self):
         conf = self.validate()
-        service = GitlabService(conf['myservice'], conf['general'], 'myservice')
+        service = GitlabService(conf['myservice'], conf['general'])
         service.gitlab_client.repo_cache = {1: {
             'id': 1,
             'path_with_namespace': 'arbitrary_namespace/arbitrary_project',

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -38,8 +38,7 @@ class TestGmailService(ConfigTest):
         gmail.GmailService.build_api = mock_api
 
         conf = self.validate()
-        self.service = gmail.GmailService(
-            conf['myservice'], conf['general'], 'myservice')
+        self.service = gmail.GmailService(conf['myservice'], conf['general'])
 
     def test_get_credentials_exists_and_valid(self):
         expected = Credentials(**copy(TEST_CREDENTIAL))

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -46,7 +46,7 @@ class testJiraService(ConfigTest):
         self.config['myjira']['body_length'] = '5'
         conf = schema.validate_config(self.config, 'general', 'configpath')
         service = JiraService(
-            conf['myjira'], conf['general'], 'myjira', _skip_server=True)
+            conf['myjira'], conf['general'], _skip_server=True)
         issue = mock.Mock()
         issue.record = dict(fields=dict(description=description))
         self.assertEqual(description[:5], service.body(issue))
@@ -55,7 +55,7 @@ class testJiraService(ConfigTest):
         description = "A very short issue body.  Fixes #828."
         conf = schema.validate_config(self.config, 'general', 'configpath')
         service = JiraService(
-            conf['myjira'], conf['general'], 'myjira', _skip_server=True)
+            conf['myjira'], conf['general'], _skip_server=True)
         issue = mock.Mock()
         issue = mock.Mock()
         issue.record = dict(fields=dict(description=description))

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -62,7 +62,7 @@ class ServiceBase(ConfigTest):
         with unittest.mock.patch('bugwarrior.config.schema.get_service',
                                  lambda x: DumbIssueService):
             conf = schema.validate_config(self.config, 'general', 'configpath')
-        return DumbIssueService(conf['test'], conf['general'], 'test')
+        return DumbIssueService(conf['test'], conf['general'])
 
     def makeIssue(self):
         service = self.makeService()

--- a/tests/test_trello.py
+++ b/tests/test_trello.py
@@ -96,7 +96,7 @@ class TestTrelloService(ConfigTest):
     def test_get_boards_config(self):
         self.config['mytrello']['include_boards'] = 'F00, B4R'
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
+        service = TrelloService(conf['mytrello'], conf['general'])
         boards = service.get_boards()
         self.assertEqual(list(boards), [{'id': 'F00', 'name': 'Foo Board'},
                                         {'id': 'B4R', 'name': 'Bar Board'}])
@@ -104,14 +104,14 @@ class TestTrelloService(ConfigTest):
     @responses.activate
     def test_get_boards_api(self):
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
+        service = TrelloService(conf['mytrello'], conf['general'])
         boards = service.get_boards()
         self.assertEqual(list(boards), [self.BOARD])
 
     @responses.activate
     def test_get_lists(self):
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
+        service = TrelloService(conf['mytrello'], conf['general'])
         lists = service.get_lists('B04RD')
         self.assertEqual(list(lists), [self.LIST1, self.LIST2])
 
@@ -119,7 +119,7 @@ class TestTrelloService(ConfigTest):
     def test_get_lists_include(self):
         self.config['mytrello']['include_lists'] = 'List 1'
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
+        service = TrelloService(conf['mytrello'], conf['general'])
         lists = service.get_lists('B04RD')
         self.assertEqual(list(lists), [self.LIST1])
 
@@ -127,14 +127,14 @@ class TestTrelloService(ConfigTest):
     def test_get_lists_exclude(self):
         self.config['mytrello']['exclude_lists'] = 'List 1'
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
+        service = TrelloService(conf['mytrello'], conf['general'])
         lists = service.get_lists('B04RD')
         self.assertEqual(list(lists), [self.LIST2])
 
     @responses.activate
     def test_get_cards(self):
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
+        service = TrelloService(conf['mytrello'], conf['general'])
         cards = service.get_cards('L15T')
         self.assertEqual(list(cards), [self.CARD1, self.CARD2, self.CARD3])
 
@@ -142,7 +142,7 @@ class TestTrelloService(ConfigTest):
     def test_get_cards_assigned(self):
         self.config['mytrello']['only_if_assigned'] = 'tintin'
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
+        service = TrelloService(conf['mytrello'], conf['general'])
         cards = service.get_cards('L15T')
         self.assertEqual(list(cards), [self.CARD1])
 
@@ -153,21 +153,21 @@ class TestTrelloService(ConfigTest):
             'also_unassigned': 'true',
         })
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
+        service = TrelloService(conf['mytrello'], conf['general'])
         cards = service.get_cards('L15T')
         self.assertEqual(list(cards), [self.CARD1, self.CARD3])
 
     @responses.activate
     def test_get_comments(self):
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
+        service = TrelloService(conf['mytrello'], conf['general'])
         comments = service.get_comments('C4RD')
         self.assertEqual(list(comments), [self.COMMENT1, self.COMMENT2])
 
     @responses.activate
     def test_annotations(self):
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
+        service = TrelloService(conf['mytrello'], conf['general'])
         annotations = service.annotations(self.CARD1)
         self.assertEqual(
             list(annotations), ["@luidgi - Preums", "@mario - Deuz"])
@@ -176,7 +176,7 @@ class TestTrelloService(ConfigTest):
     def test_annotations_with_link(self):
         self.config['general']['annotation_links'] = 'true'
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
+        service = TrelloService(conf['mytrello'], conf['general'])
         annotations = service.annotations(self.CARD1)
         self.assertEqual(
             list(annotations),
@@ -191,7 +191,7 @@ class TestTrelloService(ConfigTest):
             'only_if_assigned': 'tintin',
         })
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
+        service = TrelloService(conf['mytrello'], conf['general'])
         issues = service.issues()
         expected = {
             'due': parse_date('2018-12-02T12:59:00.000Z'),


### PR DESCRIPTION
<s>Based #973.</s>

This avoids having to pass the target separately into the service
constructor. It is also consistent with the broad conception of
configuration we use elsewhere (such as the `interactive` field), which
includes any modification of default behavior based on user input. In
this case the `target` is literally coming from the configuration file
so it is reasonable that we should be able to access it through the
configuration object.

This is also motivated by simplifying the base class API's before
stabilizing them (#775).