### PR TITLE
services.Issue: directly access configuration

### DIFF
--- a/bugwarrior/docs/contributing/new-service.rst
+++ b/bugwarrior/docs/contributing/new-service.rst
@@ -138,7 +138,7 @@ We will now implement an ``Issue`` class, which is essentially a wrapper for eac
       def to_taskwarrior(self):
           return {
               'project': self.extra['project'],
-              'priority': self.origin['default_priority'],
+              'priority': self.config.default_priority,
               'annotations': self.record.get('annotations', []),
               'tags': self.get_tags(),
               'entry': self.parse_date(self.record.get('createdAt')),
@@ -187,12 +187,6 @@ Now for the main service class which bugwarrior will invoke to fetch issues.
 
           self.client = GitBugClient(path=self.config.path, port=self.config.port)
 
-      def get_service_metadata(self):
-          return {
-              'import_labels_as_tags': self.config.import_labels_as_tags,
-              'label_template': self.config.label_template,
-          }
-
       def get_owner(self, issue):
           # Issue assignment hasn't been implemented in upstream git-bug yet.
           # See https://github.com/MichaelMure/git-bug/issues/112.
@@ -214,8 +208,6 @@ Now for the main service class which bugwarrior will invoke to fetch issues.
               yield self.get_issue_for_record(issue)
 
 Here we see two required class attributes (pointing to the classes we previously defined) and two required methods.
-
-The ``get_service_metadata`` method is not required, but can be used to expose additional data in the ``Issue.origin`` attribute.
 
 The ``get_owner`` method takes an individual issue and returns the "assigned" user, so that bugwarrior can filter issues on this basis. In this case git-bug has not yet implemented this feature, but it generally will just involve returning a value from the ``issue`` dictionary.
 

--- a/bugwarrior/services/azuredevops.py
+++ b/bugwarrior/services/azuredevops.py
@@ -136,9 +136,9 @@ class AzureDevopsIssue(Issue):
 
     def get_priority(self):
         value = self.record.get("fields").get(
-            "Microsoft.VSTS.Common.Priority", self.origin['default_priority']
+            "Microsoft.VSTS.Common.Priority", self.config.default_priority
         )
-        return self.PRIORITY_MAP.get(value, self.origin['default_priority'])
+        return self.PRIORITY_MAP.get(value, self.config.default_priority)
 
     def to_taskwarrior(self):
         return {
@@ -161,7 +161,7 @@ class AzureDevopsIssue(Issue):
             self.STATE: self.record["fields"]["System.State"],
             self.ACTIVITY: self.record.get("fields").get("System.Activity", ""),
             self.PRIORITY: self.record.get("fields").get(
-                "Microsoft.VSTS.Common.Priority", self.origin['default_priority']
+                "Microsoft.VSTS.Common.Priority", self.config.default_priority
             ),
             self.REMAINING_WORK: self.record.get("fields").get(
                 "Microsoft.VSTS.Scheduling.RemainingWork"

--- a/bugwarrior/services/bts.py
+++ b/bugwarrior/services/bts.py
@@ -115,7 +115,7 @@ class BTSIssue(Issue):
     def get_priority(self):
         return self.PRIORITY_MAP.get(
             self.record.get('severity'),
-            self.origin['default_priority']
+            self.config.default_priority
         )
 
 

--- a/bugwarrior/services/deck.py
+++ b/bugwarrior/services/deck.py
@@ -163,13 +163,6 @@ class NextcloudDeckService(IssueService):
             password=self.config.password
         )
 
-    def get_service_metadata(self):
-        return {
-            'import_labels_as_tags': self.config.import_labels_as_tags,
-            'label_template': self.config.label_template,
-            'only_if_assigned': self.config.only_if_assigned,
-        }
-
     def get_owner(self, issue):
         return issue[issue.ASSIGNEE]
 

--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -55,7 +55,7 @@ class GerritIssue(Issue):
             'annotations': self.extra['annotations'],
             self.URL: self.extra['url'],
 
-            'priority': self.origin['default_priority'],
+            'priority': self.config.default_priority,
             'tags': [],
             self.FOREIGN_ID: self.record['_number'],
             self.SUMMARY: self.record['subject'],
@@ -103,11 +103,6 @@ class GerritService(IssueService, ServiceClient):
     @staticmethod
     def get_keyring_service(config):
         return f"gerrit://{config.base_uri}"
-
-    def get_service_metadata(self):
-        return {
-            'url': self.config.base_uri,
-        }
 
     def get_owner(self, issue):
         # TODO

--- a/bugwarrior/services/gitbug.py
+++ b/bugwarrior/services/gitbug.py
@@ -125,8 +125,8 @@ class GitBugIssue(Issue):
 
     def to_taskwarrior(self):
         return {
-            'project': self.origin['target'],
-            'priority': self.origin['default_priority'],
+            'project': self.config.target,
+            'priority': self.config.default_priority,
             'annotations': self.record.get('annotations', []),
             'tags': self.get_tags(),
             'entry': self.parse_date(self.record.get('createdAt')),
@@ -157,12 +157,6 @@ class GitBugService(IssueService):
             path=self.config.path,
             port=self.config.port,
             annotation_comments=self.main_config.annotation_comments)
-
-    def get_service_metadata(self):
-        return {
-            'import_labels_as_tags': self.config.import_labels_as_tags,
-            'label_template': self.config.label_template,
-        }
 
     def get_owner(self, issue):
         # Issue assignment hasn't been implemented in upstream git-bug yet.

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -275,7 +275,7 @@ class GithubIssue(Issue):
 
         return {
             'project': self.extra['project'],
-            'priority': self.origin['default_priority'],
+            'priority': self.config.default_priority,
             'annotations': self.extra.get('annotations', []),
             'tags': self.get_tags(),
             'entry': created,
@@ -322,12 +322,6 @@ class GithubService(IssueService):
     @staticmethod
     def get_keyring_service(config):
         return f"github://{config.login}@{config.host}/{config.username}"
-
-    def get_service_metadata(self):
-        return {
-            'import_labels_as_tags': self.config.import_labels_as_tags,
-            'label_template': self.config.label_template,
-        }
 
     def get_owned_repo_issues(self, tag):
         """ Grab all the issues """

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -433,12 +433,12 @@ class GitlabIssue(Issue):
     # Override the method from parent class
     def get_priority(self):
         default_priority_map = {
-            'todo': self.origin['default_todo_priority'],
-            'merge_request': self.origin['default_mr_priority'],
-            'issue': self.origin['default_issue_priority']}
+            'todo': self.config.default_todo_priority,
+            'merge_request': self.config.default_mr_priority,
+            'issue': self.config.default_issue_priority}
 
         type_str = self.extra['type']
-        default_priority = self.origin['default_priority']
+        default_priority = self.config.default_priority
 
         return default_priority_map.get(type_str, default_priority)
 
@@ -546,15 +546,6 @@ class GitlabService(IssueService):
     @staticmethod
     def get_keyring_service(config):
         return f"gitlab://{config.login}@{config.host}"
-
-    def get_service_metadata(self):
-        return {
-            'import_labels_as_tags': self.config.import_labels_as_tags,
-            'label_template': self.config.label_template,
-            'default_issue_priority': self.config.default_issue_priority,
-            'default_todo_priority': self.config.default_todo_priority,
-            'default_mr_priority': self.config.default_mr_priority,
-        }
 
     def get_owner(self, issue):
         return [assignee['username'] for assignee in issue[1]['assignees']]

--- a/bugwarrior/services/gmail.py
+++ b/bugwarrior/services/gmail.py
@@ -84,7 +84,7 @@ class GmailIssue(Issue):
             'annotations': self.get_annotations(),
             'entry': self.get_entry(),
             'tags': [label for label in self.extra['labels'] if label not in self.EXCLUDE_LABELS],
-            'priority': self.origin['default_priority'],
+            'priority': self.config.default_priority,
             self.THREAD_ID: self.record['id'],
             self.SUBJECT: self.extra['subject'],
             self.URL: self.extra['url'],

--- a/bugwarrior/services/pagure.py
+++ b/bugwarrior/services/pagure.py
@@ -75,7 +75,7 @@ class PagureIssue(Issue):
         if self.extra['type'] == 'pull_request':
             priority = 'H'
         else:
-            priority = self.origin['default_priority']
+            priority = self.config.default_priority
 
         return {
             'project': self.extra['project'],
@@ -114,12 +114,6 @@ class PagureService(IssueService):
         super().__init__(*args, **kw)
 
         self.session = requests.Session()
-
-    def get_service_metadata(self):
-        return {
-            'import_tags': self.config.import_tags,
-            'tag_template': self.config.tag_template,
-        }
 
     def get_issues(self, repo, keys):
         """ Grab all the issues """

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -84,7 +84,7 @@ class PhabricatorIssue(Issue):
     @property
     def priority(self):
         return self.PRIORITY_MAP.get(self.record.get('priority')) \
-            or self.origin['default_priority']
+            or self.config.default_priority
 
 
 class PhabricatorService(IssueService):

--- a/bugwarrior/services/pivotaltracker.py
+++ b/bugwarrior/services/pivotaltracker.py
@@ -88,7 +88,7 @@ class PivotalTrackerIssue(Issue):
         return {
             'project': re.sub(
                 r'[^a-zA-Z0-9]', '_', self.extra['project_name']).lower(),
-            'priority': self.origin['default_priority'],
+            'priority': self.config.default_priority,
             'annotations': self.extra.get('annotations', []),
             'tags': self.get_tags(),
 
@@ -155,15 +155,6 @@ class PivotalTrackerService(IssueService, ServiceClient):
     def get_owner(self, issue):
         # Issue filtering is implemented as part of the api query.
         pass
-
-    def get_service_metadata(self):
-        return {
-            'import_labels_as_tags': self.config.import_labels_as_tags,
-            'label_template': self.config.label_template,
-            'annotation_template': self.config.annotation_template,
-            'import_blockers': self.config.import_blockers,
-            'blocker_template': self.config.blocker_template
-        }
 
     def annotations(self, annotations, story):
         final_annotations = []

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -211,11 +211,11 @@ class RedMineIssue(Issue):
     def get_priority(self):
         return self.PRIORITY_MAP.get(
             self.record.get('priority', {}).get('name'),
-            self.origin['default_priority']
+            self.config.default_priority
         )
 
     def get_issue_url(self):
-        return self.origin['url'] + "/issues/" + str(self.record["id"])
+        return self.config.url + "/issues/" + str(self.record["id"])
 
     def get_converted_hours(self, estimated_hours):
         tw = TaskWarriorShellout()
@@ -225,8 +225,8 @@ class RedMineIssue(Issue):
         )
 
     def get_project_name(self):
-        if self.origin['project_name']:
-            return self.origin['project_name']
+        if self.config.project_name:
+            return self.config.project_name
         # TODO: It would be nice to use the project slug (if the Redmine
         # instance supports it), but this would require (1) an API call
         # to get the list of projects, and then a look up between the
@@ -260,12 +260,6 @@ class RedMineService(IssueService):
                                     auth,
                                     self.config.issue_limit,
                                     self.config.verify_ssl)
-
-    def get_service_metadata(self):
-        return {
-            'project_name': self.config.project_name,
-            'url': self.config.url,
-        }
 
     @staticmethod
     def get_keyring_service(config):

--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -45,7 +45,7 @@ class TaigaIssue(Issue):
             'annotations': self.extra['annotations'],
             self.URL: self.extra['url'],
 
-            'priority': self.origin['default_priority'],
+            'priority': self.config.default_priority,
             'tags': self.get_tags(),
             self.FOREIGN_ID: self.record['ref'],
             self.SUMMARY: self.record['subject'],
@@ -79,12 +79,6 @@ class TaigaService(IssueService, ServiceClient):
     @staticmethod
     def get_keyring_service(config):
         return f"taiga://{config.base_uri}"
-
-    def get_service_metadata(self):
-        return {
-            'url': self.config.base_uri,
-            'label_template': self.config.label_template,
-        }
 
     def get_owner(self, issue):
         # TODO

--- a/bugwarrior/services/trac.py
+++ b/bugwarrior/services/trac.py
@@ -86,7 +86,7 @@ class TracIssue(Issue):
     def get_priority(self):
         return self.PRIORITY_MAP.get(
             self.record.get('priority'),
-            self.origin['default_priority']
+            self.config.default_priority
         )
 
 

--- a/bugwarrior/services/trello.py
+++ b/bugwarrior/services/trello.py
@@ -66,7 +66,7 @@ class TrelloIssue(Issue):
         return {
             'project': self.extra['boardname'],
             'due': self.parse_date(self.record['due']),
-            'priority': self.origin['default_priority'],
+            'priority': self.config.default_priority,
             'tags': self.get_tags(),
             self.NAME: self.record['name'],
             self.CARDID: self.record['id'],
@@ -92,15 +92,6 @@ class TrelloService(IssueService, ServiceClient):
     @staticmethod
     def get_keyring_service(config):
         return f"trello://{config.api_key}@trello.com"
-
-    def get_service_metadata(self):
-        """
-        Return extra config options to be passed to the TrelloIssue class
-        """
-        return {
-            'import_labels_as_tags': self.config.import_labels_as_tags,
-            'label_template': self.config.label_template,
-        }
 
     def issues(self):
         """

--- a/bugwarrior/services/versionone.py
+++ b/bugwarrior/services/versionone.py
@@ -123,10 +123,10 @@ class VersionOneIssue(Issue):
     def to_taskwarrior(self):
         return {
             'project': self.extra['project'],
-            'priority': self.origin['default_priority'],
+            'priority': self.config.default_priority,
             'due': self.parse_date(
                 self.record['timebox']['EndDate'],
-                self.origin['timezone']
+                self.config.timezone
             ),
 
             self.TASK_NAME: self.record['task']['Name'],
@@ -209,11 +209,6 @@ class VersionOneService(IssueService):
             parsed_address.netloc,
             parsed_address.path
         )
-
-    def get_service_metadata(self):
-        return {
-            'timezone': self.config.timezone
-        }
 
     def get_meta(self):
         if not hasattr(self, '_meta'):

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -113,7 +113,6 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
         service = super().get_mock_service(*args, **kwargs)
         service.jira = FakeJiraClient(self.arbitrary_record)
         service.sprint_field_names = ['Sprint']
-        service.import_sprints_as_tags = True
         return service
 
     def get_extra_fields(self):
@@ -177,7 +176,8 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
         arbitrary_extra = {
             'jira_version': 5,
             'annotations': ['an annotation'],
-            'extra_fields': self.get_extra_fields()}
+            'extra_fields': self.get_extra_fields()
+        }
 
         issue = self.service.get_issue_for_record(
             record_with_goal, arbitrary_extra
@@ -190,7 +190,7 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
             ),
             'annotations': arbitrary_extra['annotations'],
             'due': datetime.datetime(2016, 9, 23, 16, 8, tzinfo=tzutc()),
-            'tags': ['Sprint_1'],
+            'tags': [],
             'entry': datetime.datetime(2016, 6, 6, 13, 7, 8, tzinfo=tzutc()),
             'jirafixversion': '1.2.3',
             'jiraissuetype': 'Epic',

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -16,6 +16,9 @@ that long.""".replace('\n', ' ')
 class DumbConfig(config.ServiceConfig):
     service: typing_extensions.Literal['test']
 
+    import_labels_as_tags: bool = False
+    label_template: str = '{{label}}'
+
 
 class DumbIssue(services.Issue):
     """
@@ -35,9 +38,6 @@ class DumbIssueService(services.IssueService):
     """
     ISSUE_CLASS = DumbIssue
     CONFIG_SCHEMA = DumbConfig
-
-    def get_service_metadata(self):
-        return {'import_labels_as_tags': True, 'label_template': '{{ label }}'}
 
     def get_owner(self, issue):
         raise NotImplementedError
@@ -125,6 +125,7 @@ class TestIssue(ServiceBase):
             description, f'(bw)Is# - {LONG_MESSAGE}')
 
     def test_get_tags_from_labels_normalization(self):
+        self.config['test']['import_labels_as_tags'] = True
         issue = self.makeIssue()
 
         self.assertEqual(issue.get_tags_from_labels(['needs work']),

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,6 +1,8 @@
 from .base import ServiceTest
 from .test_service import DumbIssue
 
+from bugwarrior.config.schema import ServiceConfig, MainSectionConfig
+
 
 class TestTemplates(ServiceTest):
     def setUp(self):
@@ -15,16 +17,14 @@ class TestTemplates(ServiceTest):
         self, templates=None, issue=None, description=None, add_tags=None
     ):
         templates = {} if templates is None else templates
-        origin = {
-            'annotation_length': 100,  # Arbitrary
-            'default_priority': 'H',  # Arbitrary
-            'description_length': 100,  # Arbitrary
-            'templates': templates,
-            'shorten': False,  # Arbitrary
-            'add_tags': add_tags if add_tags else [],
-        }
+        config = ServiceConfig(
+            target='dummy',
+            templates=templates,
+            add_tags=add_tags if add_tags else [],
+        )
+        main_config = MainSectionConfig(interactive=False, targets=[])
 
-        issue = DumbIssue({}, origin)
+        issue = DumbIssue({}, config, main_config)
         issue.to_taskwarrior = lambda: (
             self.arbitrary_issue if description is None else description
         )

--- a/tests/test_trello.py
+++ b/tests/test_trello.py
@@ -1,7 +1,8 @@
 from dateutil.parser import parse as parse_date
 import responses
 
-from bugwarrior.services.trello import TrelloService, TrelloIssue
+from bugwarrior.services.trello import TrelloConfig, TrelloService, TrelloIssue
+from bugwarrior.config.schema import MainSectionConfig
 
 from .base import ConfigTest, ServiceTest
 
@@ -21,13 +22,16 @@ class TestTrelloIssue(ServiceTest):
 
     def setUp(self):
         super().setUp()
-        origin = {
-            'inline_links': True, 'description_length': 31,
-            'import_labels_as_tags': True, 'default_priority': 'M',
-            'label_template': 'trello_{{label}}'}
+        config = TrelloConfig(
+            service='trello', api_key='abc123', token='def456',
+            import_labels_as_tags=True, default_priority='M',
+            label_template='trello_{{label}}')
+        main_config = MainSectionConfig(
+            interactive=False, targets=[], inline_links=True,
+            description_length=31)
         extra = {'boardname': 'Hyperspatial express route',
                  'listname': 'Something'}
-        self.issue = TrelloIssue(self.JSON, origin, extra)
+        self.issue = TrelloIssue(self.JSON, config, main_config, extra)
 
     def test_default_description(self):
         """ Test the generated description """


### PR DESCRIPTION
*<s>Based on #979, #976, and #973.</s>*

Rather than using the `origin` dictionary to pass configuration values
from Service to Issue, give `Issue` direct access to the `config` and
`main_config` objects.

There are several advantages to this approach:

1. "Origin" is an unclear name of which a developer has to build a
   conception. It's elimination means the (more straightforward)
   conception of "config" can be transferred from the `Service` object.
   That's one fewer concept for developers to juggle, which is good for
   bugwarrior core maintenance and for service development.
2. Elimination of `get_service_metadata`. This method's name also does
   not really convey it's purpose and I was unsurprised to find that
   many services pass data through this method which is never actually
   used by the `Issue`.
3. Decoupling `Service` and `Issue`. Changes that only involve `Issue`
   and configuration no longer require meddling with `Service`, which
   is just a middle man.
4. Elimination of bidirectional communication between `Service` base
   class and instances. The child classes were calling
   `self.get_issue_for_record` on the base class, which was calling
   `self.get_service_metadata` on the child class. In some ways this is
   a re-iteration of point (2) -- this is a pattern that leads to
   confusion and to me is a code smell.

The architectural trade-off is that `Issue` is now directly coupled to
configuration, but in my opinion the previous indirection was merely a
vicarious coupling that doesn't provide much benefit any more. When this
design was first implemented, configuration was parsed in the `Service`
class, so it made sense because it avoided duplication of parsing and
provided consistency; this is no longer a relevant consideration.

This is largely motivated by a desire to simplify services for #775.