### PR TITLE
tests: use configparser "mapping protocol"

### DIFF
--- a/tests/config/test_data.py
+++ b/tests/config/test_data.py
@@ -43,13 +43,13 @@ class TestGetDataPath(ConfigTest):
     def setUp(self):
         super().setUp()
         rawconfig = load.BugwarriorConfigParser()
-        rawconfig.add_section('general')
-        rawconfig.set('general', 'targets', 'my_service')
-        rawconfig.add_section('my_service')
-        rawconfig.set('my_service', 'service', 'github')
-        rawconfig.set('my_service', 'github.login', 'ralphbean')
-        rawconfig.set('my_service', 'github.token', 'abc123')
-        rawconfig.set('my_service', 'github.username', 'ralphbean')
+        rawconfig['general'] = {'targets': 'my_service'}
+        rawconfig['my_service'] = {
+            'service': 'github',
+            'github.login': 'ralphbean',
+            'github.token': 'abc123',
+            'github.username': 'ralphbean',
+        }
         self.config = schema.validate_config(
             rawconfig, 'general', 'configpath')
 

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -73,10 +73,11 @@ class TestGetConfigPath(ConfigTest):
 class TestBugwarriorConfigParser(TestCase):
     def setUp(self):
         self.config = load.BugwarriorConfigParser()
-        self.config.add_section('general')
-        self.config.set('general', 'someint', '4')
-        self.config.set('general', 'somenone', '')
-        self.config.set('general', 'somechar', 'somestring')
+        self.config['general'] = {
+            'someint': '4',
+            'somenone': '',
+            'somechar': 'somestring',
+        }
 
     def test_getint(self):
         self.assertEqual(self.config.getint('general', 'someint'), 4)

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -59,52 +59,53 @@ class TestValidation(ConfigTest):
     def setUp(self):
         super().setUp()
         self.config = load.BugwarriorConfigParser()
-        self.config.add_section('general')
-        self.config.set('general', 'targets', 'my_service, my_kan, my_gitlab')
-        self.config.add_section('my_service')
-        self.config.set('my_service', 'service', 'github')
-        self.config.set('my_service', 'github.login', 'ralph')
-        self.config.set('my_service', 'github.username', 'ralph')
-        self.config.set('my_service', 'github.token', 'abc123')
-        self.config.add_section('my_kan')
-        self.config.set('my_kan', 'service', 'kanboard')
-        self.config.set(
-            'my_kan', 'kanboard.url', 'https://kanboard.example.org')
-        self.config.set('my_kan', 'kanboard.username', 'ralph')
-        self.config.set('my_kan', 'kanboard.password', 'abc123')
-        self.config.add_section('my_gitlab')
-        self.config.set('my_gitlab', 'service', 'gitlab')
-        self.config.set('my_gitlab', 'gitlab.host', 'my-git.org')
-        self.config.set('my_gitlab', 'gitlab.login', 'arbitrary_login')
-        self.config.set('my_gitlab', 'gitlab.token', 'arbitrary_token')
+        self.config['general'] = {'targets': 'my_service, my_kan, my_gitlab'}
+        self.config['my_service'] = {
+            'service': 'github',
+            'github.login': 'ralph',
+            'github.username': 'ralph',
+            'github.token': 'abc123',
+        }
+        self.config['my_kan'] = {
+            'service': 'kanboard',
+            'kanboard.url': 'https://kanboard.example.org',
+            'kanboard.username': 'ralph',
+            'kanboard.password': 'abc123',
+        }
+        self.config['my_gitlab'] = {
+            'service': 'gitlab',
+            'gitlab.host': 'my-git.org',
+            'gitlab.login': 'arbitrary_login',
+            'gitlab.token': 'arbitrary_token',
+        }
 
     def test_valid(self):
         self.validate()
 
     def test_main_section_required(self):
-        self.config.remove_section('general')
+        del self.config['general']
 
         self.assertValidationError("No section: 'general'")
 
     def test_main_section_missing_targets_option(self):
-        self.config.remove_option('general', 'targets')
+        del self.config['general']['targets']
 
         self.assertValidationError("No option 'targets' in section: 'general'")
 
     def test_target_section_missing(self):
-        self.config.remove_section('my_service')
+        del self.config['my_service']
 
         self.assertValidationError("No section: 'my_service'")
 
     def test_service_missing(self):
-        self.config.remove_option('my_service', 'service')
+        del self.config['my_service']['service']
 
         self.assertValidationError(
             "No option 'service' in section: 'my_service'")
 
     def test_missing_prefix(self):
         # set improperly scoped field
-        self.config.set('my_service', 'also_unassigned', 'True')
+        self.config['my_service']['also_unassigned'] = 'True'
 
         self.assertValidationError(
             "[my_service]\nalso_unassigned  <- "
@@ -112,7 +113,7 @@ class TestValidation(ConfigTest):
 
     def test_wrong_prefix(self):
         # set improperly scoped field
-        self.config.set('my_service', 'fake.also_unassigned', 'True')
+        self.config['my_service']['fake.also_unassigned'] = 'True'
 
         self.assertValidationError(
             "[my_service]\nfake.also_unassigned  <- "
@@ -120,14 +121,14 @@ class TestValidation(ConfigTest):
 
     def test_extra_field(self):
         """ Undeclared fields are forbidden. """
-        self.config.set('my_service', 'github.undeclared_field', 'extra')
+        self.config['my_service']['github.undeclared_field'] = 'extra'
 
         self.assertValidationError(
             '[my_service]\n'
             'github.undeclared_field  <- unrecognized option')
 
     def test_root_validator(self):
-        self.config.remove_option('my_service', 'github.username')
+        del self.config['my_service']['github.username']
 
         self.assertValidationError(
             '[my_service]  <- '
@@ -138,18 +139,17 @@ class TestValidation(ConfigTest):
         self.assertEqual(conf['my_service'].host, 'github.com')
 
     def test_no_scheme_url_validator_set(self):
-        self.config.set('my_service', 'github.host', 'github.com')
+        self.config['my_service']['github.host'] = 'github.com'
         conf = self.validate()
         self.assertEqual(conf['my_service'].host, 'github.com')
 
     def test_no_scheme_url_validator_scheme(self):
-        self.config.set('my_service', 'github.host', 'https://github.com')
+        self.config['my_service']['github.host'] = 'https://github.com'
         self.assertValidationError(
             "github.host  <- URL should not include scheme ('https')")
 
     def test_stripped_trailing_slash_url(self):
-        self.config.set(
-            'my_kan', 'kanboard.url', 'https://kanboard.example.org/')
+        self.config['my_kan']['kanboard.url'] = 'https://kanboard.example.org/'
         conf = self.validate()
         self.assertEqual(conf['my_kan'].url, 'https://kanboard.example.org')
 
@@ -157,24 +157,25 @@ class TestValidation(ConfigTest):
         conf = self.validate()
         self.assertEqual(conf['my_gitlab'].include_merge_requests, True)
 
-        self.config.set('my_gitlab', 'gitlab.filter_merge_requests', 'true')
+        self.config['my_gitlab']['gitlab.filter_merge_requests'] = 'true'
         conf = self.validate()
         self.assertEqual(conf['my_gitlab'].include_merge_requests, False)
 
     def test_deprecated_filter_merge_requests_and_include_merge_requests(self):
-        self.config.set('my_gitlab', 'gitlab.filter_merge_requests', 'true')
-        self.config.set('my_gitlab', 'gitlab.include_merge_requests', 'true')
+        self.config['my_gitlab']['gitlab.filter_merge_requests'] = 'true'
+        self.config['my_gitlab']['gitlab.include_merge_requests'] = 'true'
         self.assertValidationError(
             '[my_gitlab]  <- filter_merge_requests and include_merge_requests are incompatible.')
 
     def test_deprecated_project_name(self):
         """ We're just testing that deprecation doesn't break validation. """
-        self.config.set('general', 'targets', 'my_service, my_kan, my_gitlab, my_redmine')
-        self.config.add_section('my_redmine')
-        self.config.set('my_redmine', 'service', 'redmine')
-        self.config.set('my_redmine', 'redmine.url', 'https://example.com')
-        self.config.set('my_redmine', 'redmine.key', 'mykey')
+        self.config['general']['targets'] = 'my_service, my_kan, my_gitlab, my_redmine'
+        self.config['my_redmine'] = {
+            'service': 'redmine',
+            'redmine.url': 'https://example.com',
+            'redmine.key': 'mykey',
+        }
         self.validate()
 
-        self.config.set('my_redmine', 'redmine.project_name', 'myproject')
+        self.config['my_redmine']['redmine.project_name'] = 'myproject'
         self.validate()

--- a/tests/test_azuredevops.py
+++ b/tests/test_azuredevops.py
@@ -114,34 +114,40 @@ class TestAzureDevopsServiceConfig(ConfigTest):
     def setUp(self):
         super().setUp()
         self.config = BugwarriorConfigParser()
-        self.config.add_section("general")
-        self.config.set("general", "targets", "test_ado")
-        self.config.add_section("test_ado")
-        self.config.set("test_ado", "service", "azuredevops")
+        self.config["general"] = {"targets": "test_ado"}
+        self.config["test_ado"] = {"service": "azuredevops"}
 
     def test_validate_config_required_fields(self):
-        self.config.set("test_ado", "ado.organization", "test_organization")
-        self.config.set("test_ado", "ado.project", "test_project")
-        self.config.set("test_ado", "ado.PAT", "myPAT")
+        self.config["test_ado"].update({
+            "ado.organization": "test_organization",
+            "ado.project": "test_project",
+            "ado.PAT": "myPAT",
+        })
         self.validate()
 
     def test_validate_config_no_organization(self):
-        self.config.set("test_ado", "ado.project", "test_project")
-        self.config.set("test_ado", "ado.PAT", "myPAT")
+        self.config["test_ado"].update({
+            "ado.project": "test_project",
+            "ado.PAT": "myPAT",
+        })
 
         self.assertValidationError(
             '[test_ado]\nado.organization  <- field required')
 
     def test_validate_config_no_project(self):
-        self.config.set("test_ado", "ado.organization", "http://one.com/")
-        self.config.set("test_ado", "ado.PAT", "myPAT")
+        self.config["test_ado"].update({
+            "ado.organization": "http://one.com/",
+            "ado.PAT": "myPAT",
+        })
 
         self.assertValidationError(
             '[test_ado]\nado.project  <- field required')
 
     def test_validate_config_no_PAT(self):
-        self.config.set("test_ado", "ado.organization", "http://one.com/")
-        self.config.set("test_ado", "ado.project", "test_project")
+        self.config["test_ado"].update({
+            "ado.organization": "http://one.com/",
+            "ado.project": "test_project",
+        })
 
         self.assertValidationError(
             '[test_ado]\nado.PAT  <- field required')

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -22,38 +22,44 @@ class TestBugzillaServiceConfig(ConfigTest):
     def setUp(self):
         super().setUp()
         self.config = BugwarriorConfigParser()
-        self.config.add_section('general')
-        self.config.set('general', 'targets', 'mybz')
-        self.config.add_section('mybz')
-        self.config.set('mybz', 'service', 'bugzilla')
+        self.config['general'] = {'targets': 'mybz'}
+        self.config['mybz'] = {'service': 'bugzilla'}
 
     def test_validate_config_username_password(self):
-        self.config.set('mybz', 'bugzilla.base_uri', 'https://one.com/')
-        self.config.set('mybz', 'bugzilla.username', 'me')
-        self.config.set('mybz', 'bugzilla.password', 'mypas')
+        self.config['mybz'].update({
+            'bugzilla.base_uri': 'https://one.com/',
+            'bugzilla.username': 'me',
+            'bugzilla.password': 'mypas',
+        })
 
         # no error expected
         self.validate()
 
     def test_validate_config_api_key(self):
-        self.config.set('mybz', 'bugzilla.base_uri', 'https://one.com/')
-        self.config.set('mybz', 'bugzilla.username', 'me')
-        self.config.set('mybz', 'bugzilla.api_key', '123')
+        self.config['mybz'].update({
+            'bugzilla.base_uri': 'https://one.com/',
+            'bugzilla.username': 'me',
+            'bugzilla.api_key': '123',
+        })
 
         # no error expected
         self.validate()
 
     def test_validate_config_api_key_no_username(self):
-        self.config.set('mybz', 'bugzilla.base_uri', 'https://one.com/')
-        self.config.set('mybz', 'bugzilla.api_key', '123')
+        self.config['mybz'].update({
+            'bugzilla.base_uri': 'https://one.com/',
+            'bugzilla.api_key': '123',
+        })
 
         self.assertValidationError(
             '[mybz]\nbugzilla.username  <- field required')
 
     def test_validate_legacy_schemeless_uri(self):
-        self.config.set('mybz', 'bugzilla.base_uri', 'one.com/')
-        self.config.set('mybz', 'bugzilla.username', 'me')
-        self.config.set('mybz', 'bugzilla.password', 'mypas')
+        self.config['mybz'].update({
+            'bugzilla.base_uri': 'one.com/',
+            'bugzilla.username': 'me',
+            'bugzilla.password': 'mypas',
+        })
 
         # no error expected
         self.validate()

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -38,15 +38,17 @@ class TestPull(ConfigTest):
         self.runner = CliRunner()
         self.config = BugwarriorConfigParser()
 
-        self.config.add_section('general')
-        self.config.set('general', 'targets', 'my_service')
-        self.config.set('general', 'static_fields', 'project, priority')
-        self.config.set('general', 'taskrc', self.taskrc)
-        self.config.add_section('my_service')
-        self.config.set('my_service', 'service', 'github')
-        self.config.set('my_service', 'github.login', 'ralphbean')
-        self.config.set('my_service', 'github.token', 'abc123')
-        self.config.set('my_service', 'github.username', 'ralphbean')
+        self.config['general'] = {
+            'targets': 'my_service',
+            'static_fields': 'project, priority',
+            'taskrc': self.taskrc,
+        }
+        self.config['my_service'] = {
+            'service': 'github',
+            'github.login': 'ralphbean',
+            'github.token': 'abc123',
+            'github.username': 'ralphbean',
+        }
 
         self.write_rc(self.config)
 
@@ -107,13 +109,12 @@ class TestPull(ConfigTest):
         Synchronization should work for succeeding services even if one service
         fails.  See https://github.com/ralphbean/bugwarrior/issues/279.
         """
-        self.config.set('general', 'targets', 'my_service,my_broken_service')
-        self.config.add_section('my_broken_service')
-        self.config.set('my_broken_service', 'service', 'bugzilla')
-        self.config.set(
-            'my_broken_service', 'bugzilla.base_uri', 'bugzilla.redhat.com')
-        self.config.set(
-            'my_broken_service', 'bugzilla.username', 'rbean@redhat.com')
+        self.config['general']['targets'] = 'my_service,my_broken_service'
+        self.config['my_broken_service'] = {
+            'service': 'bugzilla',
+            'bugzilla.base_uri': 'bugzilla.redhat.com',
+            'bugzilla.username': 'rbean@redhat.com',
+        }
 
         self.write_rc(self.config)
 
@@ -135,13 +136,12 @@ class TestPull(ConfigTest):
         See https://github.com/ralphbean/bugwarrior/issues/821.
         """
         # Add the broken service to the configuration.
-        self.config.set('general', 'targets', 'my_service,my_broken_service')
-        self.config.add_section('my_broken_service')
-        self.config.set('my_broken_service', 'service', 'bugzilla')
-        self.config.set(
-            'my_broken_service', 'bugzilla.base_uri', 'bugzilla.redhat.com')
-        self.config.set(
-            'my_broken_service', 'bugzilla.username', 'rbean@redhat.com')
+        self.config['general']['targets'] = 'my_service,my_broken_service'
+        self.config['my_broken_service'] = {
+            'service': 'bugzilla',
+            'bugzilla.base_uri': 'bugzilla.redhat.com',
+            'bugzilla.username': 'rbean@redhat.com',
+        }
         self.write_rc(self.config)
 
         # Add a task to each service.

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -88,15 +88,17 @@ class TestSynchronize(ConfigTest):
             return remove_non_deterministic_keys(tw.load_tasks())
 
         self.config = BugwarriorConfigParser()
-        self.config.add_section('general')
-        self.config.set('general', 'targets', 'my_service')
-        self.config.set('general', 'taskrc', self.taskrc)
-        self.config.set('general', 'static_fields', 'project, priority')
-        self.config.add_section('my_service')
-        self.config.set('my_service', 'service', 'github')
-        self.config.set('my_service', 'github.login', 'ralphbean')
-        self.config.set('my_service', 'github.username', 'ralphbean')
-        self.config.set('my_service', 'github.token', 'abc123')
+        self.config['general'] = {
+            'targets': 'my_service',
+            'taskrc': self.taskrc,
+            'static_fields': 'project, priority',
+        }
+        self.config['my_service'] = {
+            'service': 'github',
+            'github.login': 'ralphbean',
+            'github.username': 'ralphbean',
+            'github.token': 'abc123',
+        }
         bwconfig = self.validate()
 
         tw = taskw.TaskWarrior(self.taskrc)
@@ -206,14 +208,13 @@ class TestSynchronize(ConfigTest):
 class TestUDAs(ConfigTest):
     def test_udas(self):
         self.config = BugwarriorConfigParser()
-        self.config.add_section('general')
-        self.config.set('general', 'targets', 'my_service')
-        self.config.add_section('my_service')
-        self.config.set('my_service', 'service', 'github')
-        self.config.set('my_service', 'github.login', 'ralphbean')
-        self.config.set('my_service', 'github.username', 'ralphbean')
-        self.config.set('my_service', 'github.token', 'abc123')
-        self.config.set('my_service', 'service', 'github')
+        self.config['general'] = {'targets': 'my_service'}
+        self.config['my_service'] = {
+            'service': 'github',
+            'github.login': 'ralphbean',
+            'github.username': 'ralphbean',
+            'github.token': 'abc123',
+        }
 
         conf = self.validate()
         udas = sorted(list(db.get_defined_udas_as_strings(conf, 'general')))

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -76,16 +76,18 @@ class TestNextcloudDeckIssue(AbstractServiceTest, ServiceTest):
     def setUp(self):
         super().setUp()
         self.config = BugwarriorConfigParser()
-        self.config.add_section('general')
-        self.config.set('general', 'targets', 'deck')
-        # would otherwise cut the title short
-        self.config.set('general', 'description_length', '45')
-        self.config.add_section('deck')
-        self.config.set('deck', 'service', 'deck')
-        self.config.set('deck', 'deck.base_uri', 'http://localhost:8080')
-        self.config.set('deck', 'deck.username', 'testuser')
-        self.config.set('deck', 'deck.password', 'testpassword')
-        self.config.set('deck', 'deck.import_labels_as_tags', 'true')
+        self.config['general'] = {
+            'targets': 'deck',
+            # would otherwise cut the title short
+            'description_length': '45'
+        }
+        self.config['deck'] = {
+            'service': 'deck',
+            'deck.base_uri': 'http://localhost:8080',
+            'deck.username': 'testuser',
+            'deck.password': 'testpassword',
+            'deck.import_labels_as_tags': 'true',
+        }
 
         self.data = TestData()
 
@@ -158,11 +160,11 @@ class TestNextcloudDeckIssue(AbstractServiceTest, ServiceTest):
         self.assertEqual(issue.get_taskwarrior_record(), expected)
 
     def test_filter_boards_include(self):
-        self.config.set('deck', 'deck.include_board_ids', '5')
+        self.config['deck']['deck.include_board_ids'] = '5'
         self.assertTrue(self.service.filter_boards({'title': 'testboard', 'id': 5}))
         self.assertFalse(self.service.filter_boards({'title': 'testboard', 'id': 6}))
 
     def test_filter_boards_exclude(self):
-        self.config.set('deck', 'deck.exclude_board_ids', '5')
+        self.config['deck']['deck.exclude_board_ids'] = '5'
         self.assertFalse(self.service.filter_boards({'title': 'testboard', 'id': 5}))
         self.assertTrue(self.service.filter_boards({'title': 'testboard', 'id': 6}))

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -28,10 +28,8 @@ class TestGmailService(ConfigTest):
     def setUp(self):
         super().setUp()
         self.config = BugwarriorConfigParser()
-        self.config.add_section('general')
-        self.config.set('general', 'targets', 'myservice')
-        self.config.add_section('myservice')
-        self.config.set('myservice', 'service', 'gmail')
+        self.config['general'] = {'targets': 'myservice'}
+        self.config['myservice'] = {'service': 'gmail'}
 
         mock_data = mock.Mock()
         mock_data.path = self.tempdir

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -27,20 +27,21 @@ class testJiraService(ConfigTest):
     def setUp(self):
         super().setUp()
         self.config = load.BugwarriorConfigParser()
-        self.config.add_section('general')
-        self.config.set('general', 'targets', 'myjira')
-        self.config.set('general', 'interactive', 'false')
-        self.config.add_section('myjira')
-        self.config.set('myjira', 'service', 'jira')
-        self.config.set('myjira', 'jira.base_uri', 'https://example.com')
-        self.config.set('myjira', 'jira.username', 'milou')
-        self.config.set('myjira', 'jira.password', 't0ps3cr3t')
-        self.config.set('myjira', 'jira.extra_fields',
-                        'jiraextra1:customfield_10000,jiraextra2:namedfield.valueinside')
+        self.config['general'] = {
+            'targets': 'myjira',
+            'interactive': 'false',
+        }
+        self.config['myjira'] = {
+            'service': 'jira',
+            'jira.base_uri': 'https://example.com',
+            'jira.username': 'milou',
+            'jira.password': 't0ps3cr3t',
+            'jira.extra_fields': 'jiraextra1:customfield_10000,jiraextra2:namedfield.valueinside',
+        }
 
     def test_body_length_no_limit(self):
         description = "A very short issue body.  Fixes #828."
-        self.config.set('myjira', 'jira.body_length', '5')
+        self.config['myjira']['jira.body_length'] = '5'
         conf = schema.validate_config(self.config, 'general', 'configpath')
         service = JiraService(
             conf['myjira'], conf['general'], 'myjira', _skip_server=True)

--- a/tests/test_kanboard.py
+++ b/tests/test_kanboard.py
@@ -13,43 +13,51 @@ class TestKanboardServiceConfig(ConfigTest):
     def setUp(self):
         super().setUp()
         self.config = BugwarriorConfigParser()
-        self.config.add_section("general")
-        self.config.set("general", "targets", "kb")
-        self.config.add_section("kb")
-        self.config.set("kb", "service", "kanboard")
+        self.config["general"] = {"targets": "kb"}
+        self.config["kb"] = {"service": "kanboard"}
 
     def test_validate_config_required_fields(self):
-        self.config.set("kb", "kanboard.url", "http://example.com/")
-        self.config.set("kb", "kanboard.username", "myuser")
-        self.config.set("kb", "kanboard.password", "mypass")
+        self.config["kb"].update({
+            "kanboard.url": "http://example.com/",
+            "kanboard.username": "myuser",
+            "kanboard.password": "mypass",
+        })
 
         self.validate()
 
     def test_validate_config_no_url(self):
-        self.config.set("kb", "kanboard.username", "myuser")
-        self.config.set("kb", "kanboard.password", "mypass")
+        self.config["kb"].update({
+            "kanboard.username": "myuser",
+            "kanboard.password": "mypass",
+        })
 
         self.assertValidationError(
             '[kb]\nkanboard.url  <- field required')
 
     def test_validate_config_no_username(self):
-        self.config.set("kb", "kanboard.url", "http://one.com/")
-        self.config.set("kb", "kanboard.password", "mypass")
+        self.config["kb"].update({
+            "kanboard.url": "http://one.com/",
+            "kanboard.password": "mypass",
+        })
 
         self.assertValidationError(
             '[kb]\nkanboard.username  <- field required')
 
     def test_validate_config_no_password(self):
-        self.config.set("kb", "kanboard.url", "http://one.com/")
-        self.config.set("kb", "kanboard.username", "myuser")
+        self.config["kb"].update({
+            "kanboard.url": "http://one.com/",
+            "kanboard.username": "myuser",
+        })
 
         self.assertValidationError(
             '[kb]\nkanboard.password  <- field required')
 
     def test_get_keyring_service(self):
-        self.config.set("kb", "kanboard.url", "http://example.com/")
-        self.config.set("kb", "kanboard.username", "myuser")
-        self.config.set("kb", "kanboard.password", "mypass")
+        self.config["kb"].update({
+            "kanboard.url": "http://example.com/",
+            "kanboard.username": "myuser",
+            "kanboard.password": "mypass",
+        })
         service_config = self.validate()['kb']
         self.assertEqual(
             KanboardService.get_keyring_service(service_config),

--- a/tests/test_pivotaltracker.py
+++ b/tests/test_pivotaltracker.py
@@ -179,44 +179,52 @@ class TestPivotalTrackerServiceConfig(ConfigTest):
     def setUp(self):
         super().setUp()
         self.config = BugwarriorConfigParser()
-        self.config.add_section('general')
-        self.config.set('general', 'targets', 'pivotal')
-        self.config.add_section('pivotal')
-        self.config.set('pivotal', 'service', 'pivotaltracker')
+        self.config['general'] = {'targets': 'pivotal'}
+        self.config['pivotal'] = {'service': 'pivotaltracker'}
 
     def test_validate_config(self):
-        self.config.set('pivotal', 'pivotaltracker.account_ids', '12345')
-        self.config.set('pivotal', 'pivotaltracker.user_id', '12345')
-        self.config.set('pivotal', 'pivotaltracker.token', '12345')
+        self.config['pivotal'].update({
+            'pivotaltracker.account_ids': '12345',
+            'pivotaltracker.user_id': '12345',
+            'pivotaltracker.token': '12345',
+        })
 
         self.validate()
 
     def test_validate_config_no_account_ids(self):
-        self.config.set('pivotal', 'pivotaltracker.token', '123')
-        self.config.set('pivotal', 'pivotaltracker.user_id', '12345')
+        self.config['pivotal'].update({
+            'pivotaltracker.token': '123',
+            'pivotaltracker.user_id': '12345',
+        })
 
         self.assertValidationError(
             '[pivotal]\npivotaltracker.account_ids  <- field required')
 
     def test_validate_config_no_user_id(self):
-        self.config.set('pivotal', 'pivotaltracker.account_ids', '12345')
-        self.config.set('pivotal', 'pivotaltracker.token', '123')
+        self.config['pivotal'].update({
+            'pivotaltracker.account_ids': '12345',
+            'pivotaltracker.token': '123',
+        })
 
         self.assertValidationError(
             '[pivotal]\npivotaltracker.user_id  <- field required')
 
     def test_validate_config_token(self):
-        self.config.set('pivotal', 'pivotaltracker.account_ids', '12345')
-        self.config.set('pivotal', 'pivotaltracker.user_id', '12345')
+        self.config['pivotal'].update({
+            'pivotaltracker.account_ids': '12345',
+            'pivotaltracker.user_id': '12345',
+        })
 
         self.assertValidationError(
             '[pivotal]\npivotaltracker.token  <- field required')
 
     def test_validate_config_invalid_endpoint(self):
-        self.config.set('pivotal', 'pivotaltracker.account_ids', '12345')
-        self.config.set('pivotal', 'pivotaltracker.token', '123')
-        self.config.set('pivotal', 'pivotaltracker.user_id', '12345')
-        self.config.set('pivotal', 'pivotaltracker.version', 'v1')
+        self.config['pivotal'].update({
+            'pivotaltracker.account_ids': '12345',
+            'pivotaltracker.token': '123',
+            'pivotaltracker.user_id': '12345',
+            'pivotaltracker.version': 'v1',
+        })
 
         self.assertValidationError(
             '[pivotal]\npivotaltracker.version  <- unexpected value')

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -51,11 +51,11 @@ class ServiceBase(ConfigTest):
     def setUp(self):
         super().setUp()
         self.config = load.BugwarriorConfigParser()
-        self.config.add_section('general')
-        self.config.set('general', 'targets', 'test')
-        self.config.set('general', 'interactive', 'false')
-        self.config.add_section('test')
-        self.config.set('test', 'service', 'test')
+        self.config['general'] = {
+            'targets': 'test',
+            'interactive': 'false',
+        }
+        self.config['test'] = {'service': 'test'}
 
     def makeService(self):
         with unittest.mock.patch('bugwarrior.config.schema.get_service',
@@ -80,7 +80,7 @@ class TestIssueService(ServiceBase):
         ])
 
     def test_build_annotations_limited(self):
-        self.config.set('general', 'annotation_length', '20')
+        self.config['general']['annotation_length'] = '20'
         service = self.makeService()
 
         annotations = service.build_annotations(
@@ -89,7 +89,7 @@ class TestIssueService(ServiceBase):
             annotations, ['@some_author - Some message that is...'])
 
     def test_build_annotations_limitless(self):
-        self.config.set('general', 'annotation_length', None)
+        self.config['general']['annotation_length'] = None
         service = self.makeService()
 
         annotations = service.build_annotations(
@@ -108,7 +108,7 @@ class TestIssue(ServiceBase):
             description, '(bw)Is# - Some message that is over 100 chara')
 
     def test_build_default_description_limited(self):
-        self.config.set('general', 'description_length', '20')
+        self.config['general']['description_length'] = '20'
         issue = self.makeIssue()
 
         description = issue.build_default_description(LONG_MESSAGE)
@@ -116,7 +116,7 @@ class TestIssue(ServiceBase):
             description, '(bw)Is# - Some message that is')
 
     def test_build_default_description_limitless(self):
-        self.config.set('general', 'description_length', None)
+        self.config['general']['description_length'] = None
         issue = self.makeIssue()
 
         description = issue.build_default_description(LONG_MESSAGE)

--- a/tests/test_trello.py
+++ b/tests/test_trello.py
@@ -67,12 +67,12 @@ class TestTrelloService(ConfigTest):
     def setUp(self):
         super().setUp()
         self.config = BugwarriorConfigParser()
-        self.config.add_section('general')
-        self.config.set('general', 'targets', 'mytrello')
-        self.config.add_section('mytrello')
-        self.config.set('mytrello', 'service', 'trello')
-        self.config.set('mytrello', 'trello.api_key', 'XXXX')
-        self.config.set('mytrello', 'trello.token', 'YYYY')
+        self.config['general'] = {'targets': 'mytrello'}
+        self.config['mytrello'] = {
+            'service': 'trello',
+            'trello.api_key': 'XXXX',
+            'trello.token': 'YYYY',
+        }
         responses.add(responses.GET,
                       'https://api.trello.com/1/lists/L15T/cards/open',
                       json=[self.CARD1, self.CARD2, self.CARD3])
@@ -94,7 +94,7 @@ class TestTrelloService(ConfigTest):
 
     @responses.activate
     def test_get_boards_config(self):
-        self.config.set('mytrello', 'trello.include_boards', 'F00, B4R')
+        self.config['mytrello']['trello.include_boards'] = 'F00, B4R'
         conf = self.validate()
         service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
         boards = service.get_boards()
@@ -117,7 +117,7 @@ class TestTrelloService(ConfigTest):
 
     @responses.activate
     def test_get_lists_include(self):
-        self.config.set('mytrello', 'trello.include_lists', 'List 1')
+        self.config['mytrello']['trello.include_lists'] = 'List 1'
         conf = self.validate()
         service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
         lists = service.get_lists('B04RD')
@@ -125,7 +125,7 @@ class TestTrelloService(ConfigTest):
 
     @responses.activate
     def test_get_lists_exclude(self):
-        self.config.set('mytrello', 'trello.exclude_lists', 'List 1')
+        self.config['mytrello']['trello.exclude_lists'] = 'List 1'
         conf = self.validate()
         service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
         lists = service.get_lists('B04RD')
@@ -140,7 +140,7 @@ class TestTrelloService(ConfigTest):
 
     @responses.activate
     def test_get_cards_assigned(self):
-        self.config.set('mytrello', 'trello.only_if_assigned', 'tintin')
+        self.config['mytrello']['trello.only_if_assigned'] = 'tintin'
         conf = self.validate()
         service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
         cards = service.get_cards('L15T')
@@ -148,8 +148,10 @@ class TestTrelloService(ConfigTest):
 
     @responses.activate
     def test_get_cards_assigned_unassigned(self):
-        self.config.set('mytrello', 'trello.only_if_assigned', 'tintin')
-        self.config.set('mytrello', 'trello.also_unassigned', 'true')
+        self.config['mytrello'].update({
+            'trello.only_if_assigned': 'tintin',
+            'trello.also_unassigned': 'true',
+        })
         conf = self.validate()
         service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
         cards = service.get_cards('L15T')
@@ -172,7 +174,7 @@ class TestTrelloService(ConfigTest):
 
     @responses.activate
     def test_annotations_with_link(self):
-        self.config.set('general', 'annotation_links', 'true')
+        self.config['general']['annotation_links'] = 'true'
         conf = self.validate()
         service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
         annotations = service.annotations(self.CARD1)
@@ -184,8 +186,10 @@ class TestTrelloService(ConfigTest):
 
     @responses.activate
     def test_issues(self):
-        self.config.set('mytrello', 'trello.include_lists', 'List 1')
-        self.config.set('mytrello', 'trello.only_if_assigned', 'tintin')
+        self.config['mytrello'].update({
+            'trello.include_lists': 'List 1',
+            'trello.only_if_assigned': 'tintin',
+        })
         conf = self.validate()
         service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
         issues = service.issues()
@@ -216,13 +220,13 @@ class TestTrelloService(ConfigTest):
         self.validate()
 
     def test_valid_config_no_access_token(self):
-        self.config.remove_option('mytrello', 'trello.token')
+        del self.config['mytrello']['trello.token']
 
         self.assertValidationError(
             '[mytrello]\ntrello.token  <- field required')
 
     def test_valid_config_no_api_key(self):
-        self.config.remove_option('mytrello', 'trello.api_key')
+        del self.config['mytrello']['trello.api_key']
 
         self.assertValidationError(
             '[mytrello]\ntrello.api_key  <- field required')

--- a/tests/test_youtrak.py
+++ b/tests/test_youtrak.py
@@ -10,15 +10,15 @@ class TestYoutrackService(ConfigTest):
     def setUp(self):
         super().setUp()
         self.config = BugwarriorConfigParser()
-        self.config.add_section('general')
-        self.config.set('general', 'targets', 'myservice')
-        self.config.add_section('myservice')
-        self.config.set('myservice', 'service', 'youtrack')
-        self.config.set('myservice', 'youtrack.login', 'foobar')
-        self.config.set('myservice', 'youtrack.password', 'XXXXXX')
+        self.config['general'] = {'targets': 'myservice'}
+        self.config['myservice'] = {
+            'service': 'youtrack',
+            'youtrack.login': 'foobar',
+            'youtrack.password': 'XXXXXX',
+        }
 
     def test_get_keyring_service(self):
-        self.config.set('myservice', 'youtrack.host', 'youtrack.example.com')
+        self.config['myservice']['youtrack.host'] = 'youtrack.example.com'
         service_config = self.validate()['myservice']
         self.assertEqual(
             YoutrackService.get_keyring_service(service_config),


### PR DESCRIPTION
*Cherry-picked out of #973.*

https://docs.python.org/3/library/configparser.html#mapping-protocol-access

This is more readable and also more generalizable to future configuration languages.