### PR TITLE
Toml Configuration (take 2)

### DIFF
--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -8,7 +8,7 @@ from lockfile.pidlockfile import PIDLockFile
 import getpass
 import click
 
-from bugwarrior.config import get_keyring, load_config
+from bugwarrior.config import get_keyring, get_config_path, load_config
 from bugwarrior.services import aggregate_issues, get_service
 from bugwarrior.db import (
     get_defined_udas_as_strings,
@@ -212,3 +212,21 @@ def uda(flavor):
     for uda in get_defined_udas_as_strings(conf, main_section):
         print(uda)
     print("# END Bugwarrior UDAs")
+
+
+@cli.command()
+@click.argument('rcfile', required=False, default=get_config_path(),
+                type=click.Path(exists=True))
+def ini2toml(rcfile):
+    """ Convert ini bugwarriorrc to toml and print result to stdout. """
+    try:
+        from ini2toml.api import Translator
+    except ImportError:
+        raise SystemExit(
+            'Install extra dependencies to use this command:\n'
+            '    pip install bugwarrior[ini2toml]')
+    if os.path.splitext(rcfile)[-1] == '.toml':
+        raise SystemExit(f'{rcfile} is already toml!')
+    with open(rcfile, 'r') as f:
+        bugwarriorrc = f.read()
+    print(Translator().translate(bugwarriorrc, 'bugwarriorrc'))

--- a/bugwarrior/config/__init__.py
+++ b/bugwarrior/config/__init__.py
@@ -1,4 +1,4 @@
-from .load import BUGWARRIORRC, load_config
+from .load import BUGWARRIORRC, get_config_path, load_config
 from .schema import (ConfigList,
                      ExpandedPath,
                      NoSchemeUrl,
@@ -9,6 +9,7 @@ from .secrets import get_keyring, get_service_password
 __all__ = [
     # load
     'BUGWARRIORRC',
+    'get_config_path',
     'load_config',
     # schema
     'ConfigList',

--- a/bugwarrior/config/ini2toml_plugin.py
+++ b/bugwarrior/config/ini2toml_plugin.py
@@ -1,0 +1,157 @@
+import logging
+import re
+import typing
+
+from ini2toml.types import IntermediateRepr, Translator
+from pydantic import BaseModel
+
+from .schema import ConfigList
+from ..services.activecollab2 import ActiveCollabProjects
+
+log = logging.getLogger(__name__)
+
+BOOLS = {
+    'general': ['interactive', 'shorten', 'inline_links', 'annotation_links',
+                'annotation_comments', 'annotation_newlines',
+                'merge_annotations', 'merge_tags', 'replace_tags'],
+    'bitbucket': ['filter_merge_requests', 'include_merge_requests',
+                  'project_owner_prefix'],
+    'bts': ['udd', 'ignore_pending', 'udd_ignore_sponsor'],
+    'bugzilla': ['ignore_cc', 'include_needinfos', 'force_rest', 'advanced'],
+    'deck': ['import_labels_as_tags'],
+    'gitbug': ['import_labels_as_tags'],
+    'github': ['include_user_repos', 'import_labels_as_tags',
+               'filter_pull_requests', 'exclude_pull_requests',
+               'include_user_issues', 'involved_issues', 'project_owner_prefix'
+               ],
+    'gitlab': ['filter_merge_requests', 'membership', 'owned',
+               'import_labels_as_tags', 'include_merge_requests',
+               'include_issues', 'include_todos', 'include_all_todos',
+               'use_https', 'verify_ssl', 'project_owner_prefix'],
+    'jira': ['import_labels_as_tags', 'import_sprints_as_tags', 'use_cookies',
+             'verify_ssl'],
+    'pagure': ['import_tags'],
+    'phabricator': ['ignore_cc', 'ignore_author', 'ignore_owner',
+                    'ignore_reviewers', 'only_if_assigned'],
+    'pivotaltracker': ['import_blockers', 'import_labels_as_tags',
+                       'only_if_author', 'only_if_assigned'],
+    'redmine': ['verify_ssl'],
+    'taiga': ['include_tasks'],
+    'track': ['no_xmlrpc'],
+    'trello': ['import_labels_as_tags'],
+    'youtrack': ['anonymous', 'use_https', 'verify_ssl', 'incloud_instance',
+                 'import_tags'],
+}
+
+INTEGERS = {
+    'general': ['annotation_length', 'description_length'],
+    'activecollab': ['user_id'],
+    'activecollab2': ['user_id'],
+    'gitbug': ['port'],
+    'github': ['body_length'],
+    'jira': ['body_length', 'version'],
+    'pivotaltracker': ['user_id'],
+    'redmine': ['issue_limit'],
+    'youtrack': ['port', 'query_limit'],
+}
+
+CONFIGLIST = {
+    'general': ['targets', 'static_tags', 'static_fields'],
+    'github': ['include_repos', 'exclude_repos', 'issue_urls'],
+    'pivotaltracker': ['account_ids', 'exclude_projects', 'exclude_stories', 'exclude_tags'],
+    'gitlab': ['include_repos', 'exclude_repos'],
+    'bitbucket': ['include_repos', 'exclude_repos'],
+    'phabricator': ['user_phids', 'project_phids'],
+    'trello': ['include_boards', 'include_lists', 'exclude_lists'],
+    'bts': ['packages', 'ignore_pkg', 'ignore_src'],
+    'deck': ['include_board_ids', 'exclude_board_ids'],
+    'bugzilla': ['open_statuses'],
+    'pagure': ['include_repos', 'exclude_repos'],
+}
+
+
+def to_type(section: IntermediateRepr, key: str, converter: typing.Callable):
+    try:
+        val = section[key]
+    except KeyError:
+        pass
+    else:
+        section[key] = converter(val)
+
+
+class BooleanModel(BaseModel):
+    """
+    Use Pydantic to convert various strings to booleans.
+
+    "True", "False", "yes", "no", etc.
+    Adapted from https://docs.pydantic.dev/usage/types/#booleans
+    """
+    bool_value: bool
+
+
+def to_bool(section: IntermediateRepr, key: str):
+    to_type(section, key, lambda val: BooleanModel(bool_value=val).bool_value)
+
+
+def to_int(section: IntermediateRepr, key: str):
+    to_type(section, key, int)
+
+
+def to_list(section: IntermediateRepr, key: str):
+    to_type(section, key, ConfigList.validate)
+
+
+def process_values(doc: IntermediateRepr) -> IntermediateRepr:
+    for name, section in doc.items():
+        if isinstance(name, str):
+            if name == 'general' or re.match(r'^flavor\.', name):
+                for k in INTEGERS['general']:
+                    to_int(section, k)
+                for k in CONFIGLIST['general']:
+                    to_list(section, k)
+                for k in BOOLS['general']:
+                    to_bool(section, k)
+                for k in ['log.level', 'log.file']:
+                    if k in section:
+                        section.rename(k, k.replace('.', '_'))
+            elif name == 'hooks':
+                to_list(section, 'pre_import')
+            elif name == 'notifications':
+                to_bool(section, 'notifications')
+                to_bool(section, 'only_on_new_tasks')
+            else:  # services
+                service = section['service']
+
+                # Validate and strip prefixes.
+                for key in section.keys():
+                    prefix = 'ado' if service == 'azuredevops' else service
+                    if isinstance(key, str) and key != 'service':
+                        newkey, subs = re.subn(f'^{prefix}\\.', '', key)
+                        if subs != 1:
+                            option = key.split('.').pop()
+                            log.warning(
+                                f"[{name}]\n{key} <-expected prefix "
+                                f"'{prefix}': did you mean "
+                                f"'{prefix}.{option}'?")
+                        section.rename(key, newkey)
+
+                to_bool(section, 'also_unassigned')
+                to_list(section, 'add_tags')
+                for k in INTEGERS.get(service, []):
+                    to_int(section, k)
+                for k in CONFIGLIST.get(service, []):
+                    to_list(section, k)
+                for k in BOOLS.get(service, []):
+                    to_bool(section, k)
+
+            if name == 'activecollab2' and 'projects' in section:
+                section['projects'] = ActiveCollabProjects.validate(
+                    section['projects'])
+
+    return doc
+
+
+def activate(translator: Translator):
+    profile = translator["bugwarriorrc"]
+    profile.description = "Convert 'bugwarriorrc' files to 'bugwarrior.toml'"
+    profile.intermediate_processors.append(process_values)

--- a/bugwarrior/config/load.py
+++ b/bugwarrior/config/load.py
@@ -55,12 +55,13 @@ def get_config_path():
 def parse_file(configpath: str) -> dict:
     rawconfig = BugwarriorConfigParser()
     rawconfig.readfp(codecs.open(configpath, "r", "utf-8",))
-    # strip off prefixes
     config = {}
     for section in rawconfig.sections():
-        if (section in ['hooks', 'notifications', 'general'] or
-                section.startswith('flavor.')):
-            config[section] = dict(rawconfig[section])
+        if section in ['hooks', 'notifications']:
+            config[section] = rawconfig[section].items()
+        elif section == 'general' or section.startswith('flavor.'):
+            config[section] = {k.replace('log.', 'log_'): v
+                               for k, v in rawconfig[section].items()}
         else:
             service = rawconfig[section].pop('service')
             service_prefix = 'ado' if service == 'azuredevops' else service
@@ -88,8 +89,8 @@ def load_config(main_section, interactive, quiet):
     main_config.interactive = interactive
     main_config.data = data.BugwarriorData(
         data.get_data_path(config[main_section].taskrc))
-    configure_logging(main_config.log__file,
-                      'WARNING' if quiet else main_config.log__level)
+    configure_logging(main_config.log_file,
+                      'WARNING' if quiet else main_config.log_level)
     return config
 
 

--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -56,7 +56,7 @@ class ConfigList(frozenset):
 
     @classmethod
     def validate(cls, value):
-        """ Cast config values to lists of strings """
+        """ Cast ini string to a list of strings """
         try:
             return [
                 item.strip() for item in re.split(",(?![^{]*})", value.strip())
@@ -247,7 +247,9 @@ def validate_config(config: dict, main_section: str, config_path: str) -> dict:
     bugwarrior_config_model = pydantic.create_model(
         'bugwarriorrc',
         __base__=SchemaBase,
-        **{main_section: (MainSectionConfig, ...)},
+        general=(MainSectionConfig, ...),
+        flavor={flavor: (MainSectionConfig, ...)
+                for flavor in config.get('flavor', {}).values()},
         **target_schemas)
 
     # Validate

--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -103,11 +103,6 @@ class PydanticConfig(pydantic.BaseConfig):
 class MainSectionConfig(pydantic.BaseModel):
 
     class Config(PydanticConfig):
-        @staticmethod
-        def alias_generator(string: str) -> str:
-            """ Handle fields with a period in the name. """
-            return string.replace('__', '.')
-
         # To set BugwarriorData based on taskrc:
         allow_mutation = True
         arbitrary_types_allowed = True
@@ -135,11 +130,10 @@ class MainSectionConfig(pydantic.BaseModel):
     static_tags: ConfigList = ConfigList([])
     static_fields: ConfigList = ConfigList(['priority'])
 
-    # Fields with a period in the name (fixed by alias)
-    log__level: typing_extensions.Literal[
+    log_level: typing_extensions.Literal[
         ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL', 'DISABLED')
     ] = 'INFO'
-    log__file: typing.Optional[LoggingPath] = None
+    log_file: typing.Optional[LoggingPath] = None
 
 
 class Hooks(pydantic.BaseModel):

--- a/bugwarrior/docs/_ext/config.py
+++ b/bugwarrior/docs/_ext/config.py
@@ -1,0 +1,49 @@
+from ini2toml.api import Translator
+from sphinx.util.docutils import SphinxDirective
+from sphinx.directives.code import CodeBlock
+from sphinx_inline_tabs._impl import TabDirective
+
+
+class Config(SphinxDirective):
+    optional_arguments = 1
+    option_spec = {'fragment': str}  # section schema to stub
+    has_content = True
+
+    def _make_tab(self, lang: str):
+        self.arguments = [lang]
+        tab = TabDirective.run(self)[0]
+        tab[1][0] = CodeBlock.run(self)[0]
+        # While line breaks were previously separate elements, they're now
+        # within the single CodeBlock element.
+        del tab[1][1:]
+        return tab
+
+    def run(self):
+        self.assert_has_content()
+
+        ini = self._make_tab('ini')
+        initext = '\n'.join(self.content)
+
+        if 'fragment' in self.options:  # add stub
+            stub_section = (
+                '[some_section]\nservice = ' + self.options['fragment'] + '\n')
+            initext = stub_section + initext
+        tomltext = Translator().translate(initext, 'bugwarriorrc')
+        if 'fragment' in self.options:  # remove stub
+            stub_len = len(stub_section) + 2  # toml adds quotes to strings
+            tomltext = tomltext[stub_len:]
+
+        tomllines = tomltext.split('\n')
+        for i in range(0, len(self.content)):  # mutate self.content
+            # ini2toml removes newlines within sections, so we leave them as is
+            if self.content[i] == '' and tomllines != '':
+                continue
+            self.content[i] = tomllines.pop(0)
+
+        toml = self._make_tab('toml')
+
+        return [ini, toml]
+
+
+def setup(app):
+    app.add_directive('config', Config)

--- a/bugwarrior/docs/common_configuration.rst
+++ b/bugwarrior/docs/common_configuration.rst
@@ -1,6 +1,24 @@
 How to Configure
 ================
 
+Bugwarrior's configuration file is written in `toml <https://toml.io>`_.
+
+A basic configuration might look like this:
+
+.. code:: toml
+
+    [general]
+    targets = my_github
+
+    [my_github]
+    service = github
+    github.login = ralphbean
+    github.token = 123456
+    github.username = ralphbean
+
+Main Section
+------------
+
 Your :ref:`configuration file <configuration-files>` must include at least a ``[general]`` section including the
 following option:
 
@@ -47,9 +65,6 @@ In addition to the ``[general]`` section, sections may be named
 ``[flavor.myflavor]`` and may be selected using the ``--flavor`` option to
 ``bugwarrior pull``. This section will then be used rather than the
 ``[general]`` section.
-
-A more-detailed example configuration can be found at
-:ref:`example_configuration`.
 
 
 .. _common_configuration_options:

--- a/bugwarrior/docs/common_configuration.rst
+++ b/bugwarrior/docs/common_configuration.rst
@@ -1,11 +1,11 @@
 How to Configure
 ================
 
-Bugwarrior's configuration file is written in `toml <https://toml.io>`_.
+Bugwarrior's configuration file can be written either in `ini <https://en.wikipedia.org/wiki/INI_file#Format>`_ or `toml <https://toml.io>`_ format.
 
 A basic configuration might look like this:
 
-.. code:: toml
+.. config::
 
     [general]
     targets = my_github
@@ -22,44 +22,64 @@ Main Section
 Your :ref:`configuration file <configuration-files>` must include at least a ``[general]`` section including the
 following option:
 
-* ``targets``: A comma-separated list of *other* section names to use
+* ``targets``: A list of *other* section names to use
   as task sources.
 
-Optional options include:
+Optional options and their defaults include:
 
-* ``taskrc``: Specify which TaskRC configuration file to use.  By default,
-  will use the system default (usually ``~/.taskrc``).
-* ``shorten``: Set to ``True`` to shorten links.
-* ``inline_links``: When ``False``, links are appended as an annotation.
-  Defaults to ``True``.
-* ``annotation_links``: When ``True`` will include a link to the ticket as an
-  annotation. Defaults to ``False``.
-* ``annotation_comments``: When ``False`` skips putting issue comments into
-  annotations. Defaults to ``True``.
-* ``annotation_newlines``: When ``False`` strips newlines from comments in
-  annotations. Defaults to ``False``.
-* ``log.level``: Set to one of ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``,
-  ``CRITICAL``, or ``DISABLED`` to control the logging verbosity.  By
-  default, this is set to ``INFO``.
-* ``log.file``: Set to the path at which you would like logging messages
-  written.  By default, logging messages will be written to stderr.
-* ``annotation_length``: Import maximally this number of characters
-  of incoming annotations.  Default: 45.
-* ``description_length``: Use maximally this number of characters in the
-  description. Default: 35.
-* ``merge_annotations``: If ``False``, bugwarrior won't bother with adding
-  annotations to your tasks at all.  Default: ``True``.
-* ``merge_tags``: If ``False``, bugwarrior won't bother with adding
-  tags to your tasks at all.  Default: ``True``.
-* ``replace_tags``: If ``True``, bugwarrior will delete all tags prior to
-  fetching new ones, except those listed in ``static_tags``. Only work if
-  merge_tags is ``True``. Default: ``False``.
-* ``static_tags``: A comma separated list of tags that shouldn't be *removed* by
-  bugwarrior. Use for tags that you want to keep when replace_tags is set to
-  ``True``.
-* ``static_fields``: A comma separated list of attributes that shouldn't be
-  *updated* by bugwarrior.  Use for values that you want to tune manually.
-  Note that service-specific UDAs can be included here.  Default: ``priority``.
+.. config::
+
+    [general]
+
+    # Specify which TaskRC configuration file to use.
+    taskrc = <system default, which is usually ~/.taskrc>
+
+    # Set to true to shorten links.
+    shorten = False
+
+    # When false, links are appended as an annotation.
+    inline_links = True
+
+    # When true will include a link to the ticket as an annotation.
+    annotation_links = False
+
+    # When false skips putting issue comments into annotations.
+    annotation_comments = True
+
+    # When false strips newlines from comments in annotations.
+    annotation_newlines = False
+
+    # Set to one of DEBUG, INFO, WARNING, ERROR, CRITICAL, or DISABLED to
+    # control the logging verbosity.
+    log.level = INFO
+
+    # Set to the path at which you would like logging messages written.
+    log.file = <by default messages are written to stderr>
+
+    # Import maximally this number of characters of incoming annotations.
+    annotation_length = 45
+
+    # Use maximally this number of characters in the description.
+    description_length = 35
+
+    # If false, bugwarrior won't bother with adding annotations to your tasks at all.
+    merge_annotations = True
+
+    # If false, bugwarrior won't bother with adding tags to your tasks at all.
+    merge_tags = True
+
+    # If true, bugwarrior will delete all tags prior to fetching new ones,
+    # except those listed in static_tags. Only work if merge_tags is true.
+    replace_tags = False
+
+    # A list of tags that shouldn't be *removed* by bugwarrior. Use for tags
+    # that you want to keep when replace_tags is set to true.
+    static_tags =
+
+    # A list of attributes that shouldn't be *updated* by bugwarrior.  Use for
+    # values that you want to tune manually. Note that service-specific UDAs
+    # can be included here.
+    static_fields = priority
 
 In addition to the ``[general]`` section, sections may be named
 ``[flavor.myflavor]`` and may be selected using the ``--flavor`` option to
@@ -74,19 +94,21 @@ Common Service Configuration Options
 
 All services support common configuration options in addition
 to their service-specific features.
-These configuration options are meant to be prefixed with the service name,
-e.g. ``github.add_tags``, or ``gitlab.default_priority``.
+
+.. note::
+    If using INI format, these configuration options must be prefixed with the service name,
+    e.g. ``github.add_tags``, or ``github.default_priority``.
 
 The following options are supported:
 
-* ``SERVICE.only_if_assigned``: If set to a username, only import issues
+* ``only_if_assigned``: If set to a username, only import issues
   assigned to the specified user.
-* ``SERVICE.also_unassigned``: If set to ``True`` and ``only_if_assigned`` is
+* ``also_unassigned``: If set to ``true`` and ``only_if_assigned`` is
   set, then also create tasks for issues that are not assigned to anybody.
-  Defaults to ``False``.
-* ``SERVICE.default_priority``: Assign this priority ('L', 'M', 'H', or '') to
+  Defaults to ``false``.
+* ``default_priority``: Assign this priority ('L', 'M', 'H', or '') to
   newly-imported issues. Defaults to ``M``.
-* ``SERVICE.add_tags``: A comma-separated list of tags to add to an issue.  In
+* ``add_tags``: A list of tags to add to an issue.  In
   most cases, plain strings will suffice, but you can also specify
   templates.  See the section `Field Templates`_ for more information.
 
@@ -104,7 +126,7 @@ but depending upon your workflow, the information presented may not be
 useful to you.
 
 To help users build descriptions that suit their needs, all services allow
-one to specify a ``SERVICE.description_template`` configuration option, in
+one to specify a ``description_template`` configuration option, in
 which one can enter a one-line Jinja template.  The context available includes
 all Taskwarrior fields and all UDAs (see section named 'Provided UDA Fields'
 for each service) defined for the relevant service.
@@ -118,7 +140,9 @@ for each service) defined for the relevant service.
 For example, to pull-in Github issues assigned to
 `@ralphbean <https://github.com/ralphbean>`_, setting the issue description
 such that it is composed of only the Github issue number and title, you could
-create a service entry like this::
+create a service entry like this:
+
+.. config::
 
     [ralphs_github_account]
     service = github
@@ -128,20 +152,26 @@ create a service entry like this::
 You can also use this tool for altering the generated value of any other
 Taskwarrior record field by using the same kind of template.
 
-Uppercasing the project name for imported issues::
+Uppercasing the project name for imported issues:
 
-    SERVICE.project_template = {{project|upper}}
+.. config::
+   :fragment: github
+
+   github.project_template = {{project|upper}}
 
 You can also use this feature to override the generated value of any field.
 This example causes imported issues to be assigned to the 'Office' project
-regardless of what project was assigned by the service itself::
+regardless of what project was assigned by the service itself:
 
-    SERVICE.project_template = Office
+.. config::
+   :fragment: github
+
+   github.project_template = Office
 
 Password Management
 -------------------
 
-You need not store your password in plain text in your `bugwarriorrc` file; 
+You need not store your password in plain text in your `bugwarriorrc` file;
 you can enter the following values to control where to gather your password
 from:
 
@@ -166,12 +196,12 @@ Use hooks to run commands prior to importing from ``bugwarrior pull``.
 below.
 
 To use hooks, add a ``[hooks]`` section to your configuration, mapping
-the hook you'd like to use with a comma-separated list of scripts to execute.
+the hook you'd like to use with a list of scripts to execute.
 
-::
+.. config::
 
-  [hooks]
-  pre_import = /home/someuser/backup.sh, /home/someuser/sometask.sh
+      [hooks]
+      pre_import = /home/someuser/backup.sh, /home/someuser/sometask.sh
 
 Hook options:
 
@@ -186,12 +216,14 @@ Notifications
 
 Add a ``[notifications]`` section to your configuration to receive notifications
 when a bugwarrior pull runs, and when issues are created, updated, or deleted
-by ``bugwarrior pull``::
+by ``bugwarrior pull``
 
-  [notifications]
-  notifications = True
-  backend = gobject
-  only_on_new_tasks = True
+.. config::
+
+      [notifications]
+      notifications = true
+      backend = gobject
+      only_on_new_tasks = true
 
 Backend options:
 

--- a/bugwarrior/docs/conf.py
+++ b/bugwarrior/docs/conf.py
@@ -40,6 +40,8 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx_click',
     'udas',
+    'config',
+    'sphinx_inline_tabs',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/bugwarrior/docs/configuration.rst
+++ b/bugwarrior/docs/configuration.rst
@@ -1,8 +1,0 @@
-.. _example_configuration:
-
-Example Configuration
-======================
-
-.. include:: example-bugwarriorrc
-   :code: ini
-

--- a/bugwarrior/docs/contributing/new-service.rst
+++ b/bugwarrior/docs/contributing/new-service.rst
@@ -69,7 +69,7 @@ This class is a `pydantic <https://pydantic-docs.helpmanual.io/>`_ model which w
 
 The ``service`` attribute is how bugwarrior will know to assign a given section of the ``bugwarriorrc`` file to your service, for example:
 
-.. code:: ini
+.. config::
 
   [my_gitbug]
   service = gitbug
@@ -297,10 +297,13 @@ Copy and complete the following template:
    Example Service
    ---------------
 
-   Here's an example of a SERVICE_NAME target::
+   Here's an example of a SERVICE_NAME target:
+
+   .. config::
+
        [my_issue_tracker]
        service = SERVICE
-       ADDITIONAL REQUIRED CONFIGURATION OPTIONS
+       ADDITIONAL REQUIRED CONFIGURATION OPTIONS, IN INI FORMAT
 
 
    The above example is the minimum required to import issues from SERVICE_NAME.

--- a/bugwarrior/docs/index.rst
+++ b/bugwarrior/docs/index.rst
@@ -31,7 +31,6 @@ Contents
    using
    common_configuration
    services
-   configuration
    contributing
    faq
 

--- a/bugwarrior/docs/services/activecollab.rst
+++ b/bugwarrior/docs/services/activecollab.rst
@@ -43,7 +43,7 @@ Here's an example of an activecollab target.
 This is only valid for activeCollab 4.x and greater,
 see :ref:`activecollab2` for activeCollab2.x.
 
-::
+.. config::
 
     [my_bug_tracker]
     service = activecollab

--- a/bugwarrior/docs/services/activecollab2.rst
+++ b/bugwarrior/docs/services/activecollab2.rst
@@ -31,7 +31,7 @@ Example Service
 Here's an example of an activecollab2 target. Note that this will only work
 with ActiveCollab 2.x - see above for 3.x and greater.
 
-::
+.. config::
 
     [my_bug_tracker]
     service = activecollab2

--- a/bugwarrior/docs/services/azuredevops.rst
+++ b/bugwarrior/docs/services/azuredevops.rst
@@ -8,7 +8,9 @@ the ``azuredevops`` service name.
 Example Service
 ---------------
 
-Here's an example of a azure devops project::
+Here's an example of a azure devops project:
+
+.. config::
 
     [my_issue_tracker]
     service = azuredevops
@@ -17,7 +19,7 @@ Here's an example of a azure devops project::
     ado.organization = testorganization
 
 .. note::
- 
+
    If you look at a work item in the browser, the url should be something like https://dev.azure.com/testorganziation/testproject/_workitems/edit/12345/
 
 
@@ -32,7 +34,10 @@ The PAT (Personal Access Token) can be generated for your project by following h
 Service Features
 ----------------
 
-The following default configuration is used::
+The following default configuration is used:
+
+.. config::
+    :fragment: azuredevops
 
     ado.host = dev.azure.com
     ado.wiql_filter = SELECT [System.Id] FROM workitems
@@ -42,16 +47,22 @@ Specify the Query to Use for Gathering Issues
 +++++++++++++++++++++++++++++++++++++++++++++
 
 By default, the Azure DevOps plugin will include all issues in the project, but you can fine-tune the query used
-for gathering issues by setting the ``ado.wiql_filter`` parameter. 
-Please note there is a limit imposed by the Azure DevOps API on the number of workitems you can pull at the same time (20000). If your query exceeds this limitation, the application will produce an error. 
+for gathering issues by setting the ``wiql_filter`` parameter.
+Please note there is a limit imposed by the Azure DevOps API on the number of workitems you can pull at the same time (20000). If your query exceeds this limitation, the application will produce an error.
 A good default would be to only pull ado workitem assigned to yourself. Do that with this query:
-configuration option::
+configuration option:
+
+.. config::
+    :fragment: azuredevops
 
     ado.wiql_filter = [System.AssignedTo] = @me
 
 
-To select issues only in an active state 
-configuration option::
+To select issues only in an active state
+configuration option:
+
+.. config::
+    :fragment: azuredevops
 
     ado.wiql_filter = [System.AssignedTo] = @me AND [System.State] = 'Active'
 

--- a/bugwarrior/docs/services/bitbucket.rst
+++ b/bugwarrior/docs/services/bitbucket.rst
@@ -7,7 +7,9 @@ the ``bitbucket`` service name.
 Example Service
 ---------------
 
-Here's an example of a Bitbucket target::
+Here's an example of a Bitbucket target:
+
+.. config::
 
     [my_issue_tracker]
     service = bitbucket
@@ -22,7 +24,7 @@ configuration options described in :ref:`common_configuration_options`.
 To get a key and secret,
 go to the "OAuth" section of your profile settings and click "Add consumer". Set the
 "Callback URL" to ``https://localhost/`` and set the appropriate permissions. Then
-assign your consumer's credentials to ``bitbucket.key`` and ``bitbucket.secret``.
+assign your consumer's credentials to ``key`` and ``secret``.
 
 Service Features
 ----------------
@@ -32,20 +34,26 @@ Include and Exclude Certain Repositories
 
 If you happen to be working with a large number of projects, you
 may want to pull issues from only a subset of your repositories.  To
-do that, you can use the ``bitbucket.include_repos`` option.
+do that, you can use the ``include_repos`` option.
 
 For example, if you would like to only pull-in issues from
 your ``project_foo`` and ``project_fox`` repositories, you could add
-this line to your service configuration::
+this line to your service configuration:
+
+.. config::
+    :fragment: bitbucket
 
     bitbucket.include_repos = project_foo,project_fox
 
 Alternatively, if you have a particularly noisy repository, you can
 instead choose to import all issues excepting it using the
-``bitbucket.exclude_repos`` configuration option.
+``exclude_repos`` configuration option.
 
 In this example, ``noisy_repository`` is the repository you would
-*not* like issues created for::
+*not* like issues created for:
+
+.. config::
+    :fragment: bitbucket
 
     bitbucket.exclude_repos = noisy_repository
 
@@ -56,14 +64,20 @@ Include Merge Requests
 ++++++++++++++++++++++
 
 Merge requests are included by default. You can exclude them by disabling
-this feature::
+this feature:
+
+.. config::
+    :fragment: bitbucket
 
     bitbucket.include_merge_requests = False
 
 Project Owner Prefix
 ++++++++++++++++++++
 
-To include the project owner in the project name::
+To include the project owner in the project name:
+
+.. config::
+    :fragment: bitbucket
 
     bitbucket.project_owner_prefix = True
 

--- a/bugwarrior/docs/services/bts.rst
+++ b/bugwarrior/docs/services/bts.rst
@@ -19,7 +19,9 @@ You will need to install the following additional packages via ``pip``:
 Example Service
 ---------------
 
-Here's an example of a Debian BTS target::
+Here's an example of a Debian BTS target:
+
+.. config::
 
     [debian_bts]
     service = bts
@@ -37,10 +39,13 @@ Include all bugs for packages
 +++++++++++++++++++++++++++++
 
 If you would like more bugs than just those you are the owner of, you can specify
-the ``bts.packages`` option.
+the ``packages`` option.
 
 For example if you wanted to include bugs on the ``hello`` package, you can add
-this line to your service configuration::
+this line to your service configuration:
+
+.. config::
+    :fragment: bts
 
     bts.packages = hello
 
@@ -54,7 +59,10 @@ packages where you are listed as a Maintainer or an Uploader in the Debian archi
 you can enable the use of the `UDD Bugs Search <https://udd.debian.org/bugs/>`_.
 
 This will peform a search and include the bugs from the result. To enable this
-feature, you can add this line to your service configuration::
+feature, you can add this line to your service configuration:
+
+.. config::
+    :fragment: bts
 
     bts.udd = True
 
@@ -68,7 +76,10 @@ with the pending tag in the BTS.
 
 This is the default behaviour, but if you feel you would like to include bugs that
 are marked as pending in the BTS, you can disable this by adding this line to your
-service configuration::
+service configuration:
+
+.. config::
+    :fragment: bts
 
     bts.ignore_pending = False
 
@@ -77,7 +88,10 @@ Including sponsored and NMU'd packages
 
 By default, packages that you have sponsored or have uploaded as a non-maintainer
 upload or team upload will be excluded. You can include tasks from these packages
-by disabling this feature::
+by disabling this feature:
+
+.. config::
+    :fragment: bts
 
     bts.udd_ignore_sponsor = False
 
@@ -92,7 +106,10 @@ If you would like to exclude a particularly noisy package, that is perhaps team
 maintained, or a package that you have orphaned and no longer have interest in but
 are still listed as Maintainer or Uploader in stable suites, you can explicitly
 ignore bugs based on their binary or source package names. To do this add one
-of the following lines to your service configuration::
+of the following lines to your service configuration:
+
+.. config::
+    :fragment: bts
 
     bts.ignore_pkg = hello,anarchism
     bts.ignore_src = linux

--- a/bugwarrior/docs/services/bugzilla.rst
+++ b/bugwarrior/docs/services/bugzilla.rst
@@ -25,7 +25,7 @@ Bugzilla instances can be quite different from one another so use this
 with caution and please report bugs so we can
 make bugwarrior support more robust!
 
-::
+.. config::
 
     [my_issue_tracker]
     service = bugzilla
@@ -37,7 +37,8 @@ Alternately, if you are using a version of python-bugzilla newer than 2.1.0,
 you can specify an API key instead of a password. Note that the username is
 still required in this case, in order to identify bugs belonging to you.
 
-::
+.. config::
+    :fragment: bugzilla
 
     bugzilla.api_key = 4f4d475f4c554c5a4f4d475f4c554c5a
 
@@ -45,11 +46,17 @@ The above example is the minimum required to import issues from
 Bugzilla.  You can also feel free to use any of the
 configuration options described in :ref:`common_configuration_options`.
 
-There is also an option to ignore bugs that you are only cc'd on::
+There is also an option to ignore bugs that you are only cc'd on:
+
+.. config::
+    :fragment: bugzilla
 
     bugzilla.ignore_cc = True
 
-If your bugzilla "actionable" bugs only include ON_QA, FAILS_QA, PASSES_QA, and POST::
+If your bugzilla "actionable" bugs only include ON_QA, FAILS_QA, PASSES_QA, and POST:
+
+.. config::
+    :fragment: bugzilla
 
     bugzilla.open_statuses = ON_QA,FAILS_QA,PASSES_QA,POST
 
@@ -58,7 +65,7 @@ This won't create tasks for bugs in other states. The default open statuses:
 
 If you're on a more recent Bugzilla install, the NEEDINFO status no longer
 exists, and has been replaced by the "needinfo?" flag. Set
-``bugzilla.include_needinfos`` to "True" to have taskwarrior also add bugs where
+``include_needinfos`` to "True" to have taskwarrior also add bugs where
 information is requested of you. The "bugzillaneedinfo" UDA will be filled in
 with the date the needinfo was set.
 
@@ -66,19 +73,28 @@ To see all your needinfo bugs, you can use "task bugzillaneedinfo.any: list".
 
 If the filtering options are not sufficient to find the set of bugs you'd like,
 you can tell Bugwarrior exactly which bugs to sync by pasting a full query URL
-from your browser into the ``bugzilla.query_url`` option::
+from your browser into the ``query_url`` option:
+
+.. config::
+    :fragment: bugzilla
 
     bugzilla.query_url = https://bugzilla.mozilla.org/query.cgi?bug_status=ASSIGNED&email1=myname%40mozilla.com&emailassigned_to1=1&emailtype1=exact
 
 Note that versions of Python-Bugzilla newer than 2.3.0 support the Bugzilla REST interface, but prefer the XMLRPC interface if both are configured.
-To force use of the REST interface, ensure you are using a newer version of the library and add::
+To force use of the REST interface, ensure you are using a newer version of the library and add:
+
+.. config::
+    :fragment: bugzilla
 
     bugzilla.force_rest = True
 
 More modern bugzilla's require that we specify query_format=advanced along with
 the xmlrpc request (https://bugzilla.redhat.com/show_bug.cgi?id=825370)
 …but older bugzilla's don't know anything about that argument. Here we make it
-possible for the user to specify whether they want to pass that argument or not::
+possible for the user to specify whether they want to pass that argument or not:
+
+.. config::
+    :fragment: bugzilla
 
     bugzilla.advanced = True
 

--- a/bugwarrior/docs/services/deck.rst
+++ b/bugwarrior/docs/services/deck.rst
@@ -8,7 +8,9 @@ This service requires `deck <https://github.com/nextcloud/deck#installationupdat
 Example Service
 ---------------
 
-Here's an example of a Nextcloud Deck target::
+Here's an example of a Nextcloud Deck target:
+
+.. config::
 
    [my_nextcloud_deck]
    service = deck
@@ -28,13 +30,19 @@ Service Features
 Import Labels as Tags
 +++++++++++++++++++++
 
-The Deck allows you to attach labels to cards. To use those labels as tags, you can use the ``deck.import_labels_as_tags`` option::
+The Deck allows you to attach labels to cards. To use those labels as tags, you can use the ``import_labels_as_tags`` option:
+
+.. config::
+    :fragment: deck
 
     deck.import_labels_as_tags = True
 
 Also, if you would like to control how these labels are created, you can specify a template used for converting the Deck label into a Taskwarrior tag.
 
-For example, to prefix all incoming labels with the string 'deck\_' (perhaps to differentiate them from any existing tags you might have), you could add the following configuration option::
+For example, to prefix all incoming labels with the string 'deck\_' (perhaps to differentiate them from any existing tags you might have), you could add the following configuration option:
+
+.. config::
+    :fragment: deck
 
     deck.label_template = deck_{{label}}
 
@@ -49,7 +57,10 @@ to all fields on the Taskwarrior task if needed.
 Only if assigned
 ++++++++++++++++
 
-You can filter for cards assigned to a specific user::
+You can filter for cards assigned to a specific user:
+
+.. config::
+    :fragment: deck
 
     deck.only_if_assigned = my_user
 
@@ -59,7 +70,10 @@ You can filter for cards assigned to a specific user::
 Exclude / include board IDs
 +++++++++++++++++++++++++++
 
-You can explicitly exclude or include specific boards::
+You can explicitly exclude or include specific boards:
+
+.. config::
+    :fragment: deck
 
     deck.exclude_board_ids = 5,6
     deck.include_board_ids = 4

--- a/bugwarrior/docs/services/gerrit.rst
+++ b/bugwarrior/docs/services/gerrit.rst
@@ -6,7 +6,9 @@ You can import code reviews from a Gerrit instance using the ``gerrit`` service 
 Example Service
 ---------------
 
-Here's an example of a gerrit project::
+Here's an example of a gerrit project:
+
+.. config::
 
     [my_issue_tracker]
     service = gerrit
@@ -20,7 +22,7 @@ The above example is the minimum required to import issues from Gerrit.
 the "HTTP Password" section in your account settings to generate/retrieve this
 password.
 
-You can also pass an optional ``gerrit.ssl_ca_path`` option which will use an
+You can also pass an optional ``ssl_ca_path`` option which will use an
 alternative certificate authority to verify the connection.
 
 You can also feel free to use any of the configuration options described in
@@ -36,7 +38,10 @@ API query::
 
 You may override this query string through your `bugwarriorrc` file.
 
-For example::
+For example:
+
+.. config::
+    :fragment: gerrit
 
     gerrit.query = is:open+((reviewer:self+-owner:self+-is:ignored)+OR+assignee:self)
 

--- a/bugwarrior/docs/services/gitbug.rst
+++ b/bugwarrior/docs/services/gitbug.rst
@@ -8,7 +8,9 @@ This service requires `git-bug <https://github.com/MichaelMure/git-bug#installat
 Example Service
 ---------------
 
-Here's an example of a Git-Bug target::
+Here's an example of a Git-Bug target:
+
+.. config::
 
    [my_issue_tracker]
    service = gitbug
@@ -25,13 +27,19 @@ Service Features
 Import Labels as Tags
 +++++++++++++++++++++
 
-The Git-Bug issue tracker allows you to attach labels to bugs to use those labels as tags, you can use the ``gitbug.import_labels_as_tags`` option::
+The Git-Bug issue tracker allows you to attach labels to bugs to use those labels as tags, you can use the ``import_labels_as_tags`` option:
+
+.. config::
+    :fragment: gitbug
 
     gitbug.import_labels_as_tags = True
 
 Also, if you would like to control how these labels are created, you can specify a template used for converting the Git-Bug label into a Taskwarrior tag.
 
-For example, to prefix all incoming labels with the string 'gitbug\_' (perhaps to differentiate them from any existing tags you might have), you could add the following configuration option::
+For example, to prefix all incoming labels with the string 'gitbug\_' (perhaps to differentiate them from any existing tags you might have), you could add the following configuration option:
+
+.. config::
+    :fragment: gitbug
 
     gitbug.label_template = gitbug_{{label}}
 
@@ -46,7 +54,10 @@ to all fields on the Taskwarrior task if needed.
 Port
 ++++
 
-By default, this service will spin up a git-bug instance served on port 43915. To change the port, assign::
+By default, this service will spin up a git-bug instance served on port 43915. To change the port, assign:
+
+.. config::
+    :fragment: gitbug
 
     gitbug.port = 12345
 

--- a/bugwarrior/docs/services/github.rst
+++ b/bugwarrior/docs/services/github.rst
@@ -7,7 +7,9 @@ the ``github`` service name.
 Example Service
 ---------------
 
-Here's an example of a Github target::
+Here's an example of a Github target:
+
+.. config::
 
     [my_issue_tracker]
     service = github
@@ -20,8 +22,8 @@ Github.  You can also feel free to use any of the
 configuration options described in :ref:`common_configuration_options`
 or described in `Service Features`_ below.
 
-``github.login`` is used to specify what account bugwarrior should use to login
-to github, combined with ``github.token``.
+``login`` is used to specify what account bugwarrior should use to login
+to github, combined with ``token``.
 
 To get a token, go to the "Personal access tokens" section of
 your profile settings. Only the ``public_repo`` scope is required, but access
@@ -33,37 +35,46 @@ Service Features
 Repo Owner
 ++++++++++
 
-``github.username`` indicates which repositories should be scraped.  For
-instance, I always have ``github.login`` set to ralphbean (my account).  But I
-have some targets with ``github.username`` pointed at organizations or other
+``username`` indicates which repositories should be scraped.  For
+instance, I always have ``login`` set to ralphbean (my account).  But I
+have some targets with ``username`` pointed at organizations or other
 users to watch issues there.  This parameter is required unless
-``github.query`` is provided.
+``query`` is provided.
 
 Include and Exclude Certain Repositories
 ++++++++++++++++++++++++++++++++++++++++
 
-By default, issues from all repos belonging to ``github.username`` are
-included. To turn this off, set::
+By default, issues from all repos belonging to ``username`` are
+included. To turn this off, set:
+
+.. config::
+    :fragment: github
 
     github.include_user_repos = False
 
 If you happen to be working with a large number of projects, you
 may want to pull issues from only a subset of your repositories.  To
-do that, you can use the ``github.include_repos`` option.
+do that, you can use the ``include_repos`` option.
 
 For example, if you would like to only pull-in issues from
 ``some_user/project_foo`` and ``some_user/project_fox`` repositories, you could add
-these lines to your service configuration::
+these lines to your service configuration:
+
+.. config::
+    :fragment: github
 
     github.username = some_user
     github.include_repos = project_foo,project_fox
 
 Alternatively, if you have a particularly noisy repository, you can
 instead choose to import all issues excepting it using the
-``github.exclude_repos`` configuration option.
+``exclude_repos`` configuration option.
 
 In this example, ``some_user/noisy_repository`` is the repository you would
-*not* like issues created for::
+*not* like issues created for:
+
+.. config::
+    :fragment: github
 
     github.username = some_user
     github.exclude_repos = noisy_repository
@@ -72,8 +83,11 @@ Import Labels as Tags
 +++++++++++++++++++++
 
 The Github issue tracker allows you to attach labels to issues; to
-use those labels as tags, you can use the ``github.import_labels_as_tags``
-option::
+use those labels as tags, you can use the ``import_labels_as_tags``
+option:
+
+.. config::
+    :fragment: github
 
     github.import_labels_as_tags = True
 
@@ -83,7 +97,10 @@ tag.
 
 For example, to prefix all incoming labels with the string 'github_' (perhaps
 to differentiate them from any existing tags you might have), you could
-add the following configuration option::
+add the following configuration option:
+
+.. config::
+    :fragment: github
 
     github.label_template = github_{{label}}
 
@@ -100,7 +117,10 @@ Filter Pull Requests
 
 Although you can filter issues using :ref:`common_configuration_options`,
 pull requests are not filtered by default.  You can filter pull requests
-by adding the following configuration option::
+by adding the following configuration option:
+
+.. config::
+    :fragment: github
 
     github.filter_pull_requests = True
 
@@ -108,7 +128,10 @@ Exclude Pull Requests
 +++++++++++++++++++++
 
 If you want bugwarrior to not track pull requests you can disable it altogether
-and ensure bugwarrior only tracks issues::
+and ensure bugwarrior only tracks issues:
+
+.. config::
+    :fragment: github
 
     github.exclude_pull_requests = True
 
@@ -116,7 +139,10 @@ Get involved issues
 +++++++++++++++++++
 
 By default, bugwarrior pulls all issues across owned and member repositories
-assigned to the authenticated user.  To disable this behavior, use::
+assigned to the authenticated user.  To disable this behavior, use:
+
+.. config::
+    :fragment: github
 
     github.include_user_issues = False
 
@@ -124,14 +150,20 @@ Instead of fetching issues and pull requests based on ``{{username}}``'s owned
 repositories, you may instead get those that ``{{username}}`` is involved in.
 This includes all issues and pull requests where the user is the author, the
 assignee, mentioned in, or has commented on.  To do so, add the following
-configuration option::
+configuration option:
+
+.. config::
+    :fragment: github
 
     github.involved_issues = True
 
 Queries
 +++++++
 
-If you want to write your own github query, as described at https://help.github.com/articles/searching-issues/::
+If you want to write your own github query, as described at https://help.github.com/articles/searching-issues/:
+
+.. config::
+    :fragment: github
 
     github.query = assignee:octocat is:open
 
@@ -139,7 +171,10 @@ Note that this search covers both issues and pull requests, which github treats
 as a special kind of issue.
 
 To disable the pre-defined queries described above and synchronize only the
-issues matched by the query, set::
+issues matched by the query, set:
+
+.. config::
+    :fragment: github
 
     github.include_user_issues = False
     github.include_user_repos = False
@@ -148,7 +183,10 @@ GitHub Enterprise Instance
 ++++++++++++++++++++++++++
 
 If you're using GitHub Enterprise, the on-premises version of GitHub, you can
-point bugwarrior to it with the ``github.host`` configuration option. E.g.::
+point bugwarrior to it with the ``host`` configuration option. E.g.:
+
+.. config::
+    :fragment: github
 
     github.host = github.acme.biz
 
@@ -161,12 +199,15 @@ Comments are synchronized as annotations.
 To limit the amount of content synchronized into TaskWarrior (which can help to avoid issues with synchronization), use
 
  * ``annotation_comments=False`` (a global configuration) to disable synchronizing comments to annotations; and
- * either ``github.body_length``` to limit the size of the Github Body UDA or include ``githubbody`` in ``static_fields`` in the ``[general]`` section to eliminate the UDA entirely.
+ * either ``body_length``` to limit the size of the Github Body UDA or include ``githubbody`` in ``static_fields`` in the ``[general]`` section to eliminate the UDA entirely.
 
 Including Project Owner in Project Name
 +++++++++++++++++++++++++++++++++++++++
 
-By default the taskwarrior ``project`` name will not include the owner. To do so set::
+By default the taskwarrior ``project`` name will not include the owner. To do so set:
+
+.. config::
+    :fragment: github
 
     github.project_owner_prefix = True
 
@@ -174,7 +215,10 @@ By default the taskwarrior ``project`` name will not include the owner. To do so
 Get Specific Issues
 +++++++++++++++++++
 
-Specific issues can be pulled in using ``github.issue_urls``::
+Specific issues can be pulled in using ``issue_urls``:
+
+.. config::
+    :fragment: github
 
     github.issue_urls = https://github.com/ralphbean/bugwarrior/issues/516,https://github.com/ralphbean/bugwarrior/pull/898
 

--- a/bugwarrior/docs/services/gitlab.rst
+++ b/bugwarrior/docs/services/gitlab.rst
@@ -7,7 +7,9 @@ the ``gitlab`` service name.
 Example Service
 ---------------
 
-Here's an example of a Gitlab target::
+Here's an example of a Gitlab target:
+
+.. config::
 
     [my_issue_tracker]
     service = gitlab
@@ -20,7 +22,7 @@ Gitlab.  You can also feel free to use any of the
 configuration options described in :ref:`common_configuration_options`
 or described in `Service Features`_ below.
 
-The ``gitlab.token`` is your private API token.
+The ``token`` is your private API token.
 
 Service Features
 ----------------
@@ -30,55 +32,70 @@ Include and Exclude Certain Repositories
 
 If you happen to be working with a large number of projects, you
 may want to pull issues from only a subset of your repositories.  To
-do that, you can use the ``gitlab.include_repos`` option.
+do that, you can use the ``include_repos`` option.
 
 For example, if you would like to only pull-in issues from
 your own ``project_foo`` and team ``bar``'s ``project_fox`` repositories, you
 could add this line to your service configuration (replacing ``me`` by your own
-login)::
+login):
+
+.. config::
+    :fragment: gitlab
 
     gitlab.include_repos = me/project_foo, bar/project_fox
 
 Alternatively, if you have a particularly noisy repository, you can
 instead choose to import all issues excepting it using the
-``gitlab.exclude_repos`` configuration option.
+``exclude_repos`` configuration option.
 
 In this example, ``noisy/repository`` is the repository you would
-*not* like issues created for::
+*not* like issues created for:
+
+.. config::
+    :fragment: gitlab
 
     gitlab.exclude_repos = noisy/repository
 
 .. hint::
    If you omit the repository's namespace, bugwarrior will automatically add
-   your login as namespace. E.g. the following are equivalent::
+   your login as namespace. E.g. the following are equivalent:
 
-       gitlab.login = foo
-       gitlab.include_repos = bar
+.. config::
+    :fragment: gitlab
 
-   and::
+    gitlab.login = foo
+    gitlab.include_repos = bar
 
-       gitlab.login = foo
-       gitlab.include_repos = foo/bar
+and:
+
+.. config::
+    :fragment: gitlab
+
+    gitlab.login = foo
+    gitlab.include_repos = foo/bar
 
 Alternatively, you can use project IDs instead of names by prefixing the
-project id with `id:`::
+project id with `id:`:
 
-   gitlab.include_repos = id:1234,id:3141
+.. config::
+    :fragment: gitlab
+
+    gitlab.include_repos = id:1234,id:3141
 
 Filtering Repositories with Regular Expressions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you don't want to list every single repository you want to include or
-exclude, you can additionally use the options ``gitlab.include_regex`` and
-``gitlab.exclude_regex`` and specify a regular expression (suitable for Python's
+exclude, you can additionally use the options ``include_regex`` and
+``exclude_regex`` and specify a regular expression (suitable for Python's
 ``re`` module).
 No default namespace is applied here, the regular expressions are matched to the
 full repository name with its namespace.
 
 The regular expressions can be used in addition to the lists explained above.
-So if a repository is not included in ``gitlab.include_repos``, it can still be
-included by ``gitlab.include_regex``, and vice versa; and likewise for
-``gitlab.exclude_repos`` and ``gitlab.exclude_regex``.
+So if a repository is not included in ``include_repos``, it can still be
+included by ``include_regex``, and vice versa; and likewise for
+``exclude_repos`` and ``exclude_regex``.
 
 .. note::
    If a repository matches both the inclusion and the exclusion options, the
@@ -86,7 +103,10 @@ included by ``gitlab.include_regex``, and vice versa; and likewise for
 
 For example, you want to include only the repositories ``foo/node`` and
 ``bar/node`` as well as all repositories in the namespace ``foo`` starting with
-``ep_``, but not ``foo/ep_example``::
+``ep_``, but not ``foo/ep_example``:
+
+.. config::
+    :fragment: gitlab
 
     gitlab.include_repos = foo/node, bar/node
     gitlab.include_regex = foo/ep_.*
@@ -95,14 +115,20 @@ For example, you want to include only the repositories ``foo/node`` and
 Filtering Membership
 ^^^^^^^^^^^^^^^^^^^^
 
-If you want to filter repositories that you have a membership::
+If you want to filter repositories that you have a membership:
+
+.. config::
+    :fragment: gitlab
 
     gitlab.membership = True
 
 Filtering Owned
 ^^^^^^^^^^^^^^^^^^^^
 
-If you want to filter repositories that you own::
+If you want to filter repositories that you own:
+
+.. config::
+    :fragment: gitlab
 
     gitlab.owned = True
 
@@ -110,8 +136,11 @@ Import Labels as Tags
 +++++++++++++++++++++
 
 The gitlab issue tracker allows you to attach labels to issues; to
-use those labels as tags, you can use the ``gitlab.import_labels_as_tags``
-option::
+use those labels as tags, you can use the ``import_labels_as_tags``
+option:
+
+.. config::
+    :fragment: gitlab
 
     gitlab.import_labels_as_tags = True
 
@@ -121,12 +150,15 @@ tag.
 
 For example, to prefix all incoming labels with the string 'gitlab_' (perhaps
 to differentiate them from any existing tags you might have), you could
-add the following configuration option::
+add the following configuration option:
+
+.. config::
+    :fragment: gitlab
 
     gitlab.label_template = gitlab_{{label}}
 
 In addition to the context variable ``{{label}}``, you also have access
-to all fields on the Taskwarrior task if needed.
+to all fields on the Taskwarrior task if needed:
 
 .. note::
 
@@ -136,7 +168,10 @@ to all fields on the Taskwarrior task if needed.
 Include Issues
 ++++++++++++++
 
-Issues are included by default, if not configured otherwise. To disable querying of issues, set::
+Issues are included by default, if not configured otherwise. To disable querying of issues, set:
+
+.. config::
+    :fragment: gitlab
 
     gitlab.include_issues = False
 
@@ -144,28 +179,40 @@ Include Merge Requests
 ++++++++++++++++++++++
 
 Merge requests are included by default. You can exclude them by disabling
-this feature::
+this feature:
 
-    bitbucket.include_merge_requests = False
+.. config::
+    :fragment: gitlab
+
+    gitlab.include_merge_requests = False
 
 Include Todo Items
 ++++++++++++++++++
 
 By default todo items are not included.  You may include them by adding the
-following configuration option::
+following configuration option:
+
+.. config::
+    :fragment: gitlab
 
     gitlab.include_todos = True
 
 If todo items are included, by default, todo items for all projects are
 included.  To apply the same repository filters to todos as to issues and merge requests, you
-may set::
+may set:
+
+.. config::
+    :fragment: gitlab
 
     gitlab.include_all_todos = False
 
 Include Only One Author
 +++++++++++++++++++++++
 
-If you would like to only pull issues and MRs that you've authored, you may set::
+If you would like to only pull issues and MRs that you've authored, you may set:
+
+.. config::
+    :fragment: gitlab
 
     gitlab.only_if_author = myusername
 
@@ -173,7 +220,10 @@ Priority by type
 ++++++++++++++++
 
 If you would like that your issues have a different default priority than your MRs or todo items,
-you can configure individual priorities for each::
+you can configure individual priorities for each:
+
+.. config::
+    :fragment: gitlab
 
     gitlab.default_issue_priority = M
     gitlab.default_todo_priority = M
@@ -184,7 +234,10 @@ Custom query strings
 ++++++++++++++++++++
 
 The Gitlab REST API allows many more configuration options than the ones provided
-by the options explained above. If you want to further customize calls, you can set for example::
+by the options explained above. If you want to further customize calls, you can set for example:
+
+.. config::
+    :fragment: gitlab
 
     gitlab.issue_query = issues?search=foo&in=title
     gitlab.merge_request_query = merge_requests?state=opened&scope=all&reviewer_username=myusername
@@ -198,32 +251,41 @@ Note: Depending in the scope you are interested in, this query-based approach ca
 than using the "default queries". For example, imagine that you want to query all issues assigned
 to your user.
 
-This can be achieved by leaving the ``gitlab.include_repos`` configuration value empty and
-setting ``gitlab.only_if_assigned`` to ``True``. This will result in querying all repos your user
+This can be achieved by leaving the ``include_repos`` configuration value empty and
+setting ``only_if_assigned`` to ``True``. This will result in querying all repos your user
 has access to, which might take a very long time.
 
-Alternatively, you could set ``gitlab.issue_query =
+Alternatively, you could set ``issue_query =
 issues?assignee_username=myusername&state=opened&scope=all``, which will fetch the assigned issues
 first and then only fetch the projects for which issues have been found.
 
 Use HTTP
 ++++++++
 
-If your Gitlab instance is only available over HTTP, set::
+If your Gitlab instance is only available over HTTP, set:
+
+.. config::
+    :fragment: gitlab
 
     gitlab.use_https = False
 
 Do Not Verify SSL Certificate
 +++++++++++++++++++++++++++++
 
-If you want to ignore verifying the SSL certificate, set::
+If you want to ignore verifying the SSL certificate, set:
+
+.. config::
+    :fragment: gitlab
 
     gitlab.verify_ssl = False
 
 Including Project Owner in Project Name
 +++++++++++++++++++++++++++++++++++++++
 
-By default the taskwarrior ``project`` name will not include the owner. To do so set::
+By default the taskwarrior ``project`` name will not include the owner. To do so set:
+
+.. config::
+    :fragment: gitlab
 
     gitlab.project_owner_prefix = True
 
@@ -234,7 +296,7 @@ This service synchronizes most Gitlab fields to UDAs, as described below.
 
 To limit the amount of content synchronized into TaskWarrior (which can help to avoid issues with synchronization), use
 
- * ``gitlab.body_length=0``` to disable synchronizing the Gitlab Description UDA (or set it to a small value to limit size).
+ * ``body_length=0`` to disable synchronizing the Gitlab Description UDA (or set it to a small value to limit size).
 
 Provided UDA Fields
 -------------------

--- a/bugwarrior/docs/services/gmail.rst
+++ b/bugwarrior/docs/services/gmail.rst
@@ -27,7 +27,7 @@ Example Service
 
 Here's an example of a gmail target:
 
-::
+.. config::
 
     [my_gmail]
     service = gmail

--- a/bugwarrior/docs/services/jira.rst
+++ b/bugwarrior/docs/services/jira.rst
@@ -14,7 +14,9 @@ Install the following package using ``pip``:
 Example Service
 ---------------
 
-Here's an example of a jira project::
+Here's an example of a jira project:
+
+.. config::
 
     [my_issue_tracker]
     service = jira
@@ -28,7 +30,7 @@ Here's an example of a jira project::
 
 .. note::
 
-   Basic authentication with passwords is deprecated. The `jira.password` may contain an `api token <https://confluence.atlassian.com/cloud/api-tokens-938839638.html>`_ or alternatively you can set `jira.PAT` to a Personal Access Token.
+   Basic authentication with passwords is deprecated. The `password` may contain an `api token <https://confluence.atlassian.com/cloud/api-tokens-938839638.html>`_ or alternatively you can set `PAT` to a Personal Access Token.
 
 The above example is the minimum required to import issues from
 Jira.  You can also feel free to use any of the
@@ -38,9 +40,12 @@ or described in `Service Features`_ below.
 Service Features
 ----------------
 
-The following default configuration is used::
+The following default configuration is used:
 
-    jira.body_length = <sys.maxsize>
+.. config::
+    :fragment: jira
+
+    # jira.body_length = <sys.maxsize>
     jira.import_labels_as_tags = False
     jira.import_sprints_as_tags = False
     jira.label_template = {{label}}
@@ -55,16 +60,22 @@ Specify the Query to Use for Gathering Issues
 
 By default, the JIRA plugin will include any issues that are assigned to you
 but do not yet have a resolution set, but you can fine-tune the query used
-for gathering issues by setting the ``jira.query`` parameter.
+for gathering issues by setting the ``query`` parameter.
 
 For example, to select issues assigned to 'ralph' having a status that is
 not 'closed' and is not 'resolved', you could add the following
-configuration option::
+configuration option:
+
+.. config::
+    :fragment: jira
 
     jira.query = assignee = ralph and status != closed and status != resolved
 
 This query needs to be modified accordingly to the literal values of your Jira
-instance; if the name contains any character, just put it in quotes, e.g.::
+instance; if the name contains any character, just put it in quotes, e.g.:
+
+.. config::
+    :fragment: jira
 
     jira.query = assignee = 'firstname.lastname' and status != Closed and status != Resolved and status != Done
 
@@ -72,14 +83,20 @@ Jira v4 Support
 +++++++++++++++
 
 If you happen to be using a very old version of Jira, add the following
-configuration option to your service configuration::
+configuration option to your service configuration:
+
+.. config::
+    :fragment: jira
 
     jira.version = 4
 
 Do Not Verify SSL Certificate
 +++++++++++++++++++++++++++++
 
-If you want to ignore verifying the SSL certificate, set::
+If you want to ignore verifying the SSL certificate, set:
+
+.. config::
+    :fragment: jira
 
     jira.verify_ssl = False
 
@@ -87,13 +104,19 @@ Import Labels and Sprints as Tags
 +++++++++++++++++++++++++++++++++
 
 The Jira issue tracker allows you to attach labels to issues; to
-use those labels as tags, you can use the ``jira.import_labels_as_tags``
-option::
+use those labels as tags, you can use the ``import_labels_as_tags``
+option:
+
+.. config::
+    :fragment: jira
 
     jira.import_labels_as_tags = True
 
 You can also import the names of any sprints associated with an issue as tags,
-by setting the ``jira.import_sprints_as_tags`` option::
+by setting the ``import_sprints_as_tags`` option:
+
+.. config::
+    :fragment: jira
 
     jira.import_sprints_as_tags = True
 
@@ -102,7 +125,10 @@ template used for converting the Jira label into a Taskwarrior tag.
 
 For example, to prefix all incoming labels with the string 'jira_' (perhaps
 to differentiate them from any existing tags you might have), you could
-add the following configuration option::
+add the following configuration option:
+
+.. config::
+    :fragment: jira
 
     jira.label_template = jira_{{label}}
 
@@ -139,7 +165,7 @@ By default, this service synchronizes the description of the Jira issue as ``jir
 In some cases, this is not required.
 It also risks triggering bugs in Taskwarrior around unicode encodings.
 
-Set ``jira.body_length``` to limit the size of the description UDA or include ``jiradescription`` in ``static_fields`` in the ``[general]`` section to eliminate the UDA entirely.
+Set ``body_length``` to limit the size of the description UDA or include ``jiradescription`` in ``static_fields`` in the ``[general]`` section to eliminate the UDA entirely.
 
 When using API token
 ++++++++++++++++++++
@@ -155,7 +181,7 @@ When using Personal Access Token
 
 Some hosts only support Personal Access Tokens (PATs) to authenticate. If so, ``bugwarrior pull`` will respond with ``Err: 401 Unauthorized``. Create a PAT as described `here`_.
 
-Put the PAT in the ``jira.PAT`` field and do not set ``jira.password``.
+Put the PAT in the ``PAT`` field and do not set ``password``.
 
 .. _here: https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html
 
@@ -168,7 +194,11 @@ Provided UDA Fields
 Support for Extra UDA Fields
 +++++++++++++++++++++++++++++
 
-To export additional UDA fields, set ``jira.extra_fields`` to comma-separated entries of the form ``uda_tag:field_key[.subkey]``. You can also chain subkeys to extract deeply embedded keys, e.g.::
+To export additional UDA fields, set ``extra_fields`` to comma-separated entries of the form ``uda_tag:field_key[.subkey]``. You can also chain subkeys to extract deeply embedded keys, e.g.:
+
+.. config::
+    :fragment: jira
+
     jira.extra_fields = jiraextrafield1:customfield_10000, jiraextrafield2:customfield_10001.attributes.description
 
 The correct key (and subkeys) can be found by inspecting the `fields` attribute of a standard Jira issue response.

--- a/bugwarrior/docs/services/kanboard.rst
+++ b/bugwarrior/docs/services/kanboard.rst
@@ -13,7 +13,9 @@ Install the following package using ``pip``:
 Example Service
 ---------------
 
-Here's an example of a Kanboard project::
+Here's an example of a Kanboard project:
+
+.. config::
 
     [my_issue_tracker]
     service = kanboard
@@ -33,10 +35,13 @@ Specify the Query to Use for Gathering Issues
 +++++++++++++++++++++++++++++++++++++++++++++
 
 By default, all open issues assigned to the specified username are imported.
-One may use the `kanboard.query` parameter to modify the search query.
+One may use the ``query`` parameter to modify the search query.
 
 For example, to import all open issues assigned to 'frank', use the following
-configuration option::
+configuration option:
+
+.. config::
+    :fragment: kanboard
 
     kanboard.query = status:open assignee:frank
 

--- a/bugwarrior/docs/services/pagure.rst
+++ b/bugwarrior/docs/services/pagure.rst
@@ -7,7 +7,9 @@ instance using the ``pagure`` service name.
 Example Service
 ---------------
 
-Here's an example of a Pagure target::
+Here's an example of a Pagure target:
+
+.. config::
 
     [my_issue_tracker]
     service = pagure
@@ -19,14 +21,14 @@ Pagure.  You can also feel free to use any of the
 configuration options described in :ref:`common_configuration_options`
 or described in `Service Features`_ below.
 
-Note that **either** ``pagure.tag`` or ``pagure.repo`` is required.
+Note that **either** ``tag`` or ``repo`` is required.
 
-- ``pagure.tag`` offers a flexible way to import issues from many pagure repos.
+- ``tag`` offers a flexible way to import issues from many pagure repos.
   It will include issues from *every* repo on the pagure instance that is
   *tagged* with the specified tag.  It is similar in usage to a github
   "organization".  In the example above, the entry will pull issues from all
   "releng" pagure repos.
-- ``pagure.repo`` offers a simple way to import issues from a single pagure repo.
+- ``repo`` offers a simple way to import issues from a single pagure repo.
 
 Note -- no authentication tokens are needed to pull issues from pagure.
 
@@ -38,21 +40,27 @@ Include and Exclude Certain Repositories
 
 If you happen to be working with a large number of projects, you
 may want to pull issues from only a subset of your repositories.  To 
-do that, you can use the ``pagure.include_repos`` option.
+do that, you can use the ``include_repos`` option.
 
 For example, if you would like to only pull-in issues from
 your ``project_foo`` and ``project_fox`` repositories, you could add
-this line to your service configuration::
+this line to your service configuration:
+
+.. config::
+    :fragment: pagure
 
     pagure.tag = fedora-infra
     pagure.include_repos = project_foo,project_fox
 
 Alternatively, if you have a particularly noisy repository, you can
 instead choose to import all issues excepting it using the
-``pagure.exclude_repos`` configuration option.  
+``exclude_repos`` configuration option.  
 
 In this example, ``noisy_repository`` is the repository you would
-*not* like issues created for::
+*not* like issues created for:
+
+.. config::
+    :fragment: pagure
 
     pagure.tag = fedora-infra
     pagure.exclude_repos = noisy_repository
@@ -62,7 +70,10 @@ Import Labels as Tags
 
 The Pagure issue tracker allows you to attach tags to issues; to
 use those pagure tags as taskwarrior tags, you can use the
-``pagure.import_tags`` option::
+``import_tags`` option:
+
+.. config::
+    :fragment: pagure
 
     pagure.import_tags = True
 
@@ -72,7 +83,10 @@ tag.
 
 For example, to prefix all incoming labels with the string 'pagure_' (perhaps
 to differentiate them from any existing tags you might have), you could
-add the following configuration option::
+add the following configuration option:
+
+.. config::
+    :fragment: pagure
 
     pagure.tag_template = pagure_{{label}}
 

--- a/bugwarrior/docs/services/phabricator.rst
+++ b/bugwarrior/docs/services/phabricator.rst
@@ -16,7 +16,9 @@ Install the following package using ``pip``:
 Example Service
 ---------------
 
-Here's an example of a Phabricator target::
+Here's an example of a Phabricator target:
+
+.. config::
 
     [my_issue_tracker]
     service = phabricator
@@ -44,22 +46,28 @@ If you have dozens of users and projects, you might want to
 pull the tasks and code review requests only for the specific ones.
 
 If you want to show only the tasks related to a specific user,
-you just need to add its PHID to the service configuration like this::
+you just need to add its PHID to the service configuration like this:
+
+.. config::
+    :fragment: phabricator
 
     phabricator.user_phids = PHID-USER-ab12c3defghi45jkl678
 
 If you want to show only the tasks and diffs related to a specific project or a repository,
-just add their PHIDs to the service configuration::
+just add their PHIDs to the service configuration:
+
+.. config::
+    :fragment: phabricator
 
     phabricator.project_phids = PHID-PROJ-ab12c3defghi45jkl678,PHID-REPO-ab12c3defghi45jkl678
 
-Both ``phabricator.user_phids`` and ``phabricator.project_phids`` accept
-a comma-separated (no spaces) list of PHIDs.
+Both ``user_phids`` and ``project_phids`` accept
+a list of PHIDs.
 
 If you specify both, you will get tasks and diffs that match one **or** the other.
 
 When working on a Phabricator installations with a huge number of users or projects,
-it is recommended that you specify ``phabricator.user_phids`` and/or ``phabricator.project_phids``,
+it is recommended that you specify ``user_phids`` and/or ``project_phids``,
 as the Phabricator API may return a timeout for a query with too many results.
 
 If you do not know PHID of a user, project or repository,
@@ -72,7 +80,10 @@ Selecting a Phabricator Host
 ............................
 
 If your ``~/.arcrc`` includes credentials for multiple Phabricator instances,
-it is undefined which one will be used. To make it explicit, you can use::
+it is undefined which one will be used. To make it explicit, you can use:
+
+.. config::
+    :fragment: phabricator
 
     phabricator.host = https://YOUR_PHABRICATOR_HOST
 
@@ -84,18 +95,21 @@ Ignoring Some Items
 
 By default, any Task or Revision relating to any of the given users or projects
 will be included.  This is likely more than you want!  You can ignore some user
-relationships with the following configuration::
+relationships with the following configuration:
 
-    phabricator.ignore_cc = True        # ignore CC field
-    phabricator.ignore_author = True    # ignore Author field
-    phabricator.ignore_owner = True     # ignore Owner field (Tasks only)
-    phabricator.ignore_reviewers = True # ignore Reviewers field (Revisions only)
+.. config::
+    :fragment: phabricator
+
+    phabricator.ignore_cc = True
+    phabricator.ignore_author = True
+    phabricator.ignore_owner = True
+    phabricator.ignore_reviewers = True
 
 Note that there is no way to filter by the reviewer's response (for example, to
 exclude Revisions you have already reviewed). Phabricator does not provide the
 necessary information in the Conduit API.
 
-Furthermore, setting `phabricator.only_if_assigned` to something other than False
+Furthermore, setting `only_if_assigned` to something other than False
 will default to ignoring the CC and Author fields as reported in phabricator.
 
 Provided UDA Fields

--- a/bugwarrior/docs/services/pivotaltracker.rst
+++ b/bugwarrior/docs/services/pivotaltracker.rst
@@ -8,7 +8,9 @@ the ``pivotaltracker`` service name.
 Example Service
 ---------------
 
-Here's an example of a Pivotal Tracker target::
+Here's an example of a Pivotal Tracker target:
+
+.. config::
 
     [my_issue_tracker]
     service = pivotaltracker
@@ -21,32 +23,32 @@ Pivotal Tracker.  You can also feel free to use any of the
 configuration options described in :ref:`common_configuration_options`
 or described in `Service Features`_ below.
 
-.. describe:: pivotaltracker.user_id
+.. describe:: user_id
 
     Your Pivotal Tracker user account.
 
     You can get your user_id by going to https://www.pivotaltracker.com/services/v5/me. It's the id field in the JSON response.
 
-.. describe:: pivotaltracker.token
+.. describe:: token
 
     Pivotal Tracker offers API keys for accounts to access resources through their
-    API. You will need to provide ``pivotaltracker.token`` to allow bugwarrior to
+    API. You will need to provide ``token`` to allow bugwarrior to
     pull stories.
 
-.. describe:: pivotaltracker.account_ids
+.. describe:: account_ids
 
     Pivotal Tracker account ids to specify which accounts to pull stories.
 
-.. describe:: pivotaltracker.version
+.. describe:: version
 
     Pivotal Tracker api version to access. The options are ``v5`` and ``edge``.
     Default is ``v5``.
 
-.. describe:: pivotaltracker.host
+.. describe:: host
 
     Pivotal Tracker host, default is ``https://www.pivotaltracker.com/services``.
 
-.. describe:: pivotaltracker.exclude_projects
+.. describe:: exclude_projects
 
     The list of projects to exclude. If omitted, bugwarrior will use all projects
     the authenticated user is a member of. This must be the projects id, In your browser,
@@ -54,7 +56,7 @@ or described in `Service Features`_ below.
     it should be something like https://www.pivotaltracker.com/n/projects/xxxxxxxx:
     copy the part after /b/projects/ in the pivotaltracker.exclude_projects field.
 
-.. describe:: pivotaltracker.exclude_stories
+.. describe:: exclude_stories
 
     The list of stories to exclude. If omitted, bugwarrior will use all stories
     the authenticated user is assigned to. This must be the story id and Pivotal
@@ -62,15 +64,15 @@ or described in `Service Features`_ below.
     story you wish to exlcude and copy the id next to 'ID' in the story. *Do not
     include the #*
 
-.. describe:: pivotaltracker.exclude_tags
+.. describe:: exclude_tags
 
     If set, pull all stories except for stories with those tags listed.
 
-.. describe:: pivotaltracker.import_blockers
+.. describe:: import_blockers
 
     A boolean that indicates whether to include blockers when listed in a story.
 
-.. describe:: pivotaltracker.blocker_template
+.. describe:: blocker_template
 
    Template used to convert Pivotal Trcker story blockers to a template defined
    before being pushed to UDA.
@@ -78,19 +80,19 @@ or described in `Service Features`_ below.
    are processed.
    The default value is ``Description: {{description}} State: {{resolved}}\n``.
 
-.. describe:: pivotaltracker.import_labels_as_tags
+.. describe:: import_labels_as_tags
 
     A boolean that indicates whether the Pivotal Tracker labels should be imported as
     tags in taskwarrior. (Defaults to false.)
 
-.. describe:: pivotaltracker.label_template
+.. describe:: label_template
 
    Template used to convert Pivotal Tracker labels to taskwarrior tags.
    See :ref:`field_templates` for more details regarding how templates
    are processed.
    The default value is ``{{label|replace(' ', '_')}}``.
 
-.. describe:: pivotaltracker.annotation_template
+.. describe:: annotation_template
 
    Template used to convert Pivotal Tracker story tasks to a template defined
    before being added as task annotations.
@@ -111,14 +113,17 @@ Exclude Certain Projects
 
 If you happen to be working with a large number of projects, you
 may want to pull stories from only a subset of your projects.  To
-do that, you can use the ``pivotaltracker.exclude_projects`` option.
+do that, you can use the ``exclude_projects`` option.
 
 For example, if you have a particularly noisy project, you can
 instead choose to import all stories except for the project listed
-using the ``pivotaltracker.exclude_projects`` configuration option.
+using the ``exclude_projects`` configuration option.
 
 In this example, ``noisy_project`` is the project you would
-*not* like stories created for::
+*not* like stories created for:
+
+.. config::
+    :fragment: pivotaltracker
 
     pivotaltracker.exclude_projects = noisy_project
 
@@ -127,12 +132,18 @@ Exclude Certain Stories
 
 If you want bugwarrior to not track specific stories you can ignore those
 stories and ensure bugwarrior only tracks the stories you want. To do
-this, you need to set::
+this, you need to set:
+
+.. config::
+    :fragment: pivotaltracker
 
     pivotaltracker.exclude_stories = 123456
 
 For example, if you have stories #123 and #344, you do not wish to pull anymore
-you can add them like so::
+you can add them like so:
+
+.. config::
+    :fragment: pivotaltracker
 
     pivotaltracker.exclude_stories = 123,344
 
@@ -141,7 +152,10 @@ Import Labels as Tags
 
 Pivotal Tracker allows you to attach labels to stories; to
 use those labels as tags, you can use the
-``pivotaltracker.import_labels_as_tags`` option::
+``import_labels_as_tags`` option:
+
+.. config::
+    :fragment: pivotaltracker
 
     pivotaltracker.import_labels_as_tags = True
 
@@ -151,7 +165,10 @@ Taskwarrior tag.
 
 For example, to prefix all incoming labels with the string `pivotal_` (perhaps
 to differentiate them from any existing tags you might have), you could
-add the following configuration option::
+add the following configuration option:
+
+.. config::
+    :fragment: pivotaltracker
 
     pivotaltracker.label_template = pivotal_{{label}}
 
@@ -166,19 +183,28 @@ to all fields on the Taskwarrior task, if needed.
 Get involved stories
 ++++++++++++++++++++
 
-By default, stories from all projects assigned to ``pivotaltracker.user_id``
-are tracked. To turn this off, set::
+By default, stories from all projects assigned to ``user_id``
+are tracked. To turn this off, set:
+
+.. config::
+    :fragment: pivotaltracker
 
     pivotaltracker.only_if_assigned = False
 
-Instead of fetching stories on ``pivotaltracker.user_id``'s assigned
+Instead of fetching stories on ``user_id``'s assigned
 stories, you may instead get those that are not assigned to
-``pivotaltracker.user_id``. This includes all stories in all projects
-the user has access to. To pull stories, use::
+``user_id``. This includes all stories in all projects
+the user has access to. To pull stories, use:
+
+.. config::
+    :fragment: pivotaltracker
 
     pivotaltracker.also_unassigned = True
 
-To only pull stories where ``{{user_id}}`` is the requestor of the story, use::
+To only pull stories where ``{{user_id}}`` is the requestor of the story, use:
+
+.. config::
+    :fragment: pivotaltracker
 
     pivotaltracker.only_if_author = True
 
@@ -188,7 +214,10 @@ Queries
 
 Pivotal Traker provides a decent search feature in their API. If you want
 to write your own query, as described at
-https://www.pivotaltracker.com/help/articles/advanced_search/ you will need to use::
+https://www.pivotaltracker.com/help/articles/advanced_search/ you will need to use:
+
+.. config::
+    :fragment: pivotaltracker
 
     pivotaltracker.query = mywork:1234
 
@@ -197,9 +226,12 @@ https://www.pivotaltracker.com/help/articles/advanced_search/ you will need to u
    project to determine what is pulled.
 
 To disable the pre-defined query described above and synchronize only the
-issues matched by a query, set::
+issues matched by a query, set:
 
-   pivotaltracker.query = <Your customer query>
+.. config::
+    :fragment: pivotaltracker
+
+    pivotaltracker.query = <Your customer query>
 
 .. note::
    Setting a custom query will pull everything that is returned from the result.
@@ -212,9 +244,12 @@ Story Tasks
 
 Pivotal Tracker provides the ability to add tasks to stories. Stories pulled in
 by bugwarrior will create an annotation for each "subtask" provided in the
-story. To turn this off, in your main section set::
+story. To turn this off, in your main section set:
 
-    annotation_comments = False
+.. config::
+    :fragment: pivotaltracker
+
+    pivotaltracker.annotation_comments = False
 
 Also, if you would like to control how these blockers are created, you can
 specify a template used for converting the story blocker into a more reasonable
@@ -228,7 +263,10 @@ Which will result in the following output::
 
    Completed: False - Do a thing and get rewarded.
 
-add the following configuration option::
+add the following configuration option:
+
+.. config::
+    :fragment: pivotaltracker
 
     pivotaltracker.annotation_template = {{description}} #{{id}} S{{complete}}
 
@@ -241,7 +279,10 @@ Story Blocker
 +++++++++++++
 
 Pivotal Tracker allows you assign blockers to stories and bugwarrior pulls
-these in by default. To disable this behavior set::
+these in by default. To disable this behavior set:
+
+.. config::
+    :fragment: pivotaltracker
 
     pivotaltracker.import_blockers = False
 
@@ -257,7 +298,10 @@ Which will result in the following output::
 
    Description: You cant do this stoy yet! Resovled: False
 
-add the following configuration option::
+add the following configuration option:
+
+.. config::
+    :fragment: pivotaltracker
 
     pivotaltracker.blocker_template = {{description}} #{{id}} S{{resolved}}
 

--- a/bugwarrior/docs/services/redmine.rst
+++ b/bugwarrior/docs/services/redmine.rst
@@ -9,7 +9,9 @@ Only first 100 issues are imported at the moment.
 Example Service
 ---------------
 
-Here's an example of a Redmine target::
+Here's an example of a Redmine target:
+
+.. config::
 
     [my_issue_tracker]
     service = redmine
@@ -20,10 +22,13 @@ Here's an example of a Redmine target::
 You can also feel free to use any of the configuration options described in
 :ref:`common_configuration_options`.
 
-There are also `redmine.login`/`redmine.password` settings if your
+There are also `login`/`password` settings if your
 instance is behind basic auth.
 
-If you want to ignore verifying the SSL certificate, set::
+If you want to ignore verifying the SSL certificate, set:
+
+.. config::
+    :fragment: redmine
 
     redmine.verify_ssl = False
 
@@ -31,8 +36,11 @@ Specify the parameters to filter issues
 +++++++++++++++++++++++++++++++++++++++
 
 If you want a finer control over the filtering of issues, you may combine
-`service.only_if_assigned` and `service.issue_limit` with the `redmine.query`
-setting.
+`only_if_assigned` and `issue_limit` with the `query`
+setting:
+
+.. config::
+    :fragment: redmine
 
     redmine.query = project_id=10&status_id=15
 

--- a/bugwarrior/docs/services/taiga.rst
+++ b/bugwarrior/docs/services/taiga.rst
@@ -6,7 +6,9 @@ You can import tasks from a Taiga instance using the ``taiga`` service name.
 Example Service
 ---------------
 
-Here's an example of a taiga project::
+Here's an example of a taiga project:
+
+.. config::
 
     [my_issue_tracker]
     service = taiga
@@ -23,14 +25,20 @@ Service Features
 Include Tasks
 +++++++++++++
 
-By default, userstories from taiga are added in taskwarrior. If you like to include taiga tasks as well, set the config option::
+By default, userstories from taiga are added in taskwarrior. If you like to include taiga tasks as well, set the config option:
+
+.. config::
+    :fragment: taiga
 
     taiga.include_tasks = True
 
 Label Template
 ++++++++++++++
 
-Use the ``label_template`` option to customize the label. For example::
+Use the ``label_template`` option to customize the label. For example:
+
+.. config::
+    :fragment: taiga
 
     taiga.label_template = taiga_{{label}}
 

--- a/bugwarrior/docs/services/teamlab.rst
+++ b/bugwarrior/docs/services/teamlab.rst
@@ -7,7 +7,9 @@ the ``teamlab`` service name.
 Example Service
 ---------------
 
-Here's an example of a Teamlab target::
+Here's an example of a Teamlab target:
+
+.. config::
 
     [my_issue_tracker]
     service = teamlab

--- a/bugwarrior/docs/services/teamwork_projects.rst
+++ b/bugwarrior/docs/services/teamwork_projects.rst
@@ -7,7 +7,9 @@ the ``teamwork_projects`` service name.
 Example Service
 ---------------
 
-Here's an example of a Teamwork Projects target::
+Here's an example of a Teamwork Projects target:
+
+.. config::
 
     [my_issue_tracker]
     service = teamwork_projects

--- a/bugwarrior/docs/services/trac.rst
+++ b/bugwarrior/docs/services/trac.rst
@@ -14,7 +14,9 @@ Install packages needed for Trac support with::
 Example Service
 ---------------
 
-Here's an example of a Trac target::
+Here's an example of a Trac target:
+
+.. config::
 
     [my_issue_tracker]
     service = trac
@@ -28,9 +30,12 @@ Service Features
 By default, this service uses the XML-RPC Trac plugin, which must be installed
 on the Trac instance.  If this is not available, the service can use Trac's
 built-in CSV support, but in this mode it cannot add annotations based on
-ticket comments.  To enable this mode, add ``trac.no_xmlrpc = true``.
+ticket comments.  To enable this mode, add ``no_xmlrpc = true``.
 
-If your trac instance requires authentication to perform the query, add::
+If your trac instance requires authentication to perform the query, add:
+
+.. config::
+    :fragment: trac
 
     trac.username = ralph
     trac.password = OMG_LULZ

--- a/bugwarrior/docs/services/trello.rst
+++ b/bugwarrior/docs/services/trello.rst
@@ -7,11 +7,11 @@ You can import tasks from Trello cards using the ``trello`` service name.
 Options
 -------
 
-.. describe:: trello.api_key
+.. describe:: api_key
 
    Your Trello API key, available from https://trello.com/app-key.
 
-.. describe:: trello.token
+.. describe:: token
 
    Your Trello token, available from https://trello.com/app-key.
 
@@ -22,7 +22,7 @@ Options
    https://trello.com/1/connect?key=TRELLO_API_KEY&name=bugwarrior&response_type=token&scope=read,write&expiration=never
    replacing ``TRELLO_API_KEY`` by the key you got on the last step.
 
-.. describe:: trello.include_boards
+.. describe:: include_boards
 
    The list of board to include. If omitted, bugwarrior will use all boards
    the authenticated user is a member of.
@@ -30,27 +30,27 @@ Options
    the easiest option as it is part of the board URL: in your browser, navigate
    to the board you want to pull cards from and look at the URL, it should be
    something like ``https://trello.com/b/xxxxxxxx/myboard``: copy the part
-   between ``/b/`` and the next ``/`` in the ``trello.include_boards`` field.
+   between ``/b/`` and the next ``/`` in the ``include_boards`` field.
 
    .. image:: pictures/trello_url.png
       :height: 1cm
 
-.. describe:: trello.include_lists
+.. describe:: include_lists
 
    If set, only pull cards from lists whose name is present in
-   ``trello.include_lists``.
+   ``include_lists``.
 
-.. describe:: trello.exclude_lists
+.. describe:: exclude_lists
 
    If set, skip cards from lists whose name is present in
-   ``trello.exclude_lists``.
+   ``exclude_lists``.
 
-.. describe:: trello.import_labels_as_tags
+.. describe:: import_labels_as_tags
 
    A boolean that indicates whether the Trello labels should be imported as
    tags in taskwarrior. (Defaults to false.)
 
-.. describe:: trello.label_template
+.. describe:: label_template
 
    Template used to convert Trello labels to taskwarrior tags.
    See :ref:`field_templates` for more details regarding how templates
@@ -60,7 +60,9 @@ Options
 Example Service
 ---------------
 
-Here's an example of a Trello target::
+Here's an example of a Trello target:
+
+.. config::
 
     [my_project]
     service = trello
@@ -70,7 +72,9 @@ Here's an example of a Trello target::
 The above example is the minimum required to import tasks from Trello.  This
 will import every card from all the user's boards.
 
-Here's an example with more options::
+Here's an example with more options:
+
+.. config::
 
     [my_project]
     service = trello
@@ -88,6 +92,7 @@ if they belong to the right lists..
 Feel free to use any of the configuration options described in
 :ref:`common_configuration_options` or described in `Service Features`_ below.
 
+
 Service Features
 ----------------
 
@@ -95,12 +100,15 @@ Include and Exclude Certain Lists
 +++++++++++++++++++++++++++++++++
 
 You may want to pull cards from only a subset of the open lists in your board.
-To do that, you can use the ``trello.include_lists`` and
-``trello.exclude_lists`` options.
+To do that, you can use the ``include_lists`` and
+``exclude_lists`` options.
 
 For example, if you would like to only pull-in cards from
 your ``Todo`` and ``Doing`` lists, you could add this line to your service
-configuration::
+configuration:
+
+.. config::
+    :fragment: trello
 
     trello.include_lists = Todo, Doing
 
@@ -109,7 +117,10 @@ Import Labels as Tags
 +++++++++++++++++++++
 
 Trello allows you to attach labels to cards; to use those labels as tags, you
-can use the ``trello.import_labels_as_tags`` option::
+can use the ``import_labels_as_tags`` option:
+
+.. config::
+    :fragment: trello
 
     trello.import_labels_as_tags = True
 
@@ -119,7 +130,10 @@ tag.
 
 For example, to prefix all incoming labels with the string 'trello_' (perhaps
 to differentiate them from any existing tags you might have), you could
-add the following configuration option::
+add the following configuration option:
+
+.. config::
+    :fragment: trello
 
     trello.label_template = trello_{{label}}
 

--- a/bugwarrior/docs/services/versionone.rst
+++ b/bugwarrior/docs/services/versionone.rst
@@ -13,7 +13,9 @@ Install the following package using ``pip``:
 Example Service
 ---------------
 
-Here's an example of a VersionOne project::
+Here's an example of a VersionOne project:
+
+.. config::
 
     [my_issue_tracker]
     service = versionone
@@ -43,8 +45,11 @@ Restrict Task Imports to a Specific Timebox (Sprint)
 
 You can restrict imported tasks to a specific Timebox (VersionOne's
 internal generic name for a Sprint) -- in this example named
-'Sprint 2014-09-22' -- by using the ``versionone.timebox_name`` option;
-for example::
+'Sprint 2014-09-22' -- by using the ``timebox_name`` option;
+for example:
+
+.. config::
+    :fragment: versionone
 
     versionone.timebox_name = Sprint 2014-09-22
 
@@ -54,8 +59,11 @@ Set a Global Project Name
 By default, this importer does not set a project name on imported tasks.
 Although you can gain more flexibility by using :ref:`field_templates`
 to generate a project name, if all you need is to set a predictable
-project name, you can use the ``versionone.project_name`` option; in this
-example, to add imported tasks to the project 'important_project'::
+project name, you can use the ``project_name`` option; in this
+example, to add imported tasks to the project 'important_project':
+
+.. config::
+    :fragment: versionone
 
     versionone.project_name = important_project
 
@@ -63,8 +71,11 @@ Set the Timezone Used for Due Dates
 +++++++++++++++++++++++++++++++++++
 
 You can configure the timezone used for setting your tasks' due dates
-by setting the ``versionone.timezone`` option.  By default, your local
-timezone will be used.  For example::
+by setting the ``timezone`` option.  By default, your local
+timezone will be used.  For example:
+
+.. config::
+    :fragment: versionone
 
     versionone.timezone = America/Los_Angeles
 

--- a/bugwarrior/docs/services/youtrack.rst
+++ b/bugwarrior/docs/services/youtrack.rst
@@ -7,7 +7,9 @@ the ``youtrack`` service name.
 Example Service
 ---------------
 
-Here's an example of a YouTrack target::
+Here's an example of a YouTrack target:
+
+.. config::
 
     [my_issue_tracker]
     service = youtrack
@@ -27,7 +29,10 @@ Unauthenticated
 +++++++++++++++
 
 While the ``login`` and ``password`` fields are still required, bugwarrior
-will not log in to the service if you set::
+will not log in to the service if you set:
+
+.. config::
+    :fragment: youtrack
 
     youtrack.anonymous = True
 
@@ -38,30 +43,45 @@ will not log in to the service if you set::
 Customize the YouTrack Connection
 +++++++++++++++++++++++++++++++++
 
-The ``youtrack.host`` field is used to construct a URL for
+The ``host`` field is used to construct a URL for
 the YouTrack server. It defaults to a secure connection scheme (HTTPS)
 on the standard port (443).
 
-To connect on a different port, set::
+To connect on a different port, set:
+
+.. config::
+    :fragment: youtrack
 
     youtrack.port = 8443
 
-If your YouTrack instance is only available over HTTP, set::
+If your YouTrack instance is only available over HTTP, set:
+
+.. config::
+    :fragment: youtrack
 
     youtrack.use_https = False
 
-If you want to ignore verifying the SSL certificate, set::
+If you want to ignore verifying the SSL certificate, set:
+
+.. config::
+    :fragment: youtrack
 
     youtrack.verify_ssl = False
 
-For YouTrack InCloud instances set::
+For YouTrack InCloud instances set:
+
+.. config::
+    :fragment: youtrack
 
     youtrack.incloud_instance = True
 
 Specify the Query to Use for Gathering Issues
 +++++++++++++++++++++++++++++++++++++++++++++
 
-The default option selects unresolved issues assigned to the login user::
+The default option selects unresolved issues assigned to the login user:
+
+.. config::
+    :fragment: youtrack
 
     youtrack.query = for:me #Unresolved
 
@@ -69,7 +89,10 @@ Reference the
 `YouTrack Search Query Grammar <https://www.jetbrains.com/help/youtrack/standalone/7.0/Search-Query-Grammar.html>`_
 for additional examples.
 
-Queries are capped at 100 max results by default, but may be adjusted to meet your needs::
+Queries are capped at 100 max results by default, but may be adjusted to meet your needs:
+
+.. config::
+    :fragment: youtrack
 
     youtrack.query_limit = 100
 
@@ -77,7 +100,10 @@ Import Issue Tags
 +++++++++++++++++
 
 The YouTrack issue tracker allows you to tag issues and these tags are applied
-to tasks by default. To disable this behavior, set::
+to tasks by default. To disable this behavior, set:
+
+.. config::
+    :fragment: youtrack
 
     youtrack.import_tags = False
 
@@ -87,7 +113,10 @@ tag.
 
 For example, to prefix all incoming tags with the string 'yt\_' (perhaps
 to differentiate them from any existing tags you might have), you could
-add the following configuration option::
+add the following configuration option:
+
+.. config::
+    :fragment: youtrack
 
     youtrack.tag_template = yt_{{tag|lower}}
 

--- a/bugwarrior/services/activecollab2.py
+++ b/bugwarrior/services/activecollab2.py
@@ -11,7 +11,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class ActiveCollabProjects(frozenset):
+class ActiveCollabProjects(dict):
 
     @classmethod
     def __get_validators__(cls):
@@ -20,11 +20,10 @@ class ActiveCollabProjects(frozenset):
     @classmethod
     def validate(cls, projects_raw):
         projects_list = projects_raw.split(',')
-        projects = []
-        for k, v in enumerate(projects_list):
-            project_data = v.strip().split(":")
-            project = dict([(project_data[0], project_data[1])])
-            projects.append(project)
+        projects = {}
+        for project in projects_list:
+            project_data = project.strip().split(":")
+            projects[project_data[0]] = project_data[1]
         return projects
 
 
@@ -211,17 +210,13 @@ class ActiveCollab2Service(IssueService):
         # Loop through each project
         start = time.time()
         issue_generators = []
-        projects = self.config.projects
-        for project in projects:
-            for project_id, project_name in project.items():
-                log.debug(
-                    " Getting tasks for #" + project_id +
-                    " " + project_name + '"')
-                issue_generators.append(
-                    self.client.get_issue_generator(
-                        self.config.user_id, project_id, project_name
-                    )
+        for project_id, project_name in self.config.projects.items():
+            log.debug(f"Getting tasks for #{project_id} {project_name}")
+            issue_generators.append(
+                self.client.get_issue_generator(
+                    self.config.user_id, project_id, project_name
                 )
+            )
 
         log.debug(" Elapsed Time: %s" % (time.time() - start))
 

--- a/bugwarrior/services/activecollab2.py
+++ b/bugwarrior/services/activecollab2.py
@@ -19,7 +19,10 @@ class ActiveCollabProjects(dict):
 
     @classmethod
     def validate(cls, projects_raw):
-        projects_list = projects_raw.split(',')
+        try:  # ini
+            projects_list = projects_raw.split(',')
+        except AttributeError:  # toml (already a dict)
+            return projects_raw
         projects = {}
         for project in projects_list:
             project_data = project.strip().split(":")

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -35,7 +35,10 @@ class JiraExtraFields(frozenset):
 
     @classmethod
     def validate(cls, extra_fields_raw):
-        extra_fields_list = extra_fields_raw.split(',')
+        try:  # ini
+            extra_fields_list = extra_fields_raw.split(',')
+        except AttributeError:  # toml
+            extra_fields_list = extra_fields_raw
         extra_fields = []
         for extra_field_raw in extra_fields_list:
             split_extra_field = extra_field_raw.strip().split(":", maxsplit=2)

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ extras = {
     "bts": ["PySimpleSOAP", "python-debianbts>=2.6.1"],
     "bugzilla": ["python-bugzilla>=2.0.0"],
     "gmail": ["google-api-python-client", "google-auth-oauthlib"],
+    "ini2toml": ["ini2toml[full]"],
     "jira": ["jira>=0.22"],
     "kanboard": ["kanboard"],
     "keyring": ["keyring"],
@@ -105,5 +106,7 @@ setup(name='bugwarrior',
       azuredevops=bugwarrior.services.azuredevops:AzureDevopsService
       gitbug=bugwarrior.services.gitbug:GitBugService
       deck=bugwarrior.services.deck:NextcloudDeckService
+      [ini2toml.processing]
+      bugwarrior = bugwarrior.config.ini2toml_plugin:activate
       """,
       )

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,8 @@ setup(name='bugwarrior',
           "pytz",
           "requests",
           "taskw>=0.8",
+          # Needed for backwards compatibility with python<=3.10.
+          "tomli",
           # Needed for backwards compatibility with python<=3.7.
           "typing-extensions",
       ],

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,18 @@ extras = {
     "kanboard": ["kanboard"],
     "keyring": ["keyring"],
     "phabricator": ["phabricator"],
-    "test": ["flake8", "pytest", "responses", "sphinx>=1.0", "sphinx-click", "docutils",
-             # Workaround https://github.com/python/importlib_metadata/issues/406
-             "importlib-metadata<5"
-             ],
+    "test": [
+        "docutils",
+        "flake8",
+        "pytest",
+        "pytest-subtests",
+        "responses",
+        "sphinx>=1.0",
+        "sphinx-click",
+
+        # Workaround https://github.com/python/importlib_metadata/issues/406
+        "importlib-metadata<5",
+    ],
     "trac": ["offtrac"],
     "versionone": ["v1pysdk"],
 }

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ extras = {
         "responses",
         "sphinx>=1.0",
         "sphinx-click",
+        "sphinx-inline-tabs",
 
         # Workaround https://github.com/python/importlib_metadata/issues/406
         "importlib-metadata<5",

--- a/tests/base.py
+++ b/tests/base.py
@@ -49,9 +49,9 @@ class ConfigTest(unittest.TestCase):
 
         # Configure environment.
         os.environ['HOME'] = self.tempdir
+        os.environ['XDG_CONFIG_HOME'] = os.path.join(self.tempdir, '.config')
         os.environ.pop(config.BUGWARRIORRC, None)
         os.environ.pop('TASKRC', None)
-        os.environ.pop('XDG_CONFIG_HOME', None)
         os.environ.pop('XDG_CONFIG_DIRS', None)
 
     def tearDown(self):

--- a/tests/config/example-bugwarrior.toml
+++ b/tests/config/example-bugwarrior.toml
@@ -1,210 +1,201 @@
 # Example bugwarriorrc
-
 # General stuff.
+
 [general]
 # Here you define a comma separated list of targets.  Each of them must have a
 # section below determining their properties, how to query them, etc.  The name
 # is just a symbol, and doesn't have any functional importance.
-targets = activecollab, activecollab2, gitlab_config, jira_project, my_github, my_gmail, my_kanboard, my_phabricator, my_redmine, my_teamlab, moksha_trac, pivotaltracker
-
+targets = [
+    "activecollab",
+    "activecollab2",
+    "gitlab_config",
+    "jira_project",
+    "my_github",
+    "my_gmail",
+    "my_kanboard",
+    "my_phabricator",
+    "my_redmine",
+    "my_teamlab",
+    "moksha_trac",
+    "pivotaltracker",
+]
 # If unspecified, the default taskwarrior config will be used.
-#taskrc = /path/to/.taskrc
-
+# taskrc = /path/to/.taskrc
 # Setting this to true will shorten links with http://da.gd/
-#shorten = False
-
+shorten = false
 # Setting this to True will include a link to the ticket in the description
-inline_links = False
-
+inline_links = false
 # Setting this to True will include a link to the ticket as an annotation
-annotation_links = True
-
+annotation_links = true
 # Setting this to True will include issue comments and author name in task
 # annotations
-annotation_comments = True
-
+annotation_comments = true
 # Setting this to False will strip newlines from comment annotations
-annotation_newlines = False
-
+annotation_newlines = false
 # log.level specifies the verbosity.  The default is DEBUG.
 # log.level can be one of DEBUG, INFO, WARNING, ERROR, CRITICAL, DISABLED
-#log.level = DEBUG
-
+log_level = "DEBUG"
 # If log.file is specified, output will be redirected there.  If it remains
 # unspecified, output is sent to sys.stderr
-#log.file = /var/log/bugwarrior.log
-
+log_file = "/var/log/bugwarrior.log"
 # Configure the default description or annotation length.
-#annotation_length = 45
-
+# annotation_length = 45
 # Use hooks to run commands prior to importing from `bugwarrior pull`.
 # `bugwarrior pull` will run the commands in the order that they are specified
 # below.
-#
+# 
 # pre_import: The pre_import hook is invoked after all issues have been pulled
 # from remote sources, but before they are synced to the TW db. If your
 # pre_import script has a non-zero exit code, the `bugwarrior pull` command will
 # exit early.
-[hooks]
-pre_import = /home/someuser/backup.sh, /home/someuser/sometask.sh
 
+[hooks]
+pre_import = ["/home/someuser/backup.sh", "/home/someuser/sometask.sh"]
 # This section is for configuring notifications when `bugwarrior pull` runs,
 # and when issues are created, updated, or deleted by `bugwarrior pull`.
 # Three backends are currently supported:
-#
-#  - applescript        macOS      no external dependencies
-#  - gobject            Linux      python gobject must be installed
-#
-#[notifications]
+# 
+# - applescript        macOS      no external dependencies
+# - gobject            Linux      python gobject must be installed
+# 
+# [notifications]
 # notifications = True
 # backend = gobject
 # only_on_new_tasks = True
-
-
 # This is a github example.  It says, "scrape every issue from every repository
 # on http://github.com/ralphbean.  It doesn't matter if ralphbean owns the issue
 # or not."
-[my_github]
-service = github
-github.default_priority = H
-github.add_tags = open_source
 
+[my_github]
+service = "github"
+default_priority = "H"
+add_tags = ["open_source"]
 # This specifies that we should pull issues from repositories belonging
 # to the 'ralphbean' github account.  See the note below about
 # 'github.username' and 'github.login'.  They are different, and you need
 # both.
-github.username = ralphbean
-
+username = "ralphbean"
 # I want taskwarrior to include issues from all my repos, except these
 # two because they're spammy or something.
-github.exclude_repos = project_bar,project_baz
-
+exclude_repos = ["project_bar", "project_baz"]
 # Working with a large number of projects, instead of excluding most of them I
 # can also simply include just a limited set.
-github.include_repos = project_foo,project_foz
-
+include_repos = ["project_foo", "project_foz"]
 # Note that login and username can be different:  I can login as me, but
 # scrape issues from an organization's repos.
-#
+# 
 # - 'github.login' is the username you ask bugwarrior to
-#   login as.  Set it to your account.
+# login as.  Set it to your account.
 # - 'github.username' is the github entity you want to pull
-#   issues for.  It could be you, or some other user entirely.
-github.login = ralphbean
-github.token = 123456
-
-
+# issues for.  It could be you, or some other user entirely.
+login = "ralphbean"
+token = "123456"
 # Here's an example of a trac target.
+
 [moksha_trac]
-service = trac
-
-trac.base_uri = fedorahosted.org/moksha
-trac.username = ralph
-trac.password = OMG_LULZ
-
-trac.only_if_assigned = ralph
-trac.also_unassigned = True
-trac.default_priority = H
-trac.add_tags = work
-
+service = "trac"
+base_uri = "fedorahosted.org/moksha"
+username = "ralph"
+password = "OMG_LULZ"
+only_if_assigned = "ralph"
+also_unassigned = true
+default_priority = "H"
+add_tags = ["work"]
 # Example gitlab configuration containing individual priorities
-[gitlab_config]
-service = gitlab
-gitlab.login = ralphbean
-gitlab.token = OMG_LULZ
-gitlab.host = gitlab.com
-gitlab.owned = true
-gitlab.default_issue_priority = M
-gitlab.default_todo_priority = M
-gitlab.default_mr_priority = H
 
+[gitlab_config]
+service = "gitlab"
+login = "ralphbean"
+token = "OMG_LULZ"
+host = "gitlab.com"
+owned = true
+default_issue_priority = "M"
+default_todo_priority = "M"
+default_mr_priority = "H"
 # Here's an example of a jira project. The ``jira-python`` module is
 # a bit particular, and jira deployments, like Bugzilla, tend to be
 # reasonably customized. So YMMV. The ``base_uri`` must not have a
 # have a trailing slash. In this case we fetch comments and
 # cases from jira assigned to 'ralph' where the status is not closed or
 # resolved.
+
 [jira_project]
-service = jira
-jira.base_uri = https://jira.example.org
-jira.username = ralph
-jira.password = OMG_LULZ
-jira.query = assignee = ralph and status != closed and status != resolved
+service = "jira"
+base_uri = "https://jira.example.org"
+username = "ralph"
+password = "OMG_LULZ"
+query = "assignee = ralph and status != closed and status != resolved"
 # Set this to your jira major version. We currently support only jira version
 # 4 and 5(the default). You can find your particular version in the footer at
 # the dashboard.
-jira.version = 5
-jira.add_tags = enterprisey,work
-
-
+version = 5
+add_tags = ["enterprisey", "work"]
 # This is a kanboard example.
+
 [my_kanboard]
-service = kanboard
-kanboard.url = https://kanboard.example.org
-kanboard.username = ralphbean
-
+service = "kanboard"
+url = "https://kanboard.example.org"
+username = "ralphbean"
 # Your password or, even better, API token
-kanboard.password = my_api_token
-
+password = "my_api_token"
 # A custom query to search for open issues. By default, assigned and open
 # tasks are queried.
-kanboard.query = status:open assignee:me
-
-
+query = "status:open assignee:me"
 # Here's an example of a phabricator target
+
 [my_phabricator]
-service = phabricator
+service = "phabricator"
 # No need to specify credentials.  They are gathered from ~/.arcrc
-
 # Here's an example of a teamlab target.
+
 [my_teamlab]
-service = teamlab
-
-teamlab.hostname = teamlab.example.com
-teamlab.login = alice
-teamlab.password = secret
-
+service = "teamlab"
+hostname = "teamlab.example.com"
+login = "alice"
+password = "secret"
 # Here's an example of a redmine target.
+
 [my_redmine]
-service = redmine
-redmine.url = http://redmine.example.org/
-redmine.key = c0c4c014cafebabe
-redmine.add_tags = chiliproject
+service = "redmine"
+url = "http://redmine.example.org/"
+key = "c0c4c014cafebabe"
+add_tags = ["chiliproject"]
 
 [activecollab]
-service = activecollab
-activecollab.url = https://ac.example.org/api.php
-activecollab.key = your-api-key
-activecollab.user_id = 15
-activecollab.add_tags = php
+service = "activecollab"
+url = "https://ac.example.org/api.php"
+key = "your-api-key"
+user_id = 15
+add_tags = ["php"]
 
 [activecollab2]
-service = activecollab2
-activecollab2.url = http://ac.example.org/api.php
-activecollab2.key = your-api-key
-activecollab2.user_id = 15
-activecollab2.projects = 1:first_project, 5:another_project
+service = "activecollab2"
+url = "http://ac.example.org/api.php"
+key = "your-api-key"
+user_id = 15
+projects = {1 = "first_project", 5 = "another_project"}
 
 [my_gmail]
-service = gmail
-gmail.query = label:action OR label:readme
-gmail.login_name = you@example.com
+service = "gmail"
+query = "label:action OR label:readme"
+login_name = "you@example.com"
 
 [pivotaltracker]
-service = pivotaltracker
-pivotaltracker.token = your-api-key
-pivotaltracker.version = v5
-pivotaltracker.user_id = 123456
-pivotaltracker.account_ids = first_account_id,second_account_id
-pivotaltracker.only_if_assigned = True
-pivotaltracker.also_unassigned = False
-pivotaltracker.only_if_author = False
-pivotaltracker.import_labels_as_tags = True
-pivotaltracker.label_template = pivotal_{{label}}
-pivotaltracker.import_blockers = True
-pivotaltracker.blocker_template = "Description: {{description}} State: {{resolved}}\n"
-pivotaltracker.annotation_template = "status: {{completed}} - MYDESC {{description}}"
-pivotaltracker.exclude_projects = first_project_id,second_project_id
-pivotaltracker.exclude_stories = first_story_id,second_story_id
-pivotaltracker.exclude_tags = "wont fix", "should fix"
-pivotaltracker.query = mywork:1234 -has:label
+service = "pivotaltracker"
+token = "your-api-key"
+version = "v5"
+user_id = 123456
+account_ids = ["first_account_id", "second_account_id"]
+only_if_assigned = true
+also_unassigned = false
+only_if_author = false
+import_labels_as_tags = true
+label_template = "pivotal_{{label}}"
+import_blockers = true
+blocker_template = 'Description: {{description}} State: {{resolved}}\n'
+annotation_template = "status: {{completed}} - MYDESC {{description}}"
+exclude_projects = ["first_project_id", "second_project_id"]
+exclude_stories = ["first_story_id", "second_story_id"]
+exclude_tags = ["wont fix", "should fix"]
+query = "mywork:1234 -has:label"
+

--- a/tests/config/example-bugwarriorrc
+++ b/tests/config/example-bugwarriorrc
@@ -1,0 +1,210 @@
+# Example bugwarriorrc
+
+# General stuff.
+[general]
+# Here you define a comma separated list of targets.  Each of them must have a
+# section below determining their properties, how to query them, etc.  The name
+# is just a symbol, and doesn't have any functional importance.
+targets = activecollab, activecollab2, gitlab_config, jira_project, my_github, my_gmail, my_kanboard, my_phabricator, my_redmine, my_teamlab, moksha_trac, pivotaltracker
+
+# If unspecified, the default taskwarrior config will be used.
+#taskrc = /path/to/.taskrc
+
+# Setting this to true will shorten links with http://da.gd/
+shorten = False
+
+# Setting this to True will include a link to the ticket in the description
+inline_links = False
+
+# Setting this to True will include a link to the ticket as an annotation
+annotation_links = True
+
+# Setting this to True will include issue comments and author name in task
+# annotations
+annotation_comments = True
+
+# Setting this to False will strip newlines from comment annotations
+annotation_newlines = False
+
+# log.level specifies the verbosity.  The default is DEBUG.
+# log.level can be one of DEBUG, INFO, WARNING, ERROR, CRITICAL, DISABLED
+log.level = DEBUG
+
+# If log.file is specified, output will be redirected there.  If it remains
+# unspecified, output is sent to sys.stderr
+log.file = /var/log/bugwarrior.log
+
+# Configure the default description or annotation length.
+#annotation_length = 45
+
+# Use hooks to run commands prior to importing from `bugwarrior pull`.
+# `bugwarrior pull` will run the commands in the order that they are specified
+# below.
+#
+# pre_import: The pre_import hook is invoked after all issues have been pulled
+# from remote sources, but before they are synced to the TW db. If your
+# pre_import script has a non-zero exit code, the `bugwarrior pull` command will
+# exit early.
+[hooks]
+pre_import = /home/someuser/backup.sh, /home/someuser/sometask.sh
+
+# This section is for configuring notifications when `bugwarrior pull` runs,
+# and when issues are created, updated, or deleted by `bugwarrior pull`.
+# Three backends are currently supported:
+#
+#  - applescript        macOS      no external dependencies
+#  - gobject            Linux      python gobject must be installed
+#
+#[notifications]
+# notifications = True
+# backend = gobject
+# only_on_new_tasks = True
+
+
+# This is a github example.  It says, "scrape every issue from every repository
+# on http://github.com/ralphbean.  It doesn't matter if ralphbean owns the issue
+# or not."
+[my_github]
+service = github
+github.default_priority = H
+github.add_tags = open_source
+
+# This specifies that we should pull issues from repositories belonging
+# to the 'ralphbean' github account.  See the note below about
+# 'github.username' and 'github.login'.  They are different, and you need
+# both.
+github.username = ralphbean
+
+# I want taskwarrior to include issues from all my repos, except these
+# two because they're spammy or something.
+github.exclude_repos = project_bar,project_baz
+
+# Working with a large number of projects, instead of excluding most of them I
+# can also simply include just a limited set.
+github.include_repos = project_foo,project_foz
+
+# Note that login and username can be different:  I can login as me, but
+# scrape issues from an organization's repos.
+#
+# - 'github.login' is the username you ask bugwarrior to
+#   login as.  Set it to your account.
+# - 'github.username' is the github entity you want to pull
+#   issues for.  It could be you, or some other user entirely.
+github.login = ralphbean
+github.token = 123456
+
+
+# Here's an example of a trac target.
+[moksha_trac]
+service = trac
+
+trac.base_uri = fedorahosted.org/moksha
+trac.username = ralph
+trac.password = OMG_LULZ
+
+trac.only_if_assigned = ralph
+trac.also_unassigned = True
+trac.default_priority = H
+trac.add_tags = work
+
+# Example gitlab configuration containing individual priorities
+[gitlab_config]
+service = gitlab
+gitlab.login = ralphbean
+gitlab.token = OMG_LULZ
+gitlab.host = gitlab.com
+gitlab.owned = true
+gitlab.default_issue_priority = M
+gitlab.default_todo_priority = M
+gitlab.default_mr_priority = H
+
+# Here's an example of a jira project. The ``jira-python`` module is
+# a bit particular, and jira deployments, like Bugzilla, tend to be
+# reasonably customized. So YMMV. The ``base_uri`` must not have a
+# have a trailing slash. In this case we fetch comments and
+# cases from jira assigned to 'ralph' where the status is not closed or
+# resolved.
+[jira_project]
+service = jira
+jira.base_uri = https://jira.example.org
+jira.username = ralph
+jira.password = OMG_LULZ
+jira.query = assignee = ralph and status != closed and status != resolved
+# Set this to your jira major version. We currently support only jira version
+# 4 and 5(the default). You can find your particular version in the footer at
+# the dashboard.
+jira.version = 5
+jira.add_tags = enterprisey,work
+
+
+# This is a kanboard example.
+[my_kanboard]
+service = kanboard
+kanboard.url = https://kanboard.example.org
+kanboard.username = ralphbean
+
+# Your password or, even better, API token
+kanboard.password = my_api_token
+
+# A custom query to search for open issues. By default, assigned and open
+# tasks are queried.
+kanboard.query = status:open assignee:me
+
+
+# Here's an example of a phabricator target
+[my_phabricator]
+service = phabricator
+# No need to specify credentials.  They are gathered from ~/.arcrc
+
+# Here's an example of a teamlab target.
+[my_teamlab]
+service = teamlab
+
+teamlab.hostname = teamlab.example.com
+teamlab.login = alice
+teamlab.password = secret
+
+# Here's an example of a redmine target.
+[my_redmine]
+service = redmine
+redmine.url = http://redmine.example.org/
+redmine.key = c0c4c014cafebabe
+redmine.add_tags = chiliproject
+
+[activecollab]
+service = activecollab
+activecollab.url = https://ac.example.org/api.php
+activecollab.key = your-api-key
+activecollab.user_id = 15
+activecollab.add_tags = php
+
+[activecollab2]
+service = activecollab2
+activecollab2.url = http://ac.example.org/api.php
+activecollab2.key = your-api-key
+activecollab2.user_id = 15
+activecollab2.projects = 1:first_project, 5:another_project
+
+[my_gmail]
+service = gmail
+gmail.query = label:action OR label:readme
+gmail.login_name = you@example.com
+
+[pivotaltracker]
+service = pivotaltracker
+pivotaltracker.token = your-api-key
+pivotaltracker.version = v5
+pivotaltracker.user_id = 123456
+pivotaltracker.account_ids = first_account_id,second_account_id
+pivotaltracker.only_if_assigned = True
+pivotaltracker.also_unassigned = False
+pivotaltracker.only_if_author = False
+pivotaltracker.import_labels_as_tags = True
+pivotaltracker.label_template = pivotal_{{label}}
+pivotaltracker.import_blockers = True
+pivotaltracker.blocker_template = Description: {{description}} State: {{resolved}}\n
+pivotaltracker.annotation_template = status: {{completed}} - MYDESC {{description}}
+pivotaltracker.exclude_projects = first_project_id,second_project_id
+pivotaltracker.exclude_stories = first_story_id,second_story_id
+pivotaltracker.exclude_tags = wont fix, should fix
+pivotaltracker.query = mywork:1234 -has:label

--- a/tests/config/test_data.py
+++ b/tests/config/test_data.py
@@ -42,13 +42,14 @@ class TestGetDataPath(ConfigTest):
 
     def setUp(self):
         super().setUp()
-        rawconfig = {}
-        rawconfig['general'] = {'targets': ['my_service']}
-        rawconfig['my_service'] = {
-            'service': 'github',
-            'login': 'ralphbean',
-            'token': 'abc123',
-            'username': 'ralphbean',
+        rawconfig = {
+            'general': {'targets': ['my_service']},
+            'my_service': {
+                'service': 'github',
+                'login': 'ralphbean',
+                'token': 'abc123',
+                'username': 'ralphbean',
+            },
         }
         self.config = schema.validate_config(
             rawconfig, 'general', 'configpath')

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -116,12 +116,17 @@ class TestParseFile(LoadTest):
         with self.assertRaises(configparser.MissingSectionHeaderError):
             load.parse_file(config_path)
 
-    def test_ini_prefix_removal(self):
+    def test_ini_options_renamed(self):
+        """
+        Prefixes are removed and log.* are renamed log_* in main section.
+        """
+
         config_path = self.create('.bugwarriorrc')
         with open(config_path, 'w') as fout:
             fout.write(textwrap.dedent("""
                 [general]
                 foo = bar
+                log.level = DEBUG
                 [baz]
                 service = qux
                 qux.optionname
@@ -130,6 +135,9 @@ class TestParseFile(LoadTest):
 
         self.assertIn('optionname', config['baz'])
         self.assertNotIn('prefix.optionname', config['baz'])
+
+        self.assertIn('log_level', config['general'])
+        self.assertNotIn('log.level', config['general'])
 
     def test_ini_missing_prefix(self):
         config_path = self.create('.bugwarriorrc')

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -1,6 +1,7 @@
 import configparser
 import itertools
 import os
+import pathlib
 import textwrap
 from unittest import TestCase
 
@@ -12,6 +13,22 @@ except ImportError:
 from bugwarrior.config import load
 
 from ..base import ConfigTest
+
+
+class ExampleTest(ConfigTest):
+    def setUp(self):
+        self.basedir = pathlib.Path(__file__).parent
+        super().setUp()
+
+    def test_example_bugwarriorrc(self):
+        os.environ['BUGWARRIORRC'] = str(
+            self.basedir / 'example-bugwarriorrc')
+        load.load_config('general', False, False)
+
+    def test_example_bugwarrior_toml(self):
+        os.environ['BUGWARRIORRC'] = str(
+            self.basedir / 'example-bugwarrior.toml')
+        load.load_config('general', False, False)
 
 
 class LoadTest(ConfigTest):

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -1,4 +1,5 @@
 import configparser
+import itertools
 import os
 import textwrap
 from unittest import TestCase
@@ -26,26 +27,39 @@ class LoadTest(ConfigTest):
 
 
 class TestGetConfigPath(LoadTest):
-    def test_default(self):
-        """
-        If it exists, use the file at $XDG_CONFIG_HOME/bugwarrior/bugwarriorrc
-        """
-        rc = self.create('.config/bugwarrior/bugwarriorrc')
-        self.assertEqual(load.get_config_path(), rc)
+    def test_path_precedence(self):
+        # We're going to manually setup and teardown each subTest.
+        self.tearDown()
+
+        config_paths = [  # ordered by precedence
+            '.config/bugwarrior/bugwarriorrc',
+            '.config/bugwarrior/bugwarrior.toml',
+            '.bugwarriorrc',
+            '.bugwarrior.toml',
+        ]
+
+        # https://docs.python.org/3/library/itertools.html#itertools.combinations
+        # > The combination tuples are emitted in lexicographic ordering
+        # > according to the order of the input iterable. So, if the input
+        # > iterable is sorted, the output tuples will be produced in sorted
+        # > order.
+        # So as long as the path list is in the correct order, path1 should have
+        # precedence.
+        for path1, path2 in itertools.combinations(config_paths, 2):
+            with self.subTest(path1=path1, path2=path2):
+                self.setUp()
+                try:
+                    config1 = self.create(path1)
+                    self.create(path2)
+                    self.assertEqual(load.get_config_path(), config1)
+                finally:
+                    self.tearDown()
 
     def test_legacy(self):
         """
         Falls back on .bugwarriorrc if it exists
         """
         rc = self.create('.bugwarriorrc')
-        self.assertEqual(load.get_config_path(), rc)
-
-    def test_xdg_first(self):
-        """
-        If both files above exist, the one in $XDG_CONFIG_HOME takes precedence
-        """
-        self.create('.bugwarriorrc')
-        rc = self.create('.config/bugwarrior/bugwarriorrc')
         self.assertEqual(load.get_config_path(), rc)
 
     def test_no_file(self):
@@ -55,7 +69,7 @@ class TestGetConfigPath(LoadTest):
         """
         self.assertEqual(
             load.get_config_path(),
-            os.path.join(self.tempdir, '.config/bugwarrior/bugwarrior.toml'))
+            os.path.join(self.tempdir, '.config/bugwarrior/bugwarriorrc'))
 
     def test_BUGWARRIORRC(self):
         """

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -58,26 +58,27 @@ class TestConfigList(unittest.TestCase):
 class TestValidation(ConfigTest):
     def setUp(self):
         super().setUp()
-        self.config = {}
-        self.config['general'] = {'targets': ['my_service', 'my_kan', 'my_gitlab']}
-        self.config['my_service'] = {
-            'service': 'github',
-            'login': 'ralph',
-            'username': 'ralph',
-            'token': 'abc123',
-        }
-        self.config['my_kan'] = {
-            'service': 'kanboard',
-            'url': 'https://kanboard.example.org',
-            'username': 'ralph',
-            'password': 'abc123',
-        }
-        self.config['my_gitlab'] = {
-            'service': 'gitlab',
-            'host': 'my-git.org',
-            'login': 'arbitrary_login',
-            'token': 'arbitrary_token',
-            'owned': 'false',
+        self.config = {
+            'general': {'targets': ['my_service', 'my_kan', 'my_gitlab']},
+            'my_service': {
+                'service': 'github',
+                'login': 'ralph',
+                'username': 'ralph',
+                'token': 'abc123',
+            },
+            'my_kan': {
+                'service': 'kanboard',
+                'url': 'https://kanboard.example.org',
+                'username': 'ralph',
+                'password': 'abc123',
+            },
+            'my_gitlab': {
+                'service': 'gitlab',
+                'host': 'my-git.org',
+                'login': 'arbitrary_login',
+                'token': 'arbitrary_token',
+                'owned': 'false',
+            },
         }
 
     def test_valid(self):

--- a/tests/test_activecollab2.py
+++ b/tests/test_activecollab2.py
@@ -15,7 +15,7 @@ class TestActiveCollab2Issue(AbstractServiceTest, ServiceTest):
         'url': 'http://hello',
         'key': 'howdy',
         'user_id': 0,
-        'projects': '1:one, 2:two'
+        'projects': {1: 'one', 2: 'two'},
     }
 
     arbitrary_due_on = (

--- a/tests/test_azuredevops.py
+++ b/tests/test_azuredevops.py
@@ -112,9 +112,10 @@ TEST_ISSUE = {
 class TestAzureDevopsServiceConfig(ConfigTest):
     def setUp(self):
         super().setUp()
-        self.config = {}
-        self.config["general"] = {"targets": ["test_ado"]}
-        self.config["test_ado"] = {"service": "azuredevops"}
+        self.config = {
+            "general": {"targets": ["test_ado"]},
+            "test_ado": {"service": "azuredevops"},
+        }
 
     def test_validate_config_required_fields(self):
         self.config["test_ado"].update({

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -20,9 +20,10 @@ class TestBugzillaServiceConfig(ConfigTest):
 
     def setUp(self):
         super().setUp()
-        self.config = {}
-        self.config['general'] = {'targets': ['mybz']}
-        self.config['mybz'] = {'service': 'bugzilla'}
+        self.config = {
+            'general': {'targets': ['mybz']},
+            'mybz': {'service': 'bugzilla'},
+        }
 
     def test_validate_config_username_password(self):
         self.config['mybz'].update({

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,6 +1,7 @@
 import os
 import logging
-from unittest import mock
+import pathlib
+from unittest import mock, TestCase
 
 from click.testing import CliRunner
 
@@ -185,3 +186,21 @@ class TestPull(ConfigTest):
         self.assertIn('Adding 1 tasks', logs)
         self.assertIn('Updating 0 tasks', logs)
         self.assertIn('Closing 0 tasks', logs)
+
+
+class TestIni2Toml(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.runner = CliRunner()
+
+    def test_bugwarriorrc(self):
+        basedir = pathlib.Path(__file__).parent
+        result = self.runner.invoke(
+            command.cli,
+            args=('ini2toml', str(basedir / 'config/example-bugwarriorrc')))
+
+        self.assertEqual(result.exit_code, 0)
+
+        self.maxDiff = None
+        with open(basedir / 'config/example-bugwarrior.toml', 'r') as f:
+            self.assertEqual(result.stdout, f.read())

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -86,17 +86,18 @@ class TestSynchronize(ConfigTest):
         def get_tasks(tw):
             return remove_non_deterministic_keys(tw.load_tasks())
 
-        self.config = {}
-        self.config['general'] = {
-            'targets': ['my_service'],
-            'taskrc': self.taskrc,
-            'static_fields': 'project, priority',
-        }
-        self.config['my_service'] = {
-            'service': 'github',
-            'login': 'ralphbean',
-            'username': 'ralphbean',
-            'token': 'abc123',
+        self.config = {
+            'general': {
+                'targets': ['my_service'],
+                'taskrc': self.taskrc,
+                'static_fields': ['project', 'priority'],
+            },
+            'my_service': {
+                'service': 'github',
+                'login': 'ralphbean',
+                'username': 'ralphbean',
+                'token': 'abc123',
+            },
         }
         bwconfig = self.validate()
 
@@ -206,13 +207,14 @@ class TestSynchronize(ConfigTest):
 
 class TestUDAs(ConfigTest):
     def test_udas(self):
-        self.config = {}
-        self.config['general'] = {'targets': ['my_service']}
-        self.config['my_service'] = {
-            'service': 'github',
-            'login': 'ralphbean',
-            'username': 'ralphbean',
-            'token': 'abc123',
+        self.config = {
+            'general': {'targets': ['my_service']},
+            'my_service': {
+                'service': 'github',
+                'login': 'ralphbean',
+                'username': 'ralphbean',
+                'token': 'abc123',
+            },
         }
 
         conf = self.validate()

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -74,18 +74,19 @@ class TestNextcloudDeckIssue(AbstractServiceTest, ServiceTest):
 
     def setUp(self):
         super().setUp()
-        self.config = {}
-        self.config['general'] = {
-            'targets': ['deck'],
-            # would otherwise cut the title short
-            'description_length': '45'
-        }
-        self.config['deck'] = {
-            'service': 'deck',
-            'base_uri': 'http://localhost:8080',
-            'username': 'testuser',
-            'password': 'testpassword',
-            'import_labels_as_tags': 'true',
+        self.config = {
+            'general': {
+                'targets': ['deck'],
+                # would otherwise cut the title short
+                'description_length': '45'
+            },
+            'deck': {
+                'service': 'deck',
+                'base_uri': 'http://localhost:8080',
+                'username': 'testuser',
+                'password': 'testpassword',
+                'import_labels_as_tags': 'true',
+            },
         }
 
         self.data = TestData()

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -9,10 +9,6 @@ import subprocess
 import tempfile
 import unittest
 
-from bugwarrior import config
-
-from .base import ConfigTest
-
 DOCS_PATH = pathlib.Path(__file__).parent / '../bugwarrior/docs'
 
 try:
@@ -82,10 +78,3 @@ class DocsTest(unittest.TestCase):
                 documented_services.add(re.sub(r'\.rst$', '', p))
 
         self.assertEqual(registered_services, documented_services)
-
-
-class ExampleBugwarriorrcTest(ConfigTest):
-    def test_example_bugwarriorrc(self):
-        os.environ['BUGWARRIORRC'] = os.path.join(
-            DOCS_PATH, 'example-bugwarriorrc')
-        config.load_config('general', False, False)

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -478,15 +478,16 @@ class TestGitlabService(ConfigTest):
 
     def setUp(self):
         super().setUp()
-        self.config = {}
-        self.config['general'] = {'targets': ['myservice']}
-        self.config['myservice'] = {
-            'service': 'gitlab',
-            'login': 'foobar',
-            'token': 'XXXXXX',
-            'host': 'gitlab.com',
-            'also_unassigned': 'true',
-            'owned': 'true',
+        self.config = {
+            'general': {'targets': ['myservice']},
+            'myservice': {
+                'service': 'gitlab',
+                'login': 'foobar',
+                'token': 'XXXXXX',
+                'host': 'gitlab.com',
+                'also_unassigned': 'true',
+                'owned': 'true',
+            },
         }
 
     @property

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -26,9 +26,10 @@ class TestGmailService(ConfigTest):
 
     def setUp(self):
         super().setUp()
-        self.config = {}
-        self.config['general'] = {'targets': ['myservice']}
-        self.config['myservice'] = {'service': 'gmail'}
+        self.config = {
+            'general': {'targets': ['myservice']},
+            'myservice': {'service': 'gmail'},
+        }
 
         mock_data = mock.Mock()
         mock_data.path = self.tempdir

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -26,17 +26,18 @@ class testJiraService(ConfigTest):
 
     def setUp(self):
         super().setUp()
-        self.config = {}
-        self.config['general'] = {
-            'targets': ['myjira'],
-            'interactive': 'false',
-        }
-        self.config['myjira'] = {
-            'service': 'jira',
-            'base_uri': 'https://example.com',
-            'username': 'milou',
-            'password': 't0ps3cr3t',
-            'extra_fields': 'jiraextra1:customfield_10000,jiraextra2:namedfield.valueinside',
+        self.config = {
+            'general': {
+                'targets': ['myjira'],
+                'interactive': 'false',
+            },
+            'myjira': {
+                'service': 'jira',
+                'base_uri': 'https://example.com',
+                'username': 'milou',
+                'password': 't0ps3cr3t',
+                'extra_fields': 'jiraextra1:customfield_10000,jiraextra2:namedfield.valueinside',
+            },
         }
 
     def test_body_length_no_limit(self):

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -36,7 +36,8 @@ class testJiraService(ConfigTest):
                 'base_uri': 'https://example.com',
                 'username': 'milou',
                 'password': 't0ps3cr3t',
-                'extra_fields': 'jiraextra1:customfield_10000,jiraextra2:namedfield.valueinside',
+                'extra_fields': [
+                    'jiraextra1:customfield_10000', 'jiraextra2:namedfield.valueinside'],
             },
         }
 
@@ -67,7 +68,7 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
         'username': 'one',
         'base_uri': 'https://two.org',
         'password': 'three',
-        'extra_fields': 'jiraextra1:customfield_10000,jiraextra2:namedfield.valueinside',
+        'extra_fields': ['jiraextra1:customfield_10000', 'jiraextra2:namedfield.valueinside'],
     }
 
     arbitrary_estimation = 3600
@@ -117,7 +118,7 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
 
     def get_extra_fields(self):
         return JiraExtraFields.validate(
-            'jiraextra1:customfield_10000,jiraextra2:namedfield.valueinside')
+            ['jiraextra1:customfield_10000', 'jiraextra2:namedfield.valueinside'])
 
     def test_to_taskwarrior(self):
         arbitrary_url = 'http://one'

--- a/tests/test_kanboard.py
+++ b/tests/test_kanboard.py
@@ -11,9 +11,10 @@ from .base import AbstractServiceTest, ConfigTest, ServiceTest
 class TestKanboardServiceConfig(ConfigTest):
     def setUp(self):
         super().setUp()
-        self.config = {}
-        self.config["general"] = {"targets": ["kb"]}
-        self.config["kb"] = {"service": "kanboard"}
+        self.config = {
+            "general": {"targets": ["kb"]},
+            "kb": {"service": "kanboard"},
+        }
 
     def test_validate_config_required_fields(self):
         self.config["kb"].update({

--- a/tests/test_pivotaltracker.py
+++ b/tests/test_pivotaltracker.py
@@ -177,9 +177,10 @@ class TestPivotalTrackerServiceConfig(ConfigTest):
 
     def setUp(self):
         super().setUp()
-        self.config = {}
-        self.config['general'] = {'targets': ['pivotal']}
-        self.config['pivotal'] = {'service': 'pivotaltracker'}
+        self.config = {
+            'general': {'targets': ['pivotal']},
+            'pivotal': {'service': 'pivotaltracker'},
+        }
 
     def test_validate_config(self):
         self.config['pivotal'].update({

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -50,12 +50,13 @@ class ServiceBase(ConfigTest):
 
     def setUp(self):
         super().setUp()
-        self.config = {}
-        self.config['general'] = {
-            'targets': ['test'],
-            'interactive': 'false',
+        self.config = {
+            'general': {
+                'targets': ['test'],
+                'interactive': 'false',
+            },
+            'test': {'service': 'test'},
         }
-        self.config['test'] = {'service': 'test'}
 
     def makeService(self):
         with unittest.mock.patch('bugwarrior.config.schema.get_service',

--- a/tests/test_trello.py
+++ b/tests/test_trello.py
@@ -65,12 +65,13 @@ class TestTrelloService(ConfigTest):
 
     def setUp(self):
         super().setUp()
-        self.config = {}
-        self.config['general'] = {'targets': ['mytrello']}
-        self.config['mytrello'] = {
-            'service': 'trello',
-            'api_key': 'XXXX',
-            'token': 'YYYY',
+        self.config = {
+            'general': {'targets': ['mytrello']},
+            'mytrello': {
+                'service': 'trello',
+                'api_key': 'XXXX',
+                'token': 'YYYY',
+            },
         }
         responses.add(responses.GET,
                       'https://api.trello.com/1/lists/L15T/cards/open',

--- a/tests/test_youtrak.py
+++ b/tests/test_youtrak.py
@@ -8,12 +8,13 @@ from .base import ConfigTest, ServiceTest, AbstractServiceTest
 class TestYoutrackService(ConfigTest):
     def setUp(self):
         super().setUp()
-        self.config = {}
-        self.config['general'] = {'targets': ['myservice']}
-        self.config['myservice'] = {
-            'service': 'youtrack',
-            'login': 'foobar',
-            'password': 'XXXXXX',
+        self.config = {
+            'general': {'targets': ['myservice']},
+            'myservice': {
+                'service': 'youtrack',
+                'login': 'foobar',
+                'password': 'XXXXXX',
+            },
         }
 
     def test_get_keyring_service(self):


### PR DESCRIPTION
<s>*Based on #984.*</s>

This is a more conservative rewrite of #973 which aims to provide first-class support for both ini and toml configuration.

The biggest user impact is probably documentation, which now includes tabbed code blocks showing both ini and toml format. It can be viewed here: <https://bugwarrior-docs.readthedocs.io/en/toml2/index.html>. (Note: If I make changes to this branch I have to push separately to this remote to keep this rendering up to date.)