### PR TITLE
config: Convert configparser to dictionary prior to validation

### DIFF
--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -161,8 +161,6 @@ class SchemaBase(pydantic.BaseSettings):
         # Allow extra top-level sections so all targets don't have to be selected.
         extra = 'ignore'
 
-    DEFAULT: dict  # configparser feature
-
     hooks: Hooks = Hooks()
     notifications: Notifications = Notifications()
 
@@ -191,16 +189,6 @@ class ValidationErrorEnhancedMessages(list):
     def display_error(self, e, error, model):
         if e['type'] == 'value_error.extra':
             e['msg'] = 'unrecognized option'
-            if len(e['loc']) == 2:  # Error is in option
-                option = e['loc'][-1].split('.').pop()
-                try:
-                    scoped = f"{model._PREFIX}.{option}"
-                except AttributeError:  # not a service model
-                    pass
-                else:
-                    if scoped in model.schema()['properties'].keys():
-                        e['msg'] = (f"expected prefix '{model._PREFIX}': "
-                                    f"did you mean '{scoped}'?")
         return f'{self.display_error_loc(e)}  <- {e["msg"]}\n'
 
     def flatten(self, err, loc=None):
@@ -234,7 +222,7 @@ def raise_validation_error(msg, config_path, no_errors=1):
     sys.exit(1)
 
 
-def validate_config(config, main_section, config_path):
+def validate_config(config: dict, main_section: str, config_path: str) -> dict:
     # Pre-validate the minimum requirements to build our pydantic models.
     try:
         main = config[main_section]
@@ -286,32 +274,9 @@ _ServiceConfig = pydantic.create_model(
 )
 
 
-class ServiceConfigMetaclass(pydantic.main.ModelMetaclass):
-    """
-    Dynamically insert alias_generator with prefix.
-
-    Pydantic parses the schema in ModelMetaclass so we have to insert the
-    alias prior to that.
-    """
-    def __new__(mcs, name, bases, namespace, prefix, **kwargs):
-        if prefix is not None:
-
-            class PydanticServiceConfig(PydanticConfig):
-                @staticmethod
-                def alias_generator(string: str) -> str:
-                    """ Add prefixes. """
-                    return (string if string == 'service'
-                            else f'{prefix}.{string}')
-
-            namespace['Config'] = PydanticServiceConfig
-        cls = super().__new__(mcs, name, bases, namespace, **kwargs)
-        cls._PREFIX = prefix
-        return cls
-
-
-class ServiceConfig(_ServiceConfig,  # type: ignore  # (dynamic base class)
-                    metaclass=ServiceConfigMetaclass, prefix=None):
+class ServiceConfig(_ServiceConfig):  # type: ignore  # (dynamic base class)
     """ Base class for service configurations. """
+    Config = PydanticConfig
 
     # Optional fields shared by all services.
     only_if_assigned: str = ''

--- a/bugwarrior/docs/contributing/new-service.rst
+++ b/bugwarrior/docs/contributing/new-service.rst
@@ -56,7 +56,7 @@ Now define an initial configuration schema as follows. Don't worry, we're about 
 
 .. code:: python
 
-  class GitbugConfig(config.ServiceConfig, prefix='gitbug'):
+  class GitbugConfig(config.ServiceConfig):
       service: typing_extensions.Literal['gitbug']
 
       path: pathlib.Path
@@ -73,8 +73,6 @@ The ``service`` attribute is how bugwarrior will know to assign a given section 
 
   [my_gitbug]
   service = gitbug
-
-The ``prefix`` is the beginning of the configuration field names that users will put in this section of their ``bugwarriorrc`` (e.g., ``gitbug.host = http://127.0.0.1:12345``).
 
 The ``path`` is the only particular detail required to access our local git-bug instance. You'll likely need additional details such as a username and token to authenticate to the service. Look at how you accessed the API in step 1 and ask yourself which components need to be configurable.
 
@@ -246,7 +244,7 @@ Create a test file and implement at least the minimal service tests by inheritin
   class TestGitBugIssue(AbstractServiceTest, ServiceTest):
       SERVICE_CONFIG = {
           'service': 'gitbug',
-          'gitbug.path': '/dev/null',
+          'path': '/dev/null',
       }
 
       def setUp(self):

--- a/bugwarrior/services/activecollab.py
+++ b/bugwarrior/services/activecollab.py
@@ -10,7 +10,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class ActiveCollabConfig(config.ServiceConfig, prefix='activecollab'):
+class ActiveCollabConfig(config.ServiceConfig):
     service: typing_extensions.Literal['activecollab']
     url: config.StrippedTrailingSlashUrl
     key: str

--- a/bugwarrior/services/activecollab2.py
+++ b/bugwarrior/services/activecollab2.py
@@ -28,7 +28,7 @@ class ActiveCollabProjects(frozenset):
         return projects
 
 
-class ActiveCollab2Config(config.ServiceConfig, prefix='activecollab2'):
+class ActiveCollab2Config(config.ServiceConfig):
     service: typing_extensions.Literal['activecollab2']
     url: config.StrippedTrailingSlashUrl
     key: str

--- a/bugwarrior/services/azuredevops.py
+++ b/bugwarrior/services/azuredevops.py
@@ -37,7 +37,7 @@ class EscapedStr(str):
         return quote(value)
 
 
-class AzureDevopsConfig(config.ServiceConfig, prefix='ado'):
+class AzureDevopsConfig(config.ServiceConfig):
     service: typing_extensions.Literal['azuredevops']
     PAT: PersonalAccessToken
     project: EscapedStr

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -11,7 +11,7 @@ from bugwarrior.services import IssueService, Issue, ServiceClient
 log = logging.getLogger(__name__)
 
 
-class BitbucketConfig(config.ServiceConfig, prefix='bitbucket'):
+class BitbucketConfig(config.ServiceConfig):
     _DEPRECATE_FILTER_MERGE_REQUESTS = True
     filter_merge_requests: typing.Union[bool, typing_extensions.Literal['Undefined']] = 'Undefined'
 
@@ -35,8 +35,8 @@ class BitbucketConfig(config.ServiceConfig, prefix='bitbucket'):
         if values['login'] != 'Undefined' or values['password'] != 'Undefined':
             log.warning(
                 'Bitbucket has disabled password authentication and, as such, '
-                'the bitbucket.login and bitbucket.password options are '
-                'deprecated and should be removed from your bugwarriorrc.')
+                'the "login" and "password" options are deprecated and should '
+                'be removed from your configuration file.')
         return values
 
 

--- a/bugwarrior/services/bts.py
+++ b/bugwarrior/services/bts.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 UDD_BUGS_SEARCH = "https://udd.debian.org/bugs/"
 
 
-class BTSConfig(config.ServiceConfig, prefix='bts'):
+class BTSConfig(config.ServiceConfig):
     service: typing_extensions.Literal['bts']
 
     email: pydantic.EmailStr = pydantic.EmailStr('')
@@ -28,13 +28,13 @@ class BTSConfig(config.ServiceConfig, prefix='bts'):
     def require_email_or_packages(cls, values):
         if not values['email'] and not values['packages']:
             raise ValueError(
-                'section requires one of:\nbts.email\nbts.packages')
+                'section requires one of:\n    email\n    packages')
         return values
 
     @pydantic.root_validator
     def udd_needs_email(cls, values):
         if values['udd'] and not values['email']:
-            raise ValueError("no 'bts.email' but UDD search was requested")
+            raise ValueError("no 'email' but UDD search was requested")
         return values
 
 

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -32,7 +32,7 @@ class OptionalSchemeUrl(pydantic.AnyUrl):
         return super().validate(value.rstrip('/'), field, config)
 
 
-class BugzillaConfig(config.ServiceConfig, prefix='bugzilla'):
+class BugzillaConfig(config.ServiceConfig):
     service: typing_extensions.Literal['bugzilla']
     username: str
     base_uri: OptionalSchemeUrl

--- a/bugwarrior/services/deck.py
+++ b/bugwarrior/services/deck.py
@@ -11,7 +11,7 @@ from bugwarrior.services import IssueService, Issue, ServiceClient
 log = logging.getLogger(__name__)
 
 
-class NextcloudDeckConfig(config.ServiceConfig, prefix='deck'):
+class NextcloudDeckConfig(config.ServiceConfig):
     service: typing_extensions.Literal['deck']
     base_uri: config.StrippedTrailingSlashUrl
     username: str

--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -8,7 +8,7 @@ from bugwarrior import config
 from bugwarrior.services import IssueService, Issue, ServiceClient
 
 
-class GerritConfig(config.ServiceConfig, prefix='gerrit'):
+class GerritConfig(config.ServiceConfig):
     service: typing_extensions.Literal['gerrit']
     base_uri: config.StrippedTrailingSlashUrl
     username: str

--- a/bugwarrior/services/gitbug.py
+++ b/bugwarrior/services/gitbug.py
@@ -14,7 +14,7 @@ from bugwarrior.services import IssueService, Issue, ServiceClient
 log = logging.getLogger(__name__)
 
 
-class GitBugConfig(config.ServiceConfig, prefix='gitbug'):
+class GitBugConfig(config.ServiceConfig):
     service: typing_extensions.Literal['gitbug']
 
     path: pathlib.Path

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -13,7 +13,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class GithubConfig(config.ServiceConfig, prefix='github'):
+class GithubConfig(config.ServiceConfig):
     password: str = 'Deprecated'
 
     # strictly required
@@ -46,14 +46,14 @@ class GithubConfig(config.ServiceConfig, prefix='github'):
         if values['password'] != 'Deprecated':
             log.warning(
                 'Basic auth is no longer supported. Please remove '
-                'github.password in favor of github.token.')
+                '"password" in favor of "token".')
         return values
 
     @pydantic.root_validator
     def require_username_or_query(cls, values):
         if not values['username'] and not values['query']:
             raise ValueError(
-                'section requires one of:\ngithub.username\ngithub.query')
+                'section requires one of:\n    username\n    query')
         return values
 
     @pydantic.root_validator
@@ -63,10 +63,10 @@ class GithubConfig(config.ServiceConfig, prefix='github'):
             parsed_url = urllib.parse.urlparse(url)
             if parsed_url.netloc != values['host']:
                 raise ValueError(
-                    f'github.issue_urls: {url} inconsistent with host {values["host"]}')
+                    f'issue_urls: {url} inconsistent with host {values["host"]}')
             if not re.match(r'^/.*/.*/(issues|pull)/[0-9]*$', parsed_url.path):
                 raise ValueError(
-                    f'github.issue_urls: {parsed_url.path} is not a valid issue path')
+                    f'issue_urls: {parsed_url.path} is not a valid issue path')
             issue_url_paths.append(parsed_url.path)
         values['issue_urls'] = issue_url_paths
         return values

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 DefaultPriority = typing_extensions.Literal['', 'L', 'M', 'H', 'unassigned']
 
 
-class GitlabConfig(config.ServiceConfig, prefix='gitlab'):
+class GitlabConfig(config.ServiceConfig):
     _DEPRECATE_FILTER_MERGE_REQUESTS = True
     filter_merge_requests: typing.Union[bool, typing_extensions.Literal['Undefined']] = 'Undefined'
 
@@ -51,7 +51,7 @@ class GitlabConfig(config.ServiceConfig, prefix='gitlab'):
         """ Add a default namespace to a repository name.  If the name already
         contains a namespace, it will be returned unchanged:
             e.g. "foo/bar" → "foo/bar"
-        otherwise, the loggin will be prepended as namespace:
+        otherwise, the login will be prepended as namespace:
             e.g. "bar" → "<login>/bar"
         """
         for repolist in ['include_repos', 'exclude_repos']:
@@ -93,7 +93,7 @@ class GitlabConfig(config.ServiceConfig, prefix='gitlab'):
                 )):
             raise ValueError(
                 "You must set at least one of the configuration options "
-                "to filter repositories (e.g., 'gitlab.owned') because there "
+                "to filter repositories (e.g., 'owned') because there "
                 "there are too many on gitlab.com to fetch them all.")
         return values
 

--- a/bugwarrior/services/gmail.py
+++ b/bugwarrior/services/gmail.py
@@ -17,7 +17,7 @@ from bugwarrior.services import IssueService, Issue
 log = logging.getLogger(__name__)
 
 
-class GmailConfig(config.ServiceConfig, prefix='gmail'):
+class GmailConfig(config.ServiceConfig):
     service: typing_extensions.Literal['gmail']
 
     client_secret_path: config.ExpandedPath = config.ExpandedPath(

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -73,7 +73,7 @@ class JiraExtraField:
         return value
 
 
-class JiraConfig(config.ServiceConfig, prefix='jira'):
+class JiraConfig(config.ServiceConfig):
     service: typing_extensions.Literal['jira']
     base_uri: pydantic.AnyUrl
     username: str
@@ -96,7 +96,7 @@ class JiraConfig(config.ServiceConfig, prefix='jira'):
         if ((values['password'] and values['PAT'])
                 or not (values['password'] or values['PAT'])):
             raise ValueError(
-                'section requires one of (not both):\njira.password\njira.PAT')
+                'section requires one of (not both):\n    password\n    PAT')
         return values
 
 

--- a/bugwarrior/services/kanboard.py
+++ b/bugwarrior/services/kanboard.py
@@ -13,7 +13,7 @@ from bugwarrior.services import Issue, IssueService
 log = logging.getLogger(__name__)
 
 
-class KanboardConfig(config.ServiceConfig, prefix='kanboard'):
+class KanboardConfig(config.ServiceConfig):
     service: typing_extensions.Literal['kanboard']
     url: config.StrippedTrailingSlashUrl
     username: str

--- a/bugwarrior/services/pagure.py
+++ b/bugwarrior/services/pagure.py
@@ -12,7 +12,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class PagureConfig(config.ServiceConfig, prefix='pagure'):
+class PagureConfig(config.ServiceConfig):
     # strictly required
     service: typing_extensions.Literal['pagure']
     base_url: config.StrippedTrailingSlashUrl
@@ -31,7 +31,7 @@ class PagureConfig(config.ServiceConfig, prefix='pagure'):
     def require_tag_or_repo(cls, values):
         if not values['tag'] and not values['repo']:
             raise ValueError(
-                'section requires one of:\npagure.tag\npagure.repo')
+                'section requires one of:\n    tag\n    repo')
         return values
 
 

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -11,7 +11,7 @@ from bugwarrior.services import IssueService, Issue
 log = logging.getLogger(__name__)
 
 
-class PhabricatorConfig(config.ServiceConfig, prefix='phabricator'):
+class PhabricatorConfig(config.ServiceConfig):
     service: typing_extensions.Literal['phabricator']
 
     user_phids: config.ConfigList = config.ConfigList([])

--- a/bugwarrior/services/pivotaltracker.py
+++ b/bugwarrior/services/pivotaltracker.py
@@ -12,7 +12,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class PivotalTrackerConfig(config.ServiceConfig, prefix='pivotaltracker'):
+class PivotalTrackerConfig(config.ServiceConfig):
     service: typing_extensions.Literal['pivotaltracker']
     user_id: int
     account_ids: config.ConfigList

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -11,7 +11,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class RedMineConfig(config.ServiceConfig, prefix='redmine'):
+class RedMineConfig(config.ServiceConfig):
     _DEPRECATE_PROJECT_NAME = True
     project_name: str = ''
 

--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -9,7 +9,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class TaigaConfig(config.ServiceConfig, prefix='taiga'):
+class TaigaConfig(config.ServiceConfig):
     service: typing_extensions.Literal['taiga']
     base_uri: config.StrippedTrailingSlashUrl
     auth_token: str

--- a/bugwarrior/services/teamlab.py
+++ b/bugwarrior/services/teamlab.py
@@ -8,7 +8,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class TeamLabConfig(config.ServiceConfig, prefix='teamlab'):
+class TeamLabConfig(config.ServiceConfig):
     _DEPRECATE_PROJECT_NAME = True
     project_name: str = ''
 

--- a/bugwarrior/services/teamwork_projects.py
+++ b/bugwarrior/services/teamwork_projects.py
@@ -8,7 +8,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class TeamworkConfig(config.ServiceConfig, prefix='teamwork_projects'):
+class TeamworkConfig(config.ServiceConfig):
     service: typing_extensions.Literal['teamwork_projects']
     host: config.StrippedTrailingSlashUrl
     token: str

--- a/bugwarrior/services/trac.py
+++ b/bugwarrior/services/trac.py
@@ -13,7 +13,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class TracConfig(config.ServiceConfig, prefix='trac'):
+class TracConfig(config.ServiceConfig):
     service: typing_extensions.Literal['trac']
     base_uri: config.NoSchemeUrl
 

--- a/bugwarrior/services/trello.py
+++ b/bugwarrior/services/trello.py
@@ -12,7 +12,7 @@ from bugwarrior.services import IssueService, Issue, ServiceClient
 from bugwarrior import config
 
 
-class TrelloConfig(config.ServiceConfig, prefix='trello'):
+class TrelloConfig(config.ServiceConfig):
     service: typing_extensions.Literal['trello']
     api_key: str
     token: str

--- a/bugwarrior/services/versionone.py
+++ b/bugwarrior/services/versionone.py
@@ -8,7 +8,7 @@ from bugwarrior import config
 from bugwarrior.services import IssueService, Issue
 
 
-class VersionOneConfig(config.ServiceConfig, prefix='versionone'):
+class VersionOneConfig(config.ServiceConfig):
     _DEPRECATE_PROJECT_NAME = True
     project_name: str = ''
 

--- a/bugwarrior/services/youtrack.py
+++ b/bugwarrior/services/youtrack.py
@@ -11,7 +11,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class YoutrackConfig(config.ServiceConfig, prefix='youtrack'):
+class YoutrackConfig(config.ServiceConfig):
     service: typing_extensions.Literal['youtrack']
     host: config.NoSchemeUrl
     login: str

--- a/tests/base.py
+++ b/tests/base.py
@@ -100,7 +100,7 @@ class ServiceTest(ConfigTest):
         config_overrides=None, general_overrides=None
     ):
         options = {
-            'general': {**self.GENERAL_CONFIG, 'targets': section},
+            'general': {**self.GENERAL_CONFIG, 'targets': [section]},
             section: self.SERVICE_CONFIG.copy(),
         }
         if config_overrides:

--- a/tests/config/test_data.py
+++ b/tests/config/test_data.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-from bugwarrior.config import data, load, schema
+from bugwarrior.config import data, schema
 
 from ..base import ConfigTest
 
@@ -42,13 +42,13 @@ class TestGetDataPath(ConfigTest):
 
     def setUp(self):
         super().setUp()
-        rawconfig = load.BugwarriorConfigParser()
-        rawconfig['general'] = {'targets': 'my_service'}
+        rawconfig = {}
+        rawconfig['general'] = {'targets': ['my_service']}
         rawconfig['my_service'] = {
             'service': 'github',
-            'github.login': 'ralphbean',
-            'github.token': 'abc123',
-            'github.username': 'ralphbean',
+            'login': 'ralphbean',
+            'token': 'abc123',
+            'username': 'ralphbean',
         }
         self.config = schema.validate_config(
             rawconfig, 'general', 'configpath')

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -1,4 +1,6 @@
+import configparser
 import os
+import textwrap
 from unittest import TestCase
 
 from bugwarrior.config import load
@@ -6,8 +8,7 @@ from bugwarrior.config import load
 from ..base import ConfigTest
 
 
-class TestGetConfigPath(ConfigTest):
-
+class LoadTest(ConfigTest):
     def create(self, path):
         """
         Create an empty file in the temporary directory, return the full path.
@@ -18,6 +19,8 @@ class TestGetConfigPath(ConfigTest):
         open(fpath, 'a').close()
         return fpath
 
+
+class TestGetConfigPath(LoadTest):
     def test_default(self):
         """
         If it exists, use the file at $XDG_CONFIG_HOME/bugwarrior/bugwarriorrc
@@ -62,7 +65,7 @@ class TestGetConfigPath(ConfigTest):
 
     def test_BUGWARRIORRC_empty(self):
         """
-        If $BUGWARRIORRC is set but emty, it is not used and the default file
+        If $BUGWARRIORRC is set but empty, it is not used and the default file
         is used instead.
         """
         os.environ['BUGWARRIORRC'] = ''
@@ -88,3 +91,70 @@ class TestBugwarriorConfigParser(TestCase):
     def test_getint_valueerror(self):
         with self.assertRaises(ValueError):
             self.config.getint('general', 'somechar')
+
+
+class TestParseFile(LoadTest):
+    def test_ini(self):
+        config_path = self.create('.bugwarriorrc')
+        with open(config_path, 'w') as fout:
+            fout.write(textwrap.dedent("""
+                [general]
+                foo = bar
+            """))
+        config = load.parse_file(config_path)
+
+        self.assertEqual(config, {'general': {'foo': 'bar'}})
+
+    def test_ini_invalid(self):
+        config_path = self.create('.bugwarriorrc')
+        with open(config_path, 'w') as fout:
+            fout.write(textwrap.dedent("""
+                [general
+                foo = bar
+            """))
+
+        with self.assertRaises(configparser.MissingSectionHeaderError):
+            load.parse_file(config_path)
+
+    def test_ini_prefix_removal(self):
+        config_path = self.create('.bugwarriorrc')
+        with open(config_path, 'w') as fout:
+            fout.write(textwrap.dedent("""
+                [general]
+                foo = bar
+                [baz]
+                service = qux
+                qux.optionname
+            """))
+        config = load.parse_file(config_path)
+
+        self.assertIn('optionname', config['baz'])
+        self.assertNotIn('prefix.optionname', config['baz'])
+
+    def test_ini_missing_prefix(self):
+        config_path = self.create('.bugwarriorrc')
+        with open(config_path, 'w') as fout:
+            fout.write(textwrap.dedent("""
+                [general]
+                foo = bar
+                [baz]
+                service = qux
+                optionname
+            """))
+
+        with self.assertRaises(SystemExit):
+            load.parse_file(config_path)
+
+    def test_ini_wrong_prefix(self):
+        config_path = self.create('.bugwarriorrc')
+        with open(config_path, 'w') as fout:
+            fout.write(textwrap.dedent("""
+                [general]
+                foo = bar
+                [baz]
+                service = qux
+                wrong.optionname
+            """))
+
+        with self.assertRaises(SystemExit):
+            load.parse_file(config_path)

--- a/tests/test_activecollab.py
+++ b/tests/test_activecollab.py
@@ -30,9 +30,9 @@ class FakeActiveCollabLib:
 class TestActiveCollabIssues(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
         'service': 'activecollab',
-        'activecollab.url': 'https://hello',
-        'activecollab.key': 'howdy',
-        'activecollab.user_id': '2',
+        'url': 'https://hello',
+        'key': 'howdy',
+        'user_id': '2',
     }
 
     arbitrary_due_on = (

--- a/tests/test_activecollab2.py
+++ b/tests/test_activecollab2.py
@@ -12,10 +12,10 @@ from .base import ServiceTest, AbstractServiceTest
 class TestActiveCollab2Issue(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
         'service': 'activecollab2',
-        'activecollab2.url': 'http://hello',
-        'activecollab2.key': 'howdy',
-        'activecollab2.user_id': 0,
-        'activecollab2.projects': '1:one, 2:two'
+        'url': 'http://hello',
+        'key': 'howdy',
+        'user_id': 0,
+        'projects': '1:one, 2:two'
     }
 
     arbitrary_due_on = (
@@ -37,7 +37,7 @@ class TestActiveCollab2Issue(AbstractServiceTest, ServiceTest):
         'body': 'Ticket Body',
         'name': 'Anonymous',
         'assignees': [
-            {'user_id': SERVICE_CONFIG['activecollab2.user_id'],
+            {'user_id': SERVICE_CONFIG['user_id'],
              'is_owner': True}
         ],
         'description': 'Further detail.',

--- a/tests/test_azuredevops.py
+++ b/tests/test_azuredevops.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 from dateutil.tz.tz import tzutc
 
-from bugwarrior.config.load import BugwarriorConfigParser
 from bugwarrior.services.azuredevops import (
     AzureDevopsService,
     striphtml,
@@ -113,52 +112,52 @@ TEST_ISSUE = {
 class TestAzureDevopsServiceConfig(ConfigTest):
     def setUp(self):
         super().setUp()
-        self.config = BugwarriorConfigParser()
-        self.config["general"] = {"targets": "test_ado"}
+        self.config = {}
+        self.config["general"] = {"targets": ["test_ado"]}
         self.config["test_ado"] = {"service": "azuredevops"}
 
     def test_validate_config_required_fields(self):
         self.config["test_ado"].update({
-            "ado.organization": "test_organization",
-            "ado.project": "test_project",
-            "ado.PAT": "myPAT",
+            "organization": "test_organization",
+            "project": "test_project",
+            "PAT": "myPAT",
         })
         self.validate()
 
     def test_validate_config_no_organization(self):
         self.config["test_ado"].update({
-            "ado.project": "test_project",
-            "ado.PAT": "myPAT",
+            "project": "test_project",
+            "PAT": "myPAT",
         })
 
         self.assertValidationError(
-            '[test_ado]\nado.organization  <- field required')
+            '[test_ado]\norganization  <- field required')
 
     def test_validate_config_no_project(self):
         self.config["test_ado"].update({
-            "ado.organization": "http://one.com/",
-            "ado.PAT": "myPAT",
+            "organization": "http://one.com/",
+            "PAT": "myPAT",
         })
 
         self.assertValidationError(
-            '[test_ado]\nado.project  <- field required')
+            '[test_ado]\nproject  <- field required')
 
     def test_validate_config_no_PAT(self):
         self.config["test_ado"].update({
-            "ado.organization": "http://one.com/",
-            "ado.project": "test_project",
+            "organization": "http://one.com/",
+            "project": "test_project",
         })
 
         self.assertValidationError(
-            '[test_ado]\nado.PAT  <- field required')
+            '[test_ado]\nPAT  <- field required')
 
 
 class TestAzureDevopsService(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
         "service": "azuredevops",
-        "ado.organization": "test_organization",
-        "ado.project": "test_project",
-        "ado.PAT": "myPAT",
+        "organization": "test_organization",
+        "project": "test_project",
+        "PAT": "myPAT",
     }
 
     @property
@@ -253,6 +252,6 @@ class TestAzureDevopsService(AbstractServiceTest, ServiceTest):
             "description": '(bw)Impediment#1 - Example Title .. https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_workitems/edit/1',  # noqa: E501
             "tags": []
         }
-        service = self.get_service(config_overrides={'ado.wiql_filter': 'something'})
+        service = self.get_service(config_overrides={'wiql_filter': 'something'})
         issue = next(service.issues())
         self.assertEqual(issue.get_taskwarrior_record(), expected)

--- a/tests/test_bitbucket.py
+++ b/tests/test_bitbucket.py
@@ -8,9 +8,9 @@ from .base import ServiceTest, AbstractServiceTest
 class TestBitbucketIssue(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
         'service': 'bitbucket',
-        'bitbucket.username': 'somename',
-        'bitbucket.key': 'something',
-        'bitbucket.secret': 'something else',
+        'username': 'somename',
+        'key': 'something',
+        'secret': 'something else',
     }
 
     @responses.activate

--- a/tests/test_bts.py
+++ b/tests/test_bts.py
@@ -32,8 +32,8 @@ class TestBTSService(AbstractServiceTest, ServiceTest):
 
     SERVICE_CONFIG = {
         'service': 'bts',
-        'bts.email': 'irl@debian.org',
-        'bts.packages': 'bugwarrior',
+        'email': 'irl@debian.org',
+        'packages': 'bugwarrior',
     }
 
     def setUp(self):

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -2,7 +2,6 @@ import datetime
 from unittest import mock
 from collections import namedtuple
 
-from bugwarrior.config.load import BugwarriorConfigParser
 from bugwarrior.services.bz import BugzillaService
 
 from .base import ConfigTest, ServiceTest, AbstractServiceTest
@@ -21,15 +20,15 @@ class TestBugzillaServiceConfig(ConfigTest):
 
     def setUp(self):
         super().setUp()
-        self.config = BugwarriorConfigParser()
-        self.config['general'] = {'targets': 'mybz'}
+        self.config = {}
+        self.config['general'] = {'targets': ['mybz']}
         self.config['mybz'] = {'service': 'bugzilla'}
 
     def test_validate_config_username_password(self):
         self.config['mybz'].update({
-            'bugzilla.base_uri': 'https://one.com/',
-            'bugzilla.username': 'me',
-            'bugzilla.password': 'mypas',
+            'base_uri': 'https://one.com/',
+            'username': 'me',
+            'password': 'mypas',
         })
 
         # no error expected
@@ -37,9 +36,9 @@ class TestBugzillaServiceConfig(ConfigTest):
 
     def test_validate_config_api_key(self):
         self.config['mybz'].update({
-            'bugzilla.base_uri': 'https://one.com/',
-            'bugzilla.username': 'me',
-            'bugzilla.api_key': '123',
+            'base_uri': 'https://one.com/',
+            'username': 'me',
+            'api_key': '123',
         })
 
         # no error expected
@@ -47,18 +46,18 @@ class TestBugzillaServiceConfig(ConfigTest):
 
     def test_validate_config_api_key_no_username(self):
         self.config['mybz'].update({
-            'bugzilla.base_uri': 'https://one.com/',
-            'bugzilla.api_key': '123',
+            'base_uri': 'https://one.com/',
+            'api_key': '123',
         })
 
         self.assertValidationError(
-            '[mybz]\nbugzilla.username  <- field required')
+            '[mybz]\nusername  <- field required')
 
     def test_validate_legacy_schemeless_uri(self):
         self.config['mybz'].update({
-            'bugzilla.base_uri': 'one.com/',
-            'bugzilla.username': 'me',
-            'bugzilla.password': 'mypas',
+            'base_uri': 'one.com/',
+            'username': 'me',
+            'password': 'mypas',
         })
 
         # no error expected
@@ -68,9 +67,9 @@ class TestBugzillaServiceConfig(ConfigTest):
 class TestBugzillaService(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
         'service': 'bugzilla',
-        'bugzilla.base_uri': 'https://one.com/',
-        'bugzilla.username': 'hello',
-        'bugzilla.password': 'there',
+        'base_uri': 'https://one.com/',
+        'username': 'hello',
+        'password': 'there',
     }
 
     arbitrary_record = {
@@ -104,9 +103,9 @@ class TestBugzillaService(AbstractServiceTest, ServiceTest):
             self.service = self.get_mock_service(
                 BugzillaService,
                 config_overrides={
-                    'bugzilla.base_uri': 'https://one.com/',
-                    'bugzilla.username': 'me',
-                    'bugzilla.api_key': '123',
+                    'base_uri': 'https://one.com/',
+                    'username': 'me',
+                    'api_key': '123',
                 })
 
     def test_to_taskwarrior(self):
@@ -162,7 +161,7 @@ class TestBugzillaService(AbstractServiceTest, ServiceTest):
             self.service = self.get_mock_service(
                 BugzillaService,
                 config_overrides={
-                    'bugzilla.only_if_assigned': 'hello',
+                    'only_if_assigned': 'hello',
                 })
 
         assigned_records = [
@@ -216,8 +215,8 @@ class TestBugzillaService(AbstractServiceTest, ServiceTest):
             self.service = self.get_mock_service(
                 BugzillaService,
                 config_overrides={
-                    'bugzilla.only_if_assigned': 'hello',
-                    'bugzilla.also_unassigned': True,
+                    'only_if_assigned': 'hello',
+                    'also_unassigned': True,
                 })
 
         assigned_records = [

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -4,7 +4,6 @@ import unittest
 import taskw.task
 
 from bugwarrior import db
-from bugwarrior.config.load import BugwarriorConfigParser
 
 from .base import ConfigTest
 
@@ -87,17 +86,17 @@ class TestSynchronize(ConfigTest):
         def get_tasks(tw):
             return remove_non_deterministic_keys(tw.load_tasks())
 
-        self.config = BugwarriorConfigParser()
+        self.config = {}
         self.config['general'] = {
-            'targets': 'my_service',
+            'targets': ['my_service'],
             'taskrc': self.taskrc,
             'static_fields': 'project, priority',
         }
         self.config['my_service'] = {
             'service': 'github',
-            'github.login': 'ralphbean',
-            'github.username': 'ralphbean',
-            'github.token': 'abc123',
+            'login': 'ralphbean',
+            'username': 'ralphbean',
+            'token': 'abc123',
         }
         bwconfig = self.validate()
 
@@ -207,13 +206,13 @@ class TestSynchronize(ConfigTest):
 
 class TestUDAs(ConfigTest):
     def test_udas(self):
-        self.config = BugwarriorConfigParser()
-        self.config['general'] = {'targets': 'my_service'}
+        self.config = {}
+        self.config['general'] = {'targets': ['my_service']}
         self.config['my_service'] = {
             'service': 'github',
-            'github.login': 'ralphbean',
-            'github.username': 'ralphbean',
-            'github.token': 'abc123',
+            'login': 'ralphbean',
+            'username': 'ralphbean',
+            'token': 'abc123',
         }
 
         conf = self.validate()

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -4,7 +4,6 @@ from unittest import mock
 import pydantic
 from dateutil.tz import tzutc
 
-from bugwarrior.config.load import BugwarriorConfigParser
 from bugwarrior.services.deck import NextcloudDeckClient, NextcloudDeckService
 from .base import AbstractServiceTest, ServiceTest
 
@@ -67,26 +66,26 @@ class TestData:
 class TestNextcloudDeckIssue(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
         'service': 'deck',
-        'deck.base_uri': 'http://localhost:8080',
-        'deck.username': 'testuser',
-        'deck.password': 'testpassword',
-        'deck.import_labels_as_tags': True,
+        'base_uri': 'http://localhost:8080',
+        'username': 'testuser',
+        'password': 'testpassword',
+        'import_labels_as_tags': True,
     }
 
     def setUp(self):
         super().setUp()
-        self.config = BugwarriorConfigParser()
+        self.config = {}
         self.config['general'] = {
-            'targets': 'deck',
+            'targets': ['deck'],
             # would otherwise cut the title short
             'description_length': '45'
         }
         self.config['deck'] = {
             'service': 'deck',
-            'deck.base_uri': 'http://localhost:8080',
-            'deck.username': 'testuser',
-            'deck.password': 'testpassword',
-            'deck.import_labels_as_tags': 'true',
+            'base_uri': 'http://localhost:8080',
+            'username': 'testuser',
+            'password': 'testpassword',
+            'import_labels_as_tags': 'true',
         }
 
         self.data = TestData()
@@ -160,11 +159,11 @@ class TestNextcloudDeckIssue(AbstractServiceTest, ServiceTest):
         self.assertEqual(issue.get_taskwarrior_record(), expected)
 
     def test_filter_boards_include(self):
-        self.config['deck']['deck.include_board_ids'] = '5'
+        self.config['deck']['include_board_ids'] = '5'
         self.assertTrue(self.service.filter_boards({'title': 'testboard', 'id': 5}))
         self.assertFalse(self.service.filter_boards({'title': 'testboard', 'id': 6}))
 
     def test_filter_boards_exclude(self):
-        self.config['deck']['deck.exclude_board_ids'] = '5'
+        self.config['deck']['exclude_board_ids'] = '5'
         self.assertFalse(self.service.filter_boards({'title': 'testboard', 'id': 5}))
         self.assertTrue(self.service.filter_boards({'title': 'testboard', 'id': 6}))

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -9,9 +9,9 @@ from .base import ServiceTest, AbstractServiceTest
 class TestGerritIssue(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
         'service': 'gerrit',
-        'gerrit.base_uri': 'https://one.com',
-        'gerrit.username': 'two',
-        'gerrit.password': 'three',
+        'base_uri': 'https://one.com',
+        'username': 'two',
+        'password': 'three',
     }
 
     record = {
@@ -30,7 +30,7 @@ class TestGerritIssue(AbstractServiceTest, ServiceTest):
 
         responses.add(
             responses.HEAD,
-            self.SERVICE_CONFIG['gerrit.base_uri'] + '/a/',
+            self.SERVICE_CONFIG['base_uri'] + '/a/',
             headers={'www-authenticate': 'digest'})
         with responses.mock:
             self.service = self.get_mock_service(GerritService)

--- a/tests/test_gitbug.py
+++ b/tests/test_gitbug.py
@@ -30,7 +30,7 @@ class TestData:
 class TestGitBugIssue(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
         'service': 'gitbug',
-        'gitbug.path': '/dev/null',
+        'path': '/dev/null',
     }
 
     def setUp(self):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -46,14 +46,14 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
     maxDiff = None
     SERVICE_CONFIG = {
         'service': 'github',
-        'github.login': 'arbitrary_login',
-        'github.token': 'arbitrary_token',
-        'github.username': 'arbitrary_username',
+        'login': 'arbitrary_login',
+        'token': 'arbitrary_token',
+        'username': 'arbitrary_username',
     }
 
     def test_to_taskwarrior(self):
         service = self.get_mock_service(GithubService, config_overrides={
-            'github.import_labels_as_tags': True})
+            'import_labels_as_tags': True})
         issue = service.get_issue_for_record(
             ARBITRARY_ISSUE,
             ARBITRARY_EXTRA
@@ -147,12 +147,12 @@ class TestGithubIssueQuery(AbstractServiceTest, ServiceTest):
     maxDiff = None
     SERVICE_CONFIG = {
         'service': 'github',
-        'github.login': 'arbitrary_login',
-        'github.token': 'arbitrary_token',
-        'github.username': 'arbitrary_username',
-        'github.query': 'is:open reviewer:octocat',
-        'github.include_user_repos': 'False',
-        'github.include_user_issues': 'False',
+        'login': 'arbitrary_login',
+        'token': 'arbitrary_token',
+        'username': 'arbitrary_username',
+        'query': 'is:open reviewer:octocat',
+        'include_user_repos': 'False',
+        'include_user_issues': 'False',
     }
 
     def setUp(self):
@@ -205,28 +205,28 @@ class TestGithubIssueQuery(AbstractServiceTest, ServiceTest):
 class TestGithubService(ServiceTest):
     SERVICE_CONFIG = {
         'service': 'github',
-        'github.login': 'tintin',
-        'github.username': 'milou',
-        'github.token': 't0ps3cr3t',
+        'login': 'tintin',
+        'username': 'milou',
+        'token': 't0ps3cr3t',
 
     }
 
     def test_token_authorization_header(self):
         service = self.get_mock_service(GithubService)
         service = self.get_mock_service(GithubService, config_overrides={
-            'github.token': '@oracle:eval:echo 1234567890ABCDEF'})
+            'token': '@oracle:eval:echo 1234567890ABCDEF'})
         self.assertEqual(service.client.session.headers['Authorization'],
                          "token 1234567890ABCDEF")
 
     def test_default_host(self):
-        """ Check that if github.host is not set, we default to github.com """
+        """ Check that if host is not set, we default to github.com """
         service = self.get_mock_service(GithubService)
         self.assertEqual("github.com", service.config.host)
 
     def test_overwrite_host(self):
-        """ Check that if github.host is set, we use its value as host """
+        """ Check that if host is set, we use its value as host """
         service = self.get_mock_service(GithubService, config_overrides={
-            'github.host': 'github.example.com'})
+            'host': 'github.example.com'})
         self.assertEqual("github.example.com", service.config.host)
 
     def test_keyring_service(self):
@@ -237,7 +237,7 @@ class TestGithubService(ServiceTest):
 
     def test_keyring_service_host(self):
         """ Checks that the keyring key depends on the github host. """
-        service_config = GithubConfig(**{'github.host': 'github.example.com'},
+        service_config = GithubConfig(**{'host': 'github.example.com'},
                                       **self.SERVICE_CONFIG)
         keyring_service = GithubService.get_keyring_service(service_config)
         self.assertEqual("github://tintin@github.example.com/milou", keyring_service)
@@ -269,7 +269,7 @@ class TestGithubService(ServiceTest):
 
     def test_body_length_limit(self):
         service = self.get_mock_service(GithubService, config_overrides={
-            'github.body_length': 5
+            'body_length': 5
         })
         issue = dict(body="A very short issue body.  Fixes #42.")
         self.assertEqual(issue["body"][:5], service.body(issue))

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 from dateutil.tz import tzutc
 from google.oauth2.credentials import Credentials
 
-from bugwarrior.config.load import BugwarriorConfigParser
 from bugwarrior.services import gmail
 
 from .base import AbstractServiceTest, ConfigTest, ServiceTest
@@ -27,8 +26,8 @@ class TestGmailService(ConfigTest):
 
     def setUp(self):
         super().setUp()
-        self.config = BugwarriorConfigParser()
-        self.config['general'] = {'targets': 'myservice'}
+        self.config = {}
+        self.config['general'] = {'targets': ['myservice']}
         self.config['myservice'] = {'service': 'gmail'}
 
         mock_data = mock.Mock()
@@ -106,8 +105,8 @@ TEST_LABELS = [
 class TestGmailIssue(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
         'service': 'gmail',
-        'gmail.add_tags': 'added',
-        'gmail.login_name': 'test@example.com',
+        'add_tags': 'added',
+        'login_name': 'test@example.com',
     }
 
     def setUp(self):

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -4,7 +4,7 @@ from unittest import mock
 from dateutil.tz import datetime
 from dateutil.tz.tz import tzutc
 
-from bugwarrior.config import load, schema
+from bugwarrior.config import schema
 from bugwarrior.services.jira import JiraExtraFields, JiraService
 
 from .base import AbstractServiceTest, ConfigTest, ServiceTest
@@ -26,22 +26,22 @@ class testJiraService(ConfigTest):
 
     def setUp(self):
         super().setUp()
-        self.config = load.BugwarriorConfigParser()
+        self.config = {}
         self.config['general'] = {
-            'targets': 'myjira',
+            'targets': ['myjira'],
             'interactive': 'false',
         }
         self.config['myjira'] = {
             'service': 'jira',
-            'jira.base_uri': 'https://example.com',
-            'jira.username': 'milou',
-            'jira.password': 't0ps3cr3t',
-            'jira.extra_fields': 'jiraextra1:customfield_10000,jiraextra2:namedfield.valueinside',
+            'base_uri': 'https://example.com',
+            'username': 'milou',
+            'password': 't0ps3cr3t',
+            'extra_fields': 'jiraextra1:customfield_10000,jiraextra2:namedfield.valueinside',
         }
 
     def test_body_length_no_limit(self):
         description = "A very short issue body.  Fixes #828."
-        self.config['myjira']['jira.body_length'] = '5'
+        self.config['myjira']['body_length'] = '5'
         conf = schema.validate_config(self.config, 'general', 'configpath')
         service = JiraService(
             conf['myjira'], conf['general'], 'myjira', _skip_server=True)
@@ -63,10 +63,10 @@ class testJiraService(ConfigTest):
 class TestJiraIssue(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
         'service': 'jira',
-        'jira.username': 'one',
-        'jira.base_uri': 'https://two.org',
-        'jira.password': 'three',
-        'jira.extra_fields': 'jiraextra1:customfield_10000,jiraextra2:namedfield.valueinside',
+        'username': 'one',
+        'base_uri': 'https://two.org',
+        'password': 'three',
+        'extra_fields': 'jiraextra1:customfield_10000,jiraextra2:namedfield.valueinside',
     }
 
     arbitrary_estimation = 3600

--- a/tests/test_kanboard.py
+++ b/tests/test_kanboard.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 from dateutil.tz.tz import tzutc
 
-from bugwarrior.config.load import BugwarriorConfigParser
 from bugwarrior.services.kanboard import KanboardService
 
 from .base import AbstractServiceTest, ConfigTest, ServiceTest
@@ -12,51 +11,51 @@ from .base import AbstractServiceTest, ConfigTest, ServiceTest
 class TestKanboardServiceConfig(ConfigTest):
     def setUp(self):
         super().setUp()
-        self.config = BugwarriorConfigParser()
-        self.config["general"] = {"targets": "kb"}
+        self.config = {}
+        self.config["general"] = {"targets": ["kb"]}
         self.config["kb"] = {"service": "kanboard"}
 
     def test_validate_config_required_fields(self):
         self.config["kb"].update({
-            "kanboard.url": "http://example.com/",
-            "kanboard.username": "myuser",
-            "kanboard.password": "mypass",
+            "url": "http://example.com/",
+            "username": "myuser",
+            "password": "mypass",
         })
 
         self.validate()
 
     def test_validate_config_no_url(self):
         self.config["kb"].update({
-            "kanboard.username": "myuser",
-            "kanboard.password": "mypass",
+            "username": "myuser",
+            "password": "mypass",
         })
 
         self.assertValidationError(
-            '[kb]\nkanboard.url  <- field required')
+            '[kb]\nurl  <- field required')
 
     def test_validate_config_no_username(self):
         self.config["kb"].update({
-            "kanboard.url": "http://one.com/",
-            "kanboard.password": "mypass",
+            "url": "http://one.com/",
+            "password": "mypass",
         })
 
         self.assertValidationError(
-            '[kb]\nkanboard.username  <- field required')
+            '[kb]\nusername  <- field required')
 
     def test_validate_config_no_password(self):
         self.config["kb"].update({
-            "kanboard.url": "http://one.com/",
-            "kanboard.username": "myuser",
+            "url": "http://one.com/",
+            "username": "myuser",
         })
 
         self.assertValidationError(
-            '[kb]\nkanboard.password  <- field required')
+            '[kb]\npassword  <- field required')
 
     def test_get_keyring_service(self):
         self.config["kb"].update({
-            "kanboard.url": "http://example.com/",
-            "kanboard.username": "myuser",
-            "kanboard.password": "mypass",
+            "url": "http://example.com/",
+            "username": "myuser",
+            "password": "mypass",
         })
         service_config = self.validate()['kb']
         self.assertEqual(
@@ -68,9 +67,9 @@ class TestKanboardServiceConfig(ConfigTest):
 class TestKanboardService(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
         "service": "kanboard",
-        "kanboard.url": "http://example.com",
-        "kanboard.username": "myuser",
-        "kanboard.password": "mypass",
+        "url": "http://example.com",
+        "username": "myuser",
+        "password": "mypass",
     }
 
     def setUp(self):

--- a/tests/test_phab.py
+++ b/tests/test_phab.py
@@ -12,7 +12,7 @@ class TestPhabricatorIssue(AbstractServiceTest, ServiceTest):
     maxDiff = None
     SERVICE_CONFIG = {
         'service': 'phabricator',
-        'phabricator.host': 'https://phabricator.example.com',
+        'host': 'https://phabricator.example.com',
     }
 
     def setUp(self):

--- a/tests/test_pivotaltracker.py
+++ b/tests/test_pivotaltracker.py
@@ -3,7 +3,6 @@ import datetime
 from dateutil.tz import tzutc
 import responses
 
-from bugwarrior.config.load import BugwarriorConfigParser
 from bugwarrior.services.pivotaltracker import PivotalTrackerService
 
 from .base import ServiceTest, AbstractServiceTest, ConfigTest
@@ -178,66 +177,66 @@ class TestPivotalTrackerServiceConfig(ConfigTest):
 
     def setUp(self):
         super().setUp()
-        self.config = BugwarriorConfigParser()
-        self.config['general'] = {'targets': 'pivotal'}
+        self.config = {}
+        self.config['general'] = {'targets': ['pivotal']}
         self.config['pivotal'] = {'service': 'pivotaltracker'}
 
     def test_validate_config(self):
         self.config['pivotal'].update({
-            'pivotaltracker.account_ids': '12345',
-            'pivotaltracker.user_id': '12345',
-            'pivotaltracker.token': '12345',
+            'account_ids': '12345',
+            'user_id': '12345',
+            'token': '12345',
         })
 
         self.validate()
 
     def test_validate_config_no_account_ids(self):
         self.config['pivotal'].update({
-            'pivotaltracker.token': '123',
-            'pivotaltracker.user_id': '12345',
+            'token': '123',
+            'user_id': '12345',
         })
 
         self.assertValidationError(
-            '[pivotal]\npivotaltracker.account_ids  <- field required')
+            '[pivotal]\naccount_ids  <- field required')
 
     def test_validate_config_no_user_id(self):
         self.config['pivotal'].update({
-            'pivotaltracker.account_ids': '12345',
-            'pivotaltracker.token': '123',
+            'account_ids': '12345',
+            'token': '123',
         })
 
         self.assertValidationError(
-            '[pivotal]\npivotaltracker.user_id  <- field required')
+            '[pivotal]\nuser_id  <- field required')
 
     def test_validate_config_token(self):
         self.config['pivotal'].update({
-            'pivotaltracker.account_ids': '12345',
-            'pivotaltracker.user_id': '12345',
+            'account_ids': '12345',
+            'user_id': '12345',
         })
 
         self.assertValidationError(
-            '[pivotal]\npivotaltracker.token  <- field required')
+            '[pivotal]\ntoken  <- field required')
 
     def test_validate_config_invalid_endpoint(self):
         self.config['pivotal'].update({
-            'pivotaltracker.account_ids': '12345',
-            'pivotaltracker.token': '123',
-            'pivotaltracker.user_id': '12345',
-            'pivotaltracker.version': 'v1',
+            'account_ids': '12345',
+            'token': '123',
+            'user_id': '12345',
+            'version': 'v1',
         })
 
         self.assertValidationError(
-            '[pivotal]\npivotaltracker.version  <- unexpected value')
+            '[pivotal]\nversion  <- unexpected value')
 
 
 class TestPivotalTrackerIssue(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
         'service': 'pivotaltracker',
-        'pivotaltracker.token': '123456',
-        'pivotaltracker.user_id': 106,
-        'pivotaltracker.account_ids': '100',
-        'pivotaltracker.import_labels_as_tags': True,
-        'pivotaltracker.import_blockers': True
+        'token': '123456',
+        'user_id': 106,
+        'account_ids': '100',
+        'import_labels_as_tags': True,
+        'import_blockers': True
     }
 
     def setUp(self):

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -13,9 +13,9 @@ class TestRedmineIssue(AbstractServiceTest, ServiceTest):
     maxDiff = None
     SERVICE_CONFIG = {
         'service': 'redmine',
-        'redmine.url': 'https://something',
-        'redmine.key': 'something_else',
-        'redmine.issue_limit': '100',
+        'url': 'https://something',
+        'key': 'something_else',
+        'issue_limit': '100',
     }
     arbitrary_created = datetime.datetime.utcnow().replace(
         tzinfo=dateutil.tz.tz.tzutc(), microsecond=0) - datetime.timedelta(1)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3,7 +3,7 @@ import unittest.mock
 import typing_extensions
 
 from bugwarrior import config, services
-from bugwarrior.config import load, schema
+from bugwarrior.config import schema
 
 from .base import ConfigTest
 
@@ -13,7 +13,7 @@ going to fill up your floppy disk taskwarrior backup. Actually it's not
 that long.""".replace('\n', ' ')
 
 
-class DumbConfig(config.ServiceConfig, prefix='dumb'):
+class DumbConfig(config.ServiceConfig):
     service: typing_extensions.Literal['test']
 
 
@@ -50,9 +50,9 @@ class ServiceBase(ConfigTest):
 
     def setUp(self):
         super().setUp()
-        self.config = load.BugwarriorConfigParser()
+        self.config = {}
         self.config['general'] = {
-            'targets': 'test',
+            'targets': ['test'],
             'interactive': 'false',
         }
         self.config['test'] = {'service': 'test'}

--- a/tests/test_taiga.py
+++ b/tests/test_taiga.py
@@ -8,8 +8,8 @@ from .base import ServiceTest, AbstractServiceTest
 class TestTaigaIssue(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
         'service': 'taiga',
-        'taiga.base_uri': 'https://one',
-        'taiga.auth_token': 'two',
+        'base_uri': 'https://one',
+        'auth_token': 'two',
     }
     record = {
         'id': 400,

--- a/tests/test_teamlab.py
+++ b/tests/test_teamlab.py
@@ -10,10 +10,10 @@ from .base import ServiceTest, AbstractServiceTest
 class TestTeamlabIssue(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
         'service': 'teamlab',
-        'teamlab.hostname': 'something',
-        'teamlab.login': 'alkjdsf',
-        'teamlab.password': 'lkjklj',
-        'teamlab.project_template': 'abcdef',
+        'hostname': 'something',
+        'login': 'alkjdsf',
+        'password': 'lkjklj',
+        'project_template': 'abcdef',
     }
     arbitrary_issue = {
         'title': 'Hello',
@@ -37,7 +37,7 @@ class TestTeamlabIssue(AbstractServiceTest, ServiceTest):
         issue = self.service.get_issue_for_record(self.arbitrary_issue)
 
         expected_output = {
-            'project': self.SERVICE_CONFIG['teamlab.hostname'],
+            'project': self.SERVICE_CONFIG['hostname'],
             'priority': self.service.config.default_priority,
             issue.TITLE: self.arbitrary_issue['title'],
             issue.FOREIGN_ID: self.arbitrary_issue['id'],

--- a/tests/test_teamwork_projects.py
+++ b/tests/test_teamwork_projects.py
@@ -9,8 +9,8 @@ from dateutil.tz import tzutc
 class TestTeamworkIssue(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
         'service': 'teamwork_projects',
-        'teamwork_projects.host': 'https://test.teamwork_projects.com',
-        'teamwork_projects.token': 'arbitrary_token',
+        'host': 'https://test.teamwork_projects.com',
+        'token': 'arbitrary_token',
     }
 
     @responses.activate

--- a/tests/test_trac.py
+++ b/tests/test_trac.py
@@ -30,9 +30,9 @@ class FakeTracLib:
 class TestTracIssue(AbstractServiceTest, ServiceTest):
     SERVICE_CONFIG = {
         'service': 'trac',
-        'trac.base_uri': 'ljlkajsdfl.com',
-        'trac.username': 'something',
-        'trac.password': 'somepwd',
+        'base_uri': 'ljlkajsdfl.com',
+        'username': 'something',
+        'password': 'somepwd',
     }
     arbitrary_issue = {
         'url': 'http://some/url.com/',

--- a/tests/test_trello.py
+++ b/tests/test_trello.py
@@ -1,7 +1,6 @@
 from dateutil.parser import parse as parse_date
 import responses
 
-from bugwarrior.config.load import BugwarriorConfigParser
 from bugwarrior.services.trello import TrelloService, TrelloIssue
 
 from .base import ConfigTest, ServiceTest
@@ -66,12 +65,12 @@ class TestTrelloService(ConfigTest):
 
     def setUp(self):
         super().setUp()
-        self.config = BugwarriorConfigParser()
-        self.config['general'] = {'targets': 'mytrello'}
+        self.config = {}
+        self.config['general'] = {'targets': ['mytrello']}
         self.config['mytrello'] = {
             'service': 'trello',
-            'trello.api_key': 'XXXX',
-            'trello.token': 'YYYY',
+            'api_key': 'XXXX',
+            'token': 'YYYY',
         }
         responses.add(responses.GET,
                       'https://api.trello.com/1/lists/L15T/cards/open',
@@ -94,7 +93,7 @@ class TestTrelloService(ConfigTest):
 
     @responses.activate
     def test_get_boards_config(self):
-        self.config['mytrello']['trello.include_boards'] = 'F00, B4R'
+        self.config['mytrello']['include_boards'] = 'F00, B4R'
         conf = self.validate()
         service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
         boards = service.get_boards()
@@ -117,7 +116,7 @@ class TestTrelloService(ConfigTest):
 
     @responses.activate
     def test_get_lists_include(self):
-        self.config['mytrello']['trello.include_lists'] = 'List 1'
+        self.config['mytrello']['include_lists'] = 'List 1'
         conf = self.validate()
         service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
         lists = service.get_lists('B04RD')
@@ -125,7 +124,7 @@ class TestTrelloService(ConfigTest):
 
     @responses.activate
     def test_get_lists_exclude(self):
-        self.config['mytrello']['trello.exclude_lists'] = 'List 1'
+        self.config['mytrello']['exclude_lists'] = 'List 1'
         conf = self.validate()
         service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
         lists = service.get_lists('B04RD')
@@ -140,7 +139,7 @@ class TestTrelloService(ConfigTest):
 
     @responses.activate
     def test_get_cards_assigned(self):
-        self.config['mytrello']['trello.only_if_assigned'] = 'tintin'
+        self.config['mytrello']['only_if_assigned'] = 'tintin'
         conf = self.validate()
         service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
         cards = service.get_cards('L15T')
@@ -149,8 +148,8 @@ class TestTrelloService(ConfigTest):
     @responses.activate
     def test_get_cards_assigned_unassigned(self):
         self.config['mytrello'].update({
-            'trello.only_if_assigned': 'tintin',
-            'trello.also_unassigned': 'true',
+            'only_if_assigned': 'tintin',
+            'also_unassigned': 'true',
         })
         conf = self.validate()
         service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
@@ -187,8 +186,8 @@ class TestTrelloService(ConfigTest):
     @responses.activate
     def test_issues(self):
         self.config['mytrello'].update({
-            'trello.include_lists': 'List 1',
-            'trello.only_if_assigned': 'tintin',
+            'include_lists': 'List 1',
+            'only_if_assigned': 'tintin',
         })
         conf = self.validate()
         service = TrelloService(conf['mytrello'], conf['general'], 'mytrello')
@@ -220,16 +219,16 @@ class TestTrelloService(ConfigTest):
         self.validate()
 
     def test_valid_config_no_access_token(self):
-        del self.config['mytrello']['trello.token']
+        del self.config['mytrello']['token']
 
         self.assertValidationError(
-            '[mytrello]\ntrello.token  <- field required')
+            '[mytrello]\ntoken  <- field required')
 
     def test_valid_config_no_api_key(self):
-        del self.config['mytrello']['trello.api_key']
+        del self.config['mytrello']['api_key']
 
         self.assertValidationError(
-            '[mytrello]\ntrello.api_key  <- field required')
+            '[mytrello]\napi_key  <- field required')
 
     def test_keyring_service(self):
         """ Checks that the keyring service name """

--- a/tests/test_youtrak.py
+++ b/tests/test_youtrak.py
@@ -1,6 +1,5 @@
 import responses
 
-from bugwarrior.config.load import BugwarriorConfigParser
 from bugwarrior.services.youtrack import YoutrackService
 
 from .base import ConfigTest, ServiceTest, AbstractServiceTest
@@ -9,16 +8,16 @@ from .base import ConfigTest, ServiceTest, AbstractServiceTest
 class TestYoutrackService(ConfigTest):
     def setUp(self):
         super().setUp()
-        self.config = BugwarriorConfigParser()
-        self.config['general'] = {'targets': 'myservice'}
+        self.config = {}
+        self.config['general'] = {'targets': ['myservice']}
         self.config['myservice'] = {
             'service': 'youtrack',
-            'youtrack.login': 'foobar',
-            'youtrack.password': 'XXXXXX',
+            'login': 'foobar',
+            'password': 'XXXXXX',
         }
 
     def test_get_keyring_service(self):
-        self.config['myservice']['youtrack.host'] = 'youtrack.example.com'
+        self.config['myservice']['host'] = 'youtrack.example.com'
         service_config = self.validate()['myservice']
         self.assertEqual(
             YoutrackService.get_keyring_service(service_config),
@@ -29,10 +28,10 @@ class TestYoutrackIssue(AbstractServiceTest, ServiceTest):
     maxDiff = None
     SERVICE_CONFIG = {
         'service': 'youtrack',
-        'youtrack.host': 'youtrack.example.com',
-        'youtrack.login': 'arbitrary_login',
-        'youtrack.password': 'arbitrary_password',
-        'youtrack.anonymous': True,
+        'host': 'youtrack.example.com',
+        'login': 'arbitrary_login',
+        'password': 'arbitrary_password',
+        'anonymous': True,
     }
     arbitrary_issue = {
         "id": "TEST-1",


### PR DESCRIPTION
*Pulled out of #973 / #983.*

While my motive is to generalize validation for the purposes of supporting toml configuration (#873), I think this change stands on its own merits:

- Simpler testing -- we no longer need to build Configparser's or specify prefixes.
- Eliminate `ServiceConfigMetaclass`. While IMO an elegant solution, it's unnecessarily complex when only one of our services (azuredevops) has a prefix that varies from the service name, which can be treated as the only allowed exception going forward.
- Reduce reliance on our custom pydantic `ValidationError`. This class is difficult to follow since it is mostly engaged with pydantic's data model and not ours. Furthermore, it appears that it will likely have to be completely redone to support pydantic-2. (On an optimistic note, I expect the implementation to be simpler because pydantic-2 will implement some of the features I've hacked onto it and they appear to be changing their data model to simplify customization.)