### PR TITLE
Fix: Add a size limit to gitlab descriptions to prevent 'Argument list too long' OsError

### DIFF
--- a/bugwarrior/docs/services/gitlab.rst
+++ b/bugwarrior/docs/services/gitlab.rst
@@ -225,8 +225,16 @@ Including Project Owner in Project Name
 
 By default the taskwarrior ``project`` name will not include the owner. To do so set::
 
-    github.project_owner_prefix = True
+    gitlab.project_owner_prefix = True
 
+Synchronizing Issue Content
++++++++++++++++++++++++++++
+
+This service synchronizes most Gitlab fields to UDAs, as described below.
+
+To limit the amount of content synchronized into TaskWarrior (which can help to avoid issues with synchronization), use
+
+ * ``gitlab.body_length=0``` to disable synchronizing the Gitlab Description UDA (or set it to a small value to limit size).
 
 Provided UDA Fields
 -------------------

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -75,6 +75,7 @@ class TestData():
             'namespace': 'arbitrary_namespace',
             'type': 'issue',
             'annotations': [],
+            'description': '',
         }
         self.arbitrary_todo = {
             "id": 42,
@@ -195,6 +196,7 @@ class TestData():
             'namespace': 'arbitrary_namespace',
             'type': 'merge_request',
             'annotations': [],
+            "description": "",
         }
         self.arbitrary_project = {
             "id": 8,
@@ -581,6 +583,21 @@ class TestGitlabService(ConfigTest):
         self.assertEqual('L', self.service.config.default_issue_priority)
         self.assertEqual('M', self.service.config.default_mr_priority)
         self.assertEqual('H', self.service.config.default_todo_priority)
+
+    def test_body_zero_limit(self):
+        self.config['myservice']['body_length'] = 0
+        issue = dict(description="A very short issue body.  Fixes #42.")
+        self.assertEqual("", self.service.description(issue))
+
+    def test_body_short_limit(self):
+        size_limit = 5
+        self.config['myservice']['body_length'] = size_limit
+        issue = dict(description="A very short issue body.  Fixes #42.")
+        self.assertEqual(issue["description"][:size_limit], self.service.description(issue))
+
+    def test_body_no_limit(self):
+        issue = dict(description="A very short issue body.  Fixes #42.")
+        self.assertEqual(issue["description"], self.service.description(issue))
 
 
 class TestGitlabIssue(AbstractServiceTest, ServiceTest):


### PR DESCRIPTION
Hello, 

I'm installing bugwarrior on a new machine and am hitting a hard limit on the `task` invocation because some of my assigned gitlab issues have markdown tables / long checklists

I don't really get where the limit is because on my machine `getconf ARG_MAX` tells `2097152` but the error happened with a line length of ~180000

This proposition adds a constant limit (arbitrarly set to 10000) and cuts gitlab descriptions when they exceed this limit, along with a warning line
```
INFO:bugwarrior.services:Done aggregating remote issues.
WARNING:bugwarrior.db:Description exceeded max size of 10000, was 166179
WARNING:bugwarrior.db:Description exceeded max size of 10000, was 11110
```


The same logic should probably be applied to other services (or even all fields) but I don't have enough insights so I kept the impacts to a minimum