### PR TITLE
Fix CI

### DIFF
--- a/bugwarrior/docs/conf.py
+++ b/bugwarrior/docs/conf.py
@@ -300,4 +300,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras = {
     "kanboard": ["kanboard"],
     "keyring": ["keyring"],
     "phabricator": ["phabricator"],
-    "test": ["flake8", "pytest", "responses", "sphinx", "sphinx-click", "docutils"],
+    "test": ["flake8", "pytest", "responses", "sphinx>=1.0", "sphinx-click", "docutils"],
     "trac": ["offtrac"],
     "versionone": ["v1pysdk"],
 }

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,10 @@ extras = {
     "kanboard": ["kanboard"],
     "keyring": ["keyring"],
     "phabricator": ["phabricator"],
-    "test": ["flake8", "pytest", "responses", "sphinx>=1.0", "sphinx-click", "docutils"],
+    "test": ["flake8", "pytest", "responses", "sphinx>=1.0", "sphinx-click", "docutils",
+             # Workaround https://github.com/python/importlib_metadata/issues/406
+             "importlib-metadata<5"
+             ],
     "trac": ["offtrac"],
     "versionone": ["v1pysdk"],
 }


### PR DESCRIPTION
This fixes the sphinx warning that is making CI red.

This format is not compatible with pre-1.0 versions of sphinx.