### PR TITLE
CI: update actions to support node16

### DIFF
--- a/.github/workflows/bugwarrior.yml
+++ b/.github/workflows/bugwarrior.yml
@@ -56,9 +56,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set Jira version ${{ matrix.jira-version }}


### PR DESCRIPTION
It appears that the node12 deprecation warning was converted to an error, breaking CI.