### PR TITLE
feat: Make it possible to start/stop Jira tasks based on Jira status

### DIFF
--- a/bugwarrior/config/ini2toml_plugin.py
+++ b/bugwarrior/config/ini2toml_plugin.py
@@ -67,6 +67,7 @@ CONFIGLIST = {
     'deck': ['include_board_ids', 'exclude_board_ids'],
     'bugzilla': ['open_statuses'],
     'pagure': ['include_repos', 'exclude_repos'],
+    'jira': ['start_states'],
 }
 
 

--- a/bugwarrior/docs/services/jira.rst
+++ b/bugwarrior/docs/services/jira.rst
@@ -140,6 +140,30 @@ to all fields on the Taskwarrior task if needed.
    See :ref:`field_templates` for more details regarding how templates
    are processed.
 
+Reflect Jira status in start/stop state
++++++++++++++++++++++++++++++++++++++++
+
+You can instruct Jira issue tracker to start/stop Taskwarrior tasks based on the Jira issue state.
+
+.. config::
+    :fragment: jira
+
+    jira.start_states = In Progress,Review
+
+Now if tracker is pulling issue that is in `In Progress` or `Review` state in Jira, it will make sure it is started in Taskwarrior, otherwise it will stop it. So if you configure this, Jira works as a source of truth: if you stop the task in Taskwarrior, but it is still in `In Progress` in Jira, on next Bugwarrior pull it will be automatically started again.
+
+.. note::
+
+   Note that status names are case sensitive and although they might be displayed in upper case in Jira UI, in API the value might be different. Take a look at some task synchronized from Jira like `task 123` at a `jirastatus` UDA field. It will help to determine correct name of the state.
+
+.. note::
+
+   Note different Jira projects you might have issues in might be using different state names, so if they are not compatible, you might need more Jira config sections.
+
+.. warning::
+
+   If you configure the state names incorrectly (e.g. because of this case sensitivity mentione above), all your Jira tasks will be stopped. This is because `start_states` is not null (i.e. you enabled status management) and Jira status did not matched your settings (i.e. task will be stopped).
+
 Kerberos authentication
 +++++++++++++++++++++++
 


### PR DESCRIPTION
This is to reflect Jira status changes in Taskwarrior start/stop status.

Please take a look and let me know if it makes sense.


Known bug is if the task is `completed` in Taskwarrior, but `In Progress` in Jira, it will not be started in Taskwarrior until another pull.