### PR TITLE
Break collect functions from services/__init__.py

### DIFF
--- a/bugwarrior/collect.py
+++ b/bugwarrior/collect.py
@@ -1,0 +1,100 @@
+import logging
+import multiprocessing
+import time
+
+from pkg_resources import iter_entry_points
+
+log = logging.getLogger(__name__)
+
+# Sentinels for process completion status
+SERVICE_FINISHED_OK = 0
+SERVICE_FINISHED_ERROR = 1
+
+
+def get_service(service_name):
+    epoint = iter_entry_points(group='bugwarrior.service', name=service_name)
+    try:
+        epoint = next(epoint)
+    except StopIteration:
+        return None
+
+    return epoint.load()
+
+
+def _aggregate_issues(conf, main_section, target, queue):
+    """ This worker function is separated out from the main
+    :func:`aggregate_issues` func only so that we can use multiprocessing
+    on it for speed reasons.
+    """
+
+    start = time.time()
+
+    try:
+        service = get_service(conf[target].service)(
+            conf[target], conf[main_section])
+        issue_count = 0
+        for issue in service.issues():
+            queue.put(issue)
+            issue_count += 1
+    except SystemExit as e:
+        log.critical(f"Worker for [{target}] exited: {e}")
+        queue.put((SERVICE_FINISHED_ERROR, (target, e)))
+    except BaseException as e:
+        if hasattr(e, 'request') and e.request:
+            # Exceptions raised by requests library have the HTTP request
+            # object stored as attribute. The request can have hooks attached
+            # to it, and we need to remove them, as there can be unpickleable
+            # methods. There is no one left to call these hooks anyway.
+            e.request.hooks = {}
+        log.exception(f"Worker for [{target}] failed: {e}")
+        queue.put((SERVICE_FINISHED_ERROR, (target, e)))
+    else:
+        log.debug(f"Worker for [{target}] finished ok.")
+        queue.put((SERVICE_FINISHED_OK, (target, issue_count, )))
+    finally:
+        duration = time.time() - start
+        log.info(f"Done with [{target}] in {duration}.")
+
+
+def aggregate_issues(conf, main_section, debug):
+    """ Return all issues from every target. """
+    log.info("Starting to aggregate remote issues.")
+
+    # Create and call service objects for every target in the config
+    targets = conf[main_section].targets
+
+    queue = multiprocessing.Queue()
+
+    log.info("Spawning %i workers." % len(targets))
+
+    if debug:
+        for target in targets:
+            _aggregate_issues(conf, main_section, target, queue)
+    else:
+        for target in targets:
+            proc = multiprocessing.Process(
+                target=_aggregate_issues,
+                args=(conf, main_section, target, queue)
+            )
+            proc.start()
+
+            # Sleep for 1 second here to try and avoid a race condition where
+            # all N workers start up and ask the gpg-agent process for
+            # information at the same time.  This causes gpg-agent to fumble
+            # and tell some of our workers some incomplete things.
+            time.sleep(1)
+
+    currently_running = len(targets)
+    while currently_running > 0:
+        issue = queue.get(True)
+        if isinstance(issue, tuple):
+            currently_running -= 1
+            completion_type, args = issue
+            if completion_type == SERVICE_FINISHED_ERROR:
+                target, e = args
+                log.error(f"Aborted [{target}] due to critical error.")
+                yield ('SERVICE FAILED', target)
+            continue
+        yield issue
+
+    log.info("Done aggregating remote issues.")

--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -9,7 +9,7 @@ import getpass
 import click
 
 from bugwarrior.config import get_keyring, get_config_path, load_config
-from bugwarrior.services import aggregate_issues, get_service
+from bugwarrior.collect import aggregate_issues, get_service
 from bugwarrior.db import (
     get_defined_udas_as_strings,
     synchronize,

--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -9,7 +9,7 @@ import pydantic.error_wrappers
 import taskw
 import typing_extensions
 
-from bugwarrior.services import get_service
+from bugwarrior.collect import get_service
 
 from .data import BugwarriorData, get_data_path
 

--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -8,6 +8,7 @@ import dogpile.cache
 from taskw import TaskWarriorShellout
 from taskw.exceptions import TaskwarriorError
 
+from bugwarrior.collect import get_service
 from bugwarrior.notifications import send_notification
 
 import logging
@@ -501,8 +502,6 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
 
 
 def build_key_list(targets):
-    from bugwarrior.services import get_service
-
     keys = {}
     for target in targets:
         keys[target] = get_service(target).ISSUE_CLASS.UNIQUE_KEY
@@ -547,9 +546,6 @@ def build_uda_config_overrides(targets):
         }
 
     """
-
-    from bugwarrior.services import get_service
-
     targets_udas = {}
     for target in targets:
         targets_udas.update(get_service(target).ISSUE_CLASS.UDAS)

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -1,10 +1,6 @@
 import abc
 import copy
-import multiprocessing
 import re
-import time
-
-from pkg_resources import iter_entry_points
 
 from dateutil.parser import parse as parse_date
 from dateutil.tz import tzlocal
@@ -18,21 +14,6 @@ from bugwarrior.db import MARKUP, URLShortener
 
 import logging
 log = logging.getLogger(__name__)
-
-
-# Sentinels for process completion status
-SERVICE_FINISHED_OK = 0
-SERVICE_FINISHED_ERROR = 1
-
-
-def get_service(service_name):
-    epoint = iter_entry_points(group='bugwarrior.service', name=service_name)
-    try:
-        epoint = next(epoint)
-    except StopIteration:
-        return None
-
-    return epoint.load()
 
 
 class IssueService(abc.ABC):
@@ -406,82 +387,3 @@ class ServiceClient:
         else:
             # Older python-requests
             return response.json
-
-
-def _aggregate_issues(conf, main_section, target, queue):
-    """ This worker function is separated out from the main
-    :func:`aggregate_issues` func only so that we can use multiprocessing
-    on it for speed reasons.
-    """
-
-    start = time.time()
-
-    try:
-        service = get_service(conf[target].service)(
-            conf[target], conf[main_section])
-        issue_count = 0
-        for issue in service.issues():
-            queue.put(issue)
-            issue_count += 1
-    except SystemExit as e:
-        log.critical(f"Worker for [{target}] exited: {e}")
-        queue.put((SERVICE_FINISHED_ERROR, (target, e)))
-    except BaseException as e:
-        if hasattr(e, 'request') and e.request:
-            # Exceptions raised by requests library have the HTTP request
-            # object stored as attribute. The request can have hooks attached
-            # to it, and we need to remove them, as there can be unpickleable
-            # methods. There is no one left to call these hooks anyway.
-            e.request.hooks = {}
-        log.exception(f"Worker for [{target}] failed: {e}")
-        queue.put((SERVICE_FINISHED_ERROR, (target, e)))
-    else:
-        log.debug(f"Worker for [{target}] finished ok.")
-        queue.put((SERVICE_FINISHED_OK, (target, issue_count, )))
-    finally:
-        duration = time.time() - start
-        log.info(f"Done with [{target}] in {duration}.")
-
-
-def aggregate_issues(conf, main_section, debug):
-    """ Return all issues from every target. """
-    log.info("Starting to aggregate remote issues.")
-
-    # Create and call service objects for every target in the config
-    targets = conf[main_section].targets
-
-    queue = multiprocessing.Queue()
-
-    log.info("Spawning %i workers." % len(targets))
-
-    if debug:
-        for target in targets:
-            _aggregate_issues(conf, main_section, target, queue)
-    else:
-        for target in targets:
-            proc = multiprocessing.Process(
-                target=_aggregate_issues,
-                args=(conf, main_section, target, queue)
-            )
-            proc.start()
-
-            # Sleep for 1 second here to try and avoid a race condition where
-            # all N workers start up and ask the gpg-agent process for
-            # information at the same time.  This causes gpg-agent to fumble
-            # and tell some of our workers some incomplete things.
-            time.sleep(1)
-
-    currently_running = len(targets)
-    while currently_running > 0:
-        issue = queue.get(True)
-        if isinstance(issue, tuple):
-            currently_running -= 1
-            completion_type, args = issue
-            if completion_type == SERVICE_FINISHED_ERROR:
-                target, e = args
-                log.error(f"Aborted [{target}] due to critical error.")
-                yield ('SERVICE FAILED', target)
-            continue
-        yield issue
-
-    log.info("Done aggregating remote issues.")


### PR DESCRIPTION
These functions are unrelated to the service classes and are really about managing the high-level control flow of issue aggregation.

As an additional benefit, this kills off what I believe are the last of our ugly workarounds to avoid circular-dependencies (in db.py).