### PR TITLE
Allow string CA path values for gitlab.verify_ssl

### DIFF
--- a/bugwarrior/docs/services/gitlab.rst
+++ b/bugwarrior/docs/services/gitlab.rst
@@ -269,10 +269,20 @@ If your Gitlab instance is only available over HTTP, set:
 
     gitlab.use_https = False
 
-Do Not Verify SSL Certificate
-+++++++++++++++++++++++++++++
+SSL Certificate Verification
+++++++++++++++++++++++++++++
 
-If you want to ignore verifying the SSL certificate, set:
+For secure connections using certificates signed by public certificate
+authorities, verification is performed automatically. For non-public CAs or
+self-signed certificates, the ``verify_ssl`` setting can be set to the path to
+a certificate file:
+
+.. config::
+   :fragment: gitlab
+
+   gitlab.verify_ssl = ~/certs/local-CA.pem
+
+If you just want to ignore any problems verifying the SSL certificate, set:
 
 .. config::
     :fragment: gitlab

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -41,7 +41,7 @@ class GitlabConfig(config.ServiceConfig):
     default_todo_priority: DefaultPriority = 'unassigned'
     default_mr_priority: DefaultPriority = 'unassigned'
     use_https: bool = True
-    verify_ssl: bool = True
+    verify_ssl: typing.Union[bool, config.ExpandedPath] = True
     body_length: int = sys.maxsize
     project_owner_prefix: bool = False
     issue_query: str = ''


### PR DESCRIPTION
In `bugwarrior.services.gitlab.GitlabClient._fetch()`, the `verify_ssl` configuration value is given as the requests `verify` parameter, which can either be a boolean or a path to a CA certificate bundle:

https://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification

Simply extending the configuration type to include `bugwarrior.config.ExpandedPath` allows users to use non-public certificate authorities without disabling TLS verification entirely. This is preferable to setting the `REQUESTS_CA_BUNDLE` environment variable, which may interfere with other services using different certificate authorities.