### PR TITLE
support for python 3.12

### DIFF
--- a/.github/workflows/bugwarrior.yml
+++ b/.github/workflows/bugwarrior.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12]
         jira-version: [1.0.10, 2.0.0]
     steps:
       - name: Checkout code
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12]
         jira-version: [1.0.10, 2.0.0]
         architecture: [aarch64, ppc64le]
 

--- a/.github/workflows/bugwarrior.yml
+++ b/.github/workflows/bugwarrior.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
         jira-version: [1.0.10, 2.0.0]
     steps:
       - name: Checkout code
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
         jira-version: [1.0.10, 2.0.0]
         architecture: [aarch64, ppc64le]
 

--- a/bugwarrior/config/load.py
+++ b/bugwarrior/config/load.py
@@ -70,7 +70,8 @@ def parse_file(configpath: str) -> dict:
             config = tomllib.load(f)
     else:
         rawconfig = BugwarriorConfigParser()
-        rawconfig.readfp(codecs.open(configpath, "r", "utf-8",))
+        with codecs.open(configpath, "r", "utf-8",) as buff:
+            rawconfig.read_file(buff)
         config = {}
         for section in rawconfig.sections():
             if section in ['hooks', 'notifications']:


### PR DESCRIPTION
python3.12 removed `readfp()`, recommended to use `read_file()` instead