### PR TITLE
readthedocs: add required build configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,10 @@
 
 # Required
 version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
 
 # Optionally declare the Python requirements required to build your docs
 python:


### PR DESCRIPTION
Resolve #1022

See docs which now show that these options are required: <https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os>.