### PR TITLE
docs: Change links to bugwarrior.readthedocs.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Thank you for your interest in contributing to Bugwarrior!
 
-See the full [contributing documentation](https://bugwarrior-docs.readthedocs.io/en/latest/contributing/getting-started.html) or view it locally in `bugwarrior/docs/contributing`.
+See the full [contributing documentation](https://bugwarrior.readthedocs.io/en/latest/contributing/getting-started.html) or view it locally in `bugwarrior/docs/contributing`.

--- a/bugwarrior/README.rst
+++ b/bugwarrior/README.rst
@@ -39,7 +39,7 @@ Documentation
 -------------
 
 For information on how to install and use bugwarrior, `read the docs
-<https://bugwarrior-docs.readthedocs.io>`_ on RTFD.
+<https://bugwarrior.readthedocs.io>`_ on RTFD.
 
 Build Status
 ------------

--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -216,7 +216,7 @@ def raise_validation_error(msg, config_path, no_errors=1):
         ('Validation error' if no_errors == 1
          else f'{no_errors} validation errors') +
         f' found in {config_path}\n'
-        f'See https://bugwarrior-docs.readthedocs.io\n\n{msg}'
+        f'See https://bugwarrior.readthedocs.io\n\n{msg}'
     )
     sys.exit(1)
 

--- a/bugwarrior/docs/manpage.rst
+++ b/bugwarrior/docs/manpage.rst
@@ -55,4 +55,4 @@ If ``$XDG_CONFIG_DIRS`` is either not set or empty, a value equal to
 See Also
 --------
 
-https://bugwarrior-docs.readthedocs.io
+https://bugwarrior.readthedocs.io


### PR DESCRIPTION
One way or another #812 is now resolved and the docs started building a couple weeks ago for the first time in 5 years.