### PR TITLE
services.IssueService: Remove unused get_author

### DIFF
--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -82,10 +82,6 @@ class IssueService(abc.ABC):
         """ Override this for filtering on tickets """
         raise NotImplementedError()
 
-    def get_author(self, issue):
-        """ Override this for filtering on tickets """
-        raise NotImplementedError()
-
     @abc.abstractmethod
     def issues(self):
         """ Returns a list of dicts representing issues from a remote service.

--- a/bugwarrior/services/pivotaltracker.py
+++ b/bugwarrior/services/pivotaltracker.py
@@ -75,10 +75,6 @@ class PivotalTrackerIssue(Issue):
         _, issue = issue
         return issue.get('pivotalowners')
 
-    def get_author(self, issue):
-        _, issue = issue
-        return issue.get('pivotalrequesters')
-
     def to_taskwarrior(self):
         description = self.record.get('description')
         created = self.parse_date(self.record.get('created_at'))

--- a/bugwarrior/services/teamwork_projects.py
+++ b/bugwarrior/services/teamwork_projects.py
@@ -76,11 +76,6 @@ class TeamworkIssue(Issue):
                 self.user_id in self.record.get("responsible-party-ids", "")):
             return self.name
 
-    def get_author(self, issue):
-        if issue:
-            author = self.record["creator-firstname"] + " " + self.record["creator-lastname"]
-            return author
-
     def get_task_url(self):
         return self.extra["host"] + "/#/tasks/" + str(self.record["id"])
 

--- a/tests/test_teamwork_projects.py
+++ b/tests/test_teamwork_projects.py
@@ -138,4 +138,3 @@ class TestTeamworkIssue(AbstractServiceTest, ServiceTest):
         issue.name = "Greg McCoy"
         self.assertEqual(issue.get_taskwarrior_record(), expected_data)
         self.assertEqual(issue.get_owner(), "Greg McCoy")
-        self.assertEqual(issue.get_author(issue), "Greg McCoy")


### PR DESCRIPTION
Defining this method on the base class gave the impression that it was a required method and services started implementing it even though it is unused.