### PR TITLE
[gitbug] Correctly expand user home directory path

### DIFF
--- a/bugwarrior/services/gitbug.py
+++ b/bugwarrior/services/gitbug.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import pathlib
 import signal
 import subprocess
 import sys
@@ -17,7 +16,7 @@ log = logging.getLogger(__name__)
 class GitBugConfig(config.ServiceConfig):
     service: typing_extensions.Literal['gitbug']
 
-    path: pathlib.Path
+    path: config.ExpandedPath
 
     import_labels_as_tags: bool = False
     label_template: str = '{{label}}'

--- a/tests/test_gitbug.py
+++ b/tests/test_gitbug.py
@@ -4,9 +4,9 @@ from unittest import mock
 import dateutil
 import pydantic
 
-from bugwarrior.services.gitbug import GitBugClient, GitBugService
+from bugwarrior.services.gitbug import GitBugClient, GitBugConfig, GitBugService
 
-from .base import AbstractServiceTest, ServiceTest
+from .base import AbstractServiceTest, ConfigTest, ServiceTest
 
 
 # NOTE: replace with stdlib dataclasses.dataclass once python-3.6 is dropped
@@ -83,3 +83,13 @@ class TestGitBugIssue(AbstractServiceTest, ServiceTest):
         }
 
         self.assertEqual(issue.get_taskwarrior_record(), expected)
+
+
+class TestGitBugConfig(ConfigTest):
+    def setUp(self):
+        super().setUp()
+        self.config = GitBugConfig(service="gitbug", path="~/custom-gitbug-repo")
+
+    def test_home_path_expansion(self):
+        expected = self.tempdir + "/custom-gitbug-repo"
+        self.assertEqual(self.config.path, expected)


### PR DESCRIPTION
Previously in the git-bug service, providing '~' as part of the path to a gitbug remote would not correctly expand to the user's home directory and error out with directory not found.

This commit fixes the behavior to correctly expand the path instead, aligning it with that of the taskrc configuration option and other services' path expansion.

It simply switches out the `pathlib.Path` class for `config.ExpandedPath`, which the gmail, gitlab and gerrit services also make use of. 

The PR includes a small test of the gitbug path configuration setup to avoid later regressions.
Hope this little PR is formatted well! Let me know if there's any remaining issues to be fixed.