### PR TITLE
Adding draft status for GH and Gerrit

### DIFF
--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -24,6 +24,8 @@ class GerritIssue(Issue):
     FOREIGN_ID = 'gerritid'
     BRANCH = 'gerritbranch'
     TOPIC = 'gerrittopic'
+    STATUS = 'gerritstatus'
+    WIP = 'gerritwip'
 
     UDAS = {
         SUMMARY: {
@@ -46,6 +48,14 @@ class GerritIssue(Issue):
             'type': 'string',
             'label': 'Gerrit Topic',
         },
+        STATUS: {
+            'type': 'string',
+            'label': 'Gerrit Status',
+        },
+        WIP: {
+            'type': 'string',
+            'label': 'Gerrit Work in Progress',
+        },
     }
     UNIQUE_KEY = (URL, )
 
@@ -61,6 +71,8 @@ class GerritIssue(Issue):
             self.SUMMARY: self.record['subject'],
             self.BRANCH: self.record['branch'],
             self.TOPIC: self.record.get('topic', 'notopic'),
+            self.STATUS: self.record.get('status', ''),
+            self.WIP: 'wip' if self.record.get('work_in_progress', False) else '',
         }
 
     def get_default_description(self):

--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -25,7 +25,7 @@ class GerritIssue(Issue):
     BRANCH = 'gerritbranch'
     TOPIC = 'gerrittopic'
     STATUS = 'gerritstatus'
-    WIP = 'gerritwip'
+    WORK_IN_PROGRESS = 'gerritwip'
 
     UDAS = {
         SUMMARY: {
@@ -52,8 +52,8 @@ class GerritIssue(Issue):
             'type': 'string',
             'label': 'Gerrit Status',
         },
-        WIP: {
-            'type': 'string',
+        WORK_IN_PROGRESS: {
+            'type': 'numeric',
             'label': 'Gerrit Work in Progress',
         },
     }
@@ -72,7 +72,7 @@ class GerritIssue(Issue):
             self.BRANCH: self.record['branch'],
             self.TOPIC: self.record.get('topic', 'notopic'),
             self.STATUS: self.record.get('status', ''),
-            self.WIP: 'wip' if self.record.get('work_in_progress', False) else '',
+            self.WORK_IN_PROGRESS: int(self.record.get('work_in_progress', 0)),
         }
 
     def get_default_description(self):

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -263,7 +263,7 @@ class GithubIssue(Issue):
             'label': 'GitHub State',
         },
         DRAFT: {
-            'type': 'string',
+            'type': 'numeric',
             'label': 'GitHub Draft',
         },
     }
@@ -299,7 +299,7 @@ class GithubIssue(Issue):
             self.CLOSED_AT: closed,
             self.NAMESPACE: self.extra['namespace'],
             self.STATE: self.record.get('state', ''),
-            self.DRAFT: 'draft' if self.record.get('draft', False) else '',
+            self.DRAFT: int(self.record.get('draft', 0)),
         }
 
     def get_tags(self):

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -207,6 +207,7 @@ class GithubIssue(Issue):
     USER = 'githubuser'
     NAMESPACE = 'githubnamespace'
     STATE = 'githubstate'
+    DRAFT = 'githubdraft'
 
     UDAS = {
         TITLE: {
@@ -260,7 +261,11 @@ class GithubIssue(Issue):
         STATE: {
             'type': 'string',
             'label': 'GitHub State',
-        }
+        },
+        DRAFT: {
+            'type': 'string',
+            'label': 'GitHub Draft',
+        },
     }
     UNIQUE_KEY = (URL, TYPE,)
 
@@ -293,7 +298,8 @@ class GithubIssue(Issue):
             self.UPDATED_AT: updated,
             self.CLOSED_AT: closed,
             self.NAMESPACE: self.extra['namespace'],
-            self.STATE: self.record.get('state', '')
+            self.STATE: self.record.get('state', ''),
+            self.DRAFT: 'draft' if self.record.get('draft', False) else '',
         }
 
     def get_tags(self):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -227,7 +227,7 @@ class TestUDAs(ConfigTest):
             'uda.githubcreatedon.label=Github Created',
             'uda.githubcreatedon.type=date',
             'uda.githubdraft.label=GitHub Draft',
-            'uda.githubdraft.type=string',
+            'uda.githubdraft.type=numeric',
             'uda.githubmilestone.label=Github Milestone',
             'uda.githubmilestone.type=string',
             'uda.githubnamespace.label=Github Namespace',

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -226,6 +226,8 @@ class TestUDAs(ConfigTest):
             'uda.githubclosedon.type=date',
             'uda.githubcreatedon.label=Github Created',
             'uda.githubcreatedon.type=date',
+            'uda.githubdraft.label=GitHub Draft',
+            'uda.githubdraft.type=string',
             'uda.githubmilestone.label=Github Milestone',
             'uda.githubmilestone.type=string',
             'uda.githubnamespace.label=Github Namespace',

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -19,6 +19,8 @@ class TestGerritIssue(AbstractServiceTest, ServiceTest):
         '_number': 1,
         'branch': 'master',
         'topic': 'test-topic',
+        'status': 'new',
+        'work_in_progress': True,
         'subject': 'this is a title',
         'messages': [{'author': {'username': 'Iam Author'},
                       'message': 'this is a message',
@@ -50,10 +52,12 @@ class TestGerritIssue(AbstractServiceTest, ServiceTest):
             'priority': 'M',
             'project': 'nova',
             'gerritid': 1,
+            'gerritstatus': 'new',
             'gerritsummary': 'this is a title',
             'gerriturl': 'this is a url',
             'gerritbranch': 'master',
             'gerrittopic': 'test-topic',
+            'gerritwip': 'wip',
             'tags': [],
         }
 
@@ -73,9 +77,11 @@ class TestGerritIssue(AbstractServiceTest, ServiceTest):
             'description': '(bw)PR#1 - this is a title .. https://one.com/#/c/1/',
             'gerritid': 1,
             'gerritsummary': 'this is a title',
+            'gerritstatus': 'new',
             'gerriturl': 'https://one.com/#/c/1/',
             'gerritbranch': 'master',
             'gerrittopic': 'test-topic',
+            'gerritwip': 'wip',
             'priority': 'M',
             'project': 'nova',
             'tags': []}

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -20,11 +20,18 @@ class TestGerritIssue(AbstractServiceTest, ServiceTest):
         'branch': 'master',
         'topic': 'test-topic',
         'status': 'new',
-        'work_in_progress': True,
+        'work_in_progress': False,
         'subject': 'this is a title',
         'messages': [{'author': {'username': 'Iam Author'},
                       'message': 'this is a message',
                       '_revision_number': 1}],
+    }
+
+    extra = {
+        'annotations': [
+            # TODO - test annotations?
+        ],
+        'url': 'https://one.com/#/c/1/',
     }
 
     def setUp(self):
@@ -38,14 +45,7 @@ class TestGerritIssue(AbstractServiceTest, ServiceTest):
             self.service = self.get_mock_service(GerritService)
 
     def test_to_taskwarrior(self):
-        extra = {
-            'annotations': [
-                # TODO - test annotations?
-            ],
-            'url': 'this is a url',
-        }
-
-        issue = self.service.get_issue_for_record(self.record, extra)
+        issue = self.service.get_issue_for_record(self.record, self.extra)
         actual = issue.to_taskwarrior()
         expected = {
             'annotations': [],
@@ -54,14 +54,35 @@ class TestGerritIssue(AbstractServiceTest, ServiceTest):
             'gerritid': 1,
             'gerritstatus': 'new',
             'gerritsummary': 'this is a title',
-            'gerriturl': 'this is a url',
+            'gerriturl': 'https://one.com/#/c/1/',
             'gerritbranch': 'master',
             'gerrittopic': 'test-topic',
-            'gerritwip': 'wip',
+            'gerritwip': 0,
             'tags': [],
         }
 
         self.assertEqual(actual, expected)
+
+    def test_work_in_progress(self):
+        wip_record = dict(self.record)  # make a copy of the dict
+        wip_record['work_in_progress'] = True
+        issue = self.service.get_issue_for_record(wip_record, self.extra)
+
+        expected = {
+            'annotations': [],
+            'description': '(bw)PR#1 - this is a title .. https://one.com/#/c/1/',
+            'gerritid': 1,
+            'gerritsummary': 'this is a title',
+            'gerritstatus': 'new',
+            'gerriturl': 'https://one.com/#/c/1/',
+            'gerritbranch': 'master',
+            'gerrittopic': 'test-topic',
+            'gerritwip': 1,
+            'priority': 'M',
+            'project': 'nova',
+            'tags': []}
+
+        self.assertEqual(issue.get_taskwarrior_record(), expected)
 
     @responses.activate
     def test_issues(self):
@@ -81,7 +102,7 @@ class TestGerritIssue(AbstractServiceTest, ServiceTest):
             'gerriturl': 'https://one.com/#/c/1/',
             'gerritbranch': 'master',
             'gerrittopic': 'test-topic',
-            'gerritwip': 'wip',
+            'gerritwip': 0,
             'priority': 'M',
             'project': 'nova',
             'tags': []}

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -32,7 +32,7 @@ ARBITRARY_ISSUE = {
     'updated_at': ARBITRARY_UPDATED.isoformat(),
     'repo': 'arbitrary_username/arbitrary_repo',
     'state': 'closed',
-    'draft': True,
+    'draft': False,
 }
 ARBITRARY_EXTRA = {
     'project': 'one',
@@ -52,6 +52,41 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
         'username': 'arbitrary_username',
     }
 
+    def test_draft(self):
+        service = self.get_mock_service(GithubService)
+        draft = dict(ARBITRARY_ISSUE)
+        draft['draft'] = True
+        issue = service.get_issue_for_record(
+            draft,
+            ARBITRARY_EXTRA
+        )
+
+        expected = {
+            'annotations': [],
+            'description': '(bw)Is#10 - Hallo .. https://github.com/arbitrary_username/arbitrary_repo/pull/1',  # noqa: E501
+            'entry': ARBITRARY_CREATED,
+            'end': ARBITRARY_CLOSED,
+            'githubbody': draft['body'],
+            'githubcreatedon': ARBITRARY_CREATED,
+            'githubclosedon': ARBITRARY_CLOSED,
+            'githubdraft': int(draft['draft']),
+            'githubmilestone': draft['milestone']['title'],
+            'githubnamespace': draft['repo'].split('/')[0],
+            'githubnumber': draft['number'],
+            'githubrepo': draft['repo'],
+            'githubtitle': draft['title'],
+            'githubtype': 'issue',
+            'githubupdatedat': ARBITRARY_UPDATED,
+            'githuburl': draft['html_url'],
+            'githubuser': draft['user']['login'],
+            'githubstate': draft['state'],
+            'priority': 'M',
+            'project': ARBITRARY_EXTRA['project'],
+            'tags': []
+        }
+
+        self.assertEqual(issue.get_taskwarrior_record(), expected)
+
     def test_to_taskwarrior(self):
         service = self.get_mock_service(GithubService, config_overrides={
             'import_labels_as_tags': True})
@@ -69,6 +104,7 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
             'end': ARBITRARY_CLOSED,
             issue.URL: ARBITRARY_ISSUE['html_url'],
             issue.REPO: ARBITRARY_ISSUE['repo'],
+            issue.DRAFT: ARBITRARY_ISSUE['draft'],
             issue.TYPE: ARBITRARY_EXTRA['type'],
             issue.TITLE: ARBITRARY_ISSUE['title'],
             issue.NUMBER: ARBITRARY_ISSUE['number'],
@@ -80,7 +116,6 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
             issue.USER: ARBITRARY_ISSUE['user']['login'],
             issue.NAMESPACE: 'arbitrary_username',
             issue.STATE: 'closed',
-            issue.DRAFT: 'draft',
         }
         actual_output = issue.to_taskwarrior()
 
@@ -128,7 +163,7 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
             'githubbody': 'Something',
             'githubcreatedon': ARBITRARY_CREATED,
             'githubclosedon': ARBITRARY_CLOSED,
-            'githubdraft': 'draft',
+            'githubdraft': 0,
             'githubmilestone': 'alpha',
             'githubnamespace': 'arbitrary_username',
             'githubnumber': 10,
@@ -188,7 +223,7 @@ class TestGithubIssueQuery(AbstractServiceTest, ServiceTest):
             'githubbody': 'Something',
             'githubcreatedon': ARBITRARY_CREATED,
             'githubclosedon': ARBITRARY_CLOSED,
-            'githubdraft': 'draft',
+            'githubdraft': 0,
             'githubmilestone': 'alpha',
             'githubnamespace': 'arbitrary_username',
             'githubnumber': 10,

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -31,7 +31,8 @@ ARBITRARY_ISSUE = {
     'closed_at': ARBITRARY_CLOSED.isoformat(),
     'updated_at': ARBITRARY_UPDATED.isoformat(),
     'repo': 'arbitrary_username/arbitrary_repo',
-    'state': 'closed'
+    'state': 'closed',
+    'draft': True,
 }
 ARBITRARY_EXTRA = {
     'project': 'one',
@@ -79,6 +80,7 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
             issue.USER: ARBITRARY_ISSUE['user']['login'],
             issue.NAMESPACE: 'arbitrary_username',
             issue.STATE: 'closed',
+            issue.DRAFT: 'draft',
         }
         actual_output = issue.to_taskwarrior()
 
@@ -126,6 +128,7 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
             'githubbody': 'Something',
             'githubcreatedon': ARBITRARY_CREATED,
             'githubclosedon': ARBITRARY_CLOSED,
+            'githubdraft': 'draft',
             'githubmilestone': 'alpha',
             'githubnamespace': 'arbitrary_username',
             'githubnumber': 10,
@@ -185,6 +188,7 @@ class TestGithubIssueQuery(AbstractServiceTest, ServiceTest):
             'githubbody': 'Something',
             'githubcreatedon': ARBITRARY_CREATED,
             'githubclosedon': ARBITRARY_CLOSED,
+            'githubdraft': 'draft',
             'githubmilestone': 'alpha',
             'githubnamespace': 'arbitrary_username',
             'githubnumber': 10,


### PR DESCRIPTION
A draft pull request is identified by a different `draft` boolean flag, not by the `state` field, but it might be an important field to display.