### PR TITLE
Add ability to ignore certain users comments

### DIFF
--- a/bugwarrior/docs/services/gerrit.rst
+++ b/bugwarrior/docs/services/gerrit.rst
@@ -45,6 +45,19 @@ For example:
 
     gerrit.query = is:open+((reviewer:self+-owner:self+-is:ignored)+OR+assignee:self)
 
+
+Synchronizing Issue Content
++++++++++++++++++++++++++++
+
+This service synchronizes fields to UDAs, as described below.
+Comments are synchronized as annotations.
+
+To limit the amount of content synchronized into TaskWarrior (which can help to avoid issues with synchronization), use
+
+ * ``annotation_comments=False`` (a global configuration) to disable synchronizing comments to annotations; and
+ * ``ignore_user_comments=<comma separated list>`` in the ``[gerrit]`` section to filter out (e.g. automated) comments turning into annotations if ``annotation_comments`` is on
+
+
 Provided UDA Fields
 -------------------
 

--- a/bugwarrior/docs/services/github.rst
+++ b/bugwarrior/docs/services/github.rst
@@ -199,7 +199,8 @@ Comments are synchronized as annotations.
 To limit the amount of content synchronized into TaskWarrior (which can help to avoid issues with synchronization), use
 
  * ``annotation_comments=False`` (a global configuration) to disable synchronizing comments to annotations; and
- * either ``body_length``` to limit the size of the Github Body UDA or include ``githubbody`` in ``static_fields`` in the ``[general]`` section to eliminate the UDA entirely.
+ * either ``body_length`` to limit the size of the Github Body UDA or include ``githubbody`` in ``static_fields`` in the ``[general]`` section to eliminate the UDA entirely.
+ * ``ignore_user_comments=<comma separated list>`` in the ``[github]`` section to filter out (e.g. automated) comments turning into annotations if ``annotation_comments`` is on
 
 Including Project Owner in Project Name
 +++++++++++++++++++++++++++++++++++++++

--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -148,7 +148,6 @@ class GerritService(Service, Client):
                     break
             else:
                 username = item['author']['_account_id']
-            # Gerrit messages are really messy
             if username in self.config.ignore_user_comments:
                 log.debug(" ignoring comment from %s", username)
                 continue

--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -6,6 +6,9 @@ import requests
 from bugwarrior import config
 from bugwarrior.services import Service, Issue, Client
 
+import logging
+log = logging.getLogger(__name__)
+
 
 class GerritConfig(config.ServiceConfig):
     service: typing.Literal['gerrit']
@@ -15,6 +18,7 @@ class GerritConfig(config.ServiceConfig):
 
     ssl_ca_path: typing.Optional[config.ExpandedPath] = None
     query: str = 'is:open+is:reviewer'
+    ignore_user_comments: config.ConfigList = config.ConfigList([])
 
 
 class GerritIssue(Issue):
@@ -145,6 +149,9 @@ class GerritService(Service, Client):
             else:
                 username = item['author']['_account_id']
             # Gerrit messages are really messy
+            if username in self.config.ignore_user_comments:
+                log.debug(" ignoring comment from %s", username)
+                continue
             message = item['message']\
                 .lstrip('Patch Set ')\
                 .lstrip("%s:" % item['_revision_number'])\

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -40,6 +40,7 @@ class GithubConfig(config.ServiceConfig):
     body_length: int = sys.maxsize
     project_owner_prefix: bool = False
     issue_urls: config.ConfigList = config.ConfigList([])
+    ignore_user_comments: config.ConfigList = config.ConfigList([])
 
     @pydantic.v1.root_validator
     def deprecate_password(cls, values):
@@ -389,11 +390,20 @@ class GithubService(Service):
         if self.main_config.annotation_comments:
             comments = self._comments(tag, issue['number'])
             log.debug(" got comments for %s", issue['html_url'])
-            annotations = ((
-                c['user']['login'],
-                c['body'],
-            ) for c in comments)
-        return self.build_annotations(annotations, url)
+            annotations = []
+            for c in comments:
+                login = c['user']['login']
+                if login in self.config.ignore_user_comments:
+                    log.debug(" ignoring comment from %s", login)
+                    continue
+                annotations.append((
+                    login,
+                    c['body'],
+                ))
+        return self.build_annotations(
+            annotations,
+            url
+        )
 
     def body(self, issue):
         body = issue['body']

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -14,6 +14,7 @@ class TestGerritIssue(AbstractServiceTest, ServiceTest):
         'base_uri': 'https://one.com',
         'username': 'two',
         'password': 'three',
+        'ignore_user_comments': ['CI Bot'],
     }
 
     record = {
@@ -26,6 +27,9 @@ class TestGerritIssue(AbstractServiceTest, ServiceTest):
         'subject': 'this is a title',
         'messages': [{'author': {'username': 'Iam Author'},
                       'message': 'this is a message',
+                      '_revision_number': 1},
+                     {'author': {'username': 'CI Bot'},
+                      'message': 'ignore me please',
                       '_revision_number': 1}],
     }
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -42,6 +42,10 @@ ARBITRARY_EXTRA = {
     'body': 'Something',
     'namespace': 'arbitrary_username',
 }
+IGNORABLE = {
+    'user': {'login': 'cibot'},
+    'body': 'Ignore this comment.'
+}
 
 
 class TestGithubIssue(AbstractServiceTest, ServiceTest):
@@ -51,6 +55,7 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
         'login': 'arbitrary_login',
         'token': 'arbitrary_token',
         'username': 'arbitrary_username',
+        'ignore_user_comments': [IGNORABLE['user']['login']],
     }
 
     def test_draft(self):
@@ -151,7 +156,7 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
             json=[{
                 'user': {'login': 'arbitrary_login'},
                 'body': 'Arbitrary comment.'
-            }])
+            }, IGNORABLE])  # second comment should be ignored and still pass
 
         service = self.get_mock_service(GithubService)
         issue = next(service.issues())
@@ -248,7 +253,6 @@ class TestGithubService(ServiceTest):
         'login': 'tintin',
         'username': 'milou',
         'token': 't0ps3cr3t',
-
     }
 
     def test_token_authorization_header(self):


### PR DESCRIPTION
Some build/CI systems can become too noisy, you still want to pull real people's comments and ignore bot accounts when adding annotations.