### PR TITLE
fix: correct Git repo owner in getting-started.rst

### DIFF
--- a/bugwarrior/docs/contributing/getting-started.rst
+++ b/bugwarrior/docs/contributing/getting-started.rst
@@ -34,7 +34,7 @@ Next step -- get the code!
 
 ::
 
-    (bugwarrior)$ git clone git@github.com:ralphbean/bugwarrior.git
+    (bugwarrior)$ git clone git@github.com:GothenburgBitFactory/bugwarrior.git
     (bugwarrior)$ cd bugwarrior
     (bugwarrior)$ pip install -e .[all]
     (bugwarrior)$ which bugwarrior


### PR DESCRIPTION
The getting started docs at https://bugwarrior.readthedocs.io/en/latest/contributing/getting-started.html still have ralphbeans as the owner not @GothenburgBitFactory  - this small PR corrects that