### PR TITLE
Use exit code 1 on failure when pulling

### DIFF
--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -117,6 +117,7 @@ def pull(dry_run, flavor, interactive, debug, quiet):
                 lockfile_path
             )
         )
+        sys.exit(1)
     except RuntimeError as e:
         log.exception("Aborted (%s)" % e)
 

--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -120,6 +120,7 @@ def pull(dry_run, flavor, interactive, debug, quiet):
         sys.exit(1)
     except RuntimeError as e:
         log.exception("Aborted (%s)" % e)
+        sys.exit(1)
 
 
 @cli.group()


### PR DESCRIPTION
Currently, the `pull` command returns 0 even when a failure occurred.

My usecase is having this running in a systemd timer job and every now and then it happens, that I shutdown my machine while there is a pull command running. This results in a lockfile being present which prevent future runs from succeeding.

However, since that case is [caught in an exception](https://github.com/GothenburgBitFactory/bugwarrior/blob/71efc97435a442646782dcb0979df43f69ce955d/bugwarrior/command.py#L112) there is the error output, but the job itself returns success (exit code 0).

This PR exits with code 1 as done in [`_try_load_config`](https://github.com/GothenburgBitFactory/bugwarrior/blob/71efc97435a442646782dcb0979df43f69ce955d/bugwarrior/command.py#L44), as this was the simplest to implement. Maybe a nicer approach would be to raise a `SystemExit` instead but that will not directly put it to the critical log. Please let me know what you would prefer.