### PR TITLE
Issue.get_default_description: delete docstring

### DIFF
--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -171,15 +171,6 @@ class Issue(abc.ABC):
 
     @abc.abstractmethod
     def get_default_description(self):
-        """ Return the old-style verbose description from bugwarrior.
-
-        This is useful for two purposes:
-
-        * Finding and linking historically-created records.
-        * Allowing people to keep using the historical description
-          for taskwarrior.
-
-        """
         raise NotImplementedError()
 
     def get_tags_from_labels(self,


### PR DESCRIPTION
The docstring is basically entirely false now:
- It's not really "old-style" or historical, it is still the present default.
- It is not used to link records, Issue.UNIQUE_KEY does that.