### PR TITLE
Break TaskConstructor out of base Issue class.

### DIFF
--- a/bugwarrior/docs/contributing/new-service.rst
+++ b/bugwarrior/docs/contributing/new-service.rst
@@ -264,7 +264,7 @@ Create a test file and implement at least the minimal service tests by inheritin
 
           expected = { ... }
 
-          self.assertEqual(issue.get_taskwarrior_record(), expected)
+          self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
 
 9. Documentation
 ------------------

--- a/tests/test_activecollab.py
+++ b/tests/test_activecollab.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pypandoc
 import pytz
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.activecollab import (
     ActiveCollabService
 )
@@ -141,4 +142,4 @@ class TestActiveCollabIssues(AbstractServiceTest, ServiceTest):
             'project': 'something',
             'tags': []}
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)

--- a/tests/test_activecollab2.py
+++ b/tests/test_activecollab2.py
@@ -4,6 +4,7 @@ import datetime
 import pytz
 import responses
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.activecollab2 import ActiveCollab2Service
 
 from .base import ServiceTest, AbstractServiceTest
@@ -97,4 +98,4 @@ class TestActiveCollab2Issue(AbstractServiceTest, ServiceTest):
             'project': 'something',
             'tags': []}
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)

--- a/tests/test_azuredevops.py
+++ b/tests/test_azuredevops.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from dateutil.tz.tz import tzutc
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.azuredevops import (
     AzureDevopsService,
     striphtml,
@@ -230,7 +231,7 @@ class TestAzureDevopsService(AbstractServiceTest, ServiceTest):
             "tags": []
         }
         issue = next(self.service.issues())
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
 
     def test_issues_wiql_filter(self):
         expected = {
@@ -255,4 +256,4 @@ class TestAzureDevopsService(AbstractServiceTest, ServiceTest):
         }
         service = self.get_service(config_overrides={'wiql_filter': 'something'})
         issue = next(service.issues())
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)

--- a/tests/test_bitbucket.py
+++ b/tests/test_bitbucket.py
@@ -1,5 +1,6 @@
 import responses
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.bitbucket import BitbucketService
 
 from .base import ServiceTest, AbstractServiceTest
@@ -104,7 +105,7 @@ class TestBitbucketIssue(AbstractServiceTest, ServiceTest):
             'project': 'somerepo',
             'tags': []}
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected_issue)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected_issue)
 
         expected_pr = {
             'annotations': ['@nobody - Some comment.'],
@@ -116,7 +117,7 @@ class TestBitbucketIssue(AbstractServiceTest, ServiceTest):
             'project': 'somerepo',
             'tags': []}
 
-        self.assertEqual(pr.get_taskwarrior_record(), expected_pr)
+        self.assertEqual(TaskConstructor(pr).get_taskwarrior_record(), expected_pr)
 
     def test_get_owner(self):
         issue = {

--- a/tests/test_bts.py
+++ b/tests/test_bts.py
@@ -1,6 +1,8 @@
 import sys
 from unittest import mock, SkipTest
 
+from bugwarrior.collect import TaskConstructor
+
 if sys.version_info >= (3, 11):
     raise SkipTest(
         "Python-3.11+ not supported. "
@@ -89,4 +91,4 @@ class TestBTSService(AbstractServiceTest, ServiceTest):
             'btsstatus': 'pending',
             'tags': []}
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -2,6 +2,7 @@ import datetime
 from unittest import mock
 from collections import namedtuple
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.bz import BugzillaService
 
 from .base import ConfigTest, ServiceTest, AbstractServiceTest
@@ -155,7 +156,7 @@ class TestBugzillaService(AbstractServiceTest, ServiceTest):
             'project': 'Something',
             'tags': []}
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
 
     def test_only_if_assigned(self):
         with mock.patch('bugzilla.Bugzilla'):
@@ -206,7 +207,7 @@ class TestBugzillaService(AbstractServiceTest, ServiceTest):
             'project': 'Something',
             'tags': []}
 
-        self.assertEqual(next(issues).get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(next(issues)).get_taskwarrior_record(), expected)
 
         # Only one issue is assigned.
         self.assertRaises(StopIteration, lambda: next(issues))
@@ -246,9 +247,9 @@ class TestBugzillaService(AbstractServiceTest, ServiceTest):
 
         issues = self.service.issues()
 
-        self.assertIn(next(issues).get_taskwarrior_record()['bugzillabugid'],
+        self.assertIn(TaskConstructor(next(issues)).get_taskwarrior_record()['bugzillabugid'],
                       [1234567, 1234568])
-        self.assertIn(next(issues).get_taskwarrior_record()['bugzillabugid'],
+        self.assertIn(TaskConstructor(next(issues)).get_taskwarrior_record()['bugzillabugid'],
                       [1234567, 1234568])
         # Only two issues are assigned to the user or unassigned.
         self.assertRaises(StopIteration, lambda: next(issues))

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -4,7 +4,9 @@ from unittest import mock
 import pydantic
 from dateutil.tz import tzutc
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.deck import NextcloudDeckClient, NextcloudDeckService
+
 from .base import AbstractServiceTest, ServiceTest
 
 
@@ -157,7 +159,7 @@ class TestNextcloudDeckIssue(AbstractServiceTest, ServiceTest):
             'tags': ['Later']
         }
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
 
     def test_filter_boards_include(self):
         self.config['deck']['include_board_ids'] = '5'

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -2,7 +2,9 @@ import json
 
 import responses
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.gerrit import GerritService
+
 from .base import ServiceTest, AbstractServiceTest
 
 
@@ -82,7 +84,7 @@ class TestGerritIssue(AbstractServiceTest, ServiceTest):
             'project': 'nova',
             'tags': []}
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
 
     @responses.activate
     def test_issues(self):
@@ -107,4 +109,4 @@ class TestGerritIssue(AbstractServiceTest, ServiceTest):
             'project': 'nova',
             'tags': []}
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)

--- a/tests/test_gitbug.py
+++ b/tests/test_gitbug.py
@@ -4,6 +4,7 @@ from unittest import mock
 import dateutil
 import pydantic
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.gitbug import GitBugClient, GitBugConfig, GitBugService
 
 from .base import AbstractServiceTest, ConfigTest, ServiceTest
@@ -82,7 +83,7 @@ class TestGitBugIssue(AbstractServiceTest, ServiceTest):
             'tags': []
         }
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
 
 
 class TestGitBugConfig(ConfigTest):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 import pytz
 import responses
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.github import (
     GithubConfig, GithubService, GithubClient)
 
@@ -85,7 +86,7 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
             'tags': []
         }
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
 
     def test_to_taskwarrior(self):
         service = self.get_mock_service(GithubService, config_overrides={
@@ -178,7 +179,7 @@ class TestGithubIssue(AbstractServiceTest, ServiceTest):
             'project': 'arbitrary_repo',
             'tags': []}
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
 
 
 class TestGithubIssueQuery(AbstractServiceTest, ServiceTest):
@@ -238,7 +239,7 @@ class TestGithubIssueQuery(AbstractServiceTest, ServiceTest):
             'project': 'arbitrary_repo',
             'tags': []}
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
 
 
 class TestGithubService(ServiceTest):

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -3,6 +3,7 @@ import datetime
 import pytz
 import responses
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.gitlab import GitlabService, GitlabClient
 
 from .base import ConfigTest, ServiceTest, AbstractServiceTest
@@ -873,7 +874,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
             'priority': 'M',
             'project': 'arbitrary_username/project',
             'tags': []}
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
 
     @responses.activate
     def test_mrs_from_query(self):
@@ -933,7 +934,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
             'priority': 'M',
             'project': 'arbitrary_username/project',
             'tags': []}
-        self.assertEqual(mr.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(mr).get_taskwarrior_record(), expected)
 
     @responses.activate
     def test_todos_from_query(self):
@@ -997,7 +998,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
             'priority': 'M',
             'project': 'project',
             'tags': []}
-        self.assertEqual(todo.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(todo).get_taskwarrior_record(), expected)
 
         overrides = {
             'include_issues': 'false',
@@ -1008,7 +1009,7 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
         }
         service = self.get_mock_service(GitlabService, config_overrides=overrides)
         todo = next(service.issues())
-        self.assertEqual(todo.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(todo).get_taskwarrior_record(), expected)
 
     @responses.activate
     def test_issues(self):
@@ -1065,4 +1066,4 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
             'project': 'arbitrary_username/project',
             'tags': []}
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from dateutil.tz import tzutc
 from google.oauth2.credentials import Credentials
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services import gmail
 
 from .base import AbstractServiceTest, ConfigTest, ServiceTest
@@ -167,7 +168,7 @@ class TestGmailIssue(AbstractServiceTest, ServiceTest):
             'gmaillabels': 'CATEGORY_PERSONAL IMPORTANT postit sticky',
             'gmaillastsenderaddr': 'foobar@example.com'}
 
-        taskwarrior = issue.get_taskwarrior_record()
+        taskwarrior = TaskConstructor(issue).get_taskwarrior_record()
         taskwarrior['tags'] = set(taskwarrior['tags'])
 
         self.assertEqual(taskwarrior, expected)

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -4,6 +4,7 @@ from unittest import mock
 from dateutil.tz import datetime
 from dateutil.tz.tz import tzutc
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.config import schema
 from bugwarrior.services.jira import JiraExtraFields, JiraService
 
@@ -240,7 +241,7 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
             'project': 'DONUT',
             'tags': []}
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
 
     def test_get_due(self):
         issue = self.service.get_issue_for_record(

--- a/tests/test_kanboard.py
+++ b/tests/test_kanboard.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from dateutil.tz.tz import tzutc
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.kanboard import KanboardService
 
 from .base import AbstractServiceTest, ConfigTest, ServiceTest
@@ -231,4 +232,4 @@ class TestKanboardService(AbstractServiceTest, ServiceTest):
             "priority": "M",  # default priority
         }
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)

--- a/tests/test_logseq.py
+++ b/tests/test_logseq.py
@@ -1,7 +1,9 @@
 from unittest import mock
 
-from .base import AbstractServiceTest, ServiceTest
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.logseq import LogseqService, LogseqClient
+
+from .base import AbstractServiceTest, ServiceTest
 
 
 class TestLogseqIssue(AbstractServiceTest, ServiceTest):
@@ -97,4 +99,4 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
             issue.URI: "logseq://graph/Test?block-id=66699a83-3ee0-4edc-81c6-a24c9b80bec6",
         }
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)

--- a/tests/test_pivotaltracker.py
+++ b/tests/test_pivotaltracker.py
@@ -3,6 +3,7 @@ import datetime
 from dateutil.tz import tzutc
 import responses
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.pivotaltracker import PivotalTrackerService
 
 from .base import ServiceTest, AbstractServiceTest, ConfigTest
@@ -354,4 +355,4 @@ class TestPivotalTrackerIssue(AbstractServiceTest, ServiceTest):
             'project': 'death_star',
             'tags': ['look_sir_metal']
         }
-        self.assertEqual(story.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(story).get_taskwarrior_record(), expected)

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -4,6 +4,7 @@ from unittest import mock
 import dateutil
 import responses
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.redmine import RedMineService
 
 from .base import ServiceTest, AbstractServiceTest
@@ -126,4 +127,4 @@ class TestRedmineIssue(AbstractServiceTest, ServiceTest):
             'redmineurl': 'https://something/issues/363901',
             'tags': []}
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)

--- a/tests/test_taiga.py
+++ b/tests/test_taiga.py
@@ -1,5 +1,6 @@
 import responses
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.taiga import TaigaService
 
 from .base import ServiceTest, AbstractServiceTest
@@ -91,4 +92,4 @@ class TestTaigaIssue(AbstractServiceTest, ServiceTest):
             'taigasummary': 'this is a title',
             'taigaurl': 'https://one/project/something/us/40'}
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)

--- a/tests/test_teamlab.py
+++ b/tests/test_teamlab.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import responses
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.teamlab import TeamLabService
 
 from .base import ServiceTest, AbstractServiceTest
@@ -73,4 +74,4 @@ class TestTeamlabIssue(AbstractServiceTest, ServiceTest):
             'teamlaburl':
                 'http://something/products/projects/tasks.aspx?prjID=140&id=10'}
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)

--- a/tests/test_teamwork_projects.py
+++ b/tests/test_teamwork_projects.py
@@ -1,9 +1,11 @@
-from .base import ServiceTest, AbstractServiceTest
-from bugwarrior.services.teamwork_projects import TeamworkService
-
 import responses
 import datetime
 from dateutil.tz import tzutc
+
+from bugwarrior.collect import TaskConstructor
+from bugwarrior.services.teamwork_projects import TeamworkService
+
+from .base import ServiceTest, AbstractServiceTest
 
 
 class TestTeamworkIssue(AbstractServiceTest, ServiceTest):
@@ -136,5 +138,5 @@ class TestTeamworkIssue(AbstractServiceTest, ServiceTest):
         }
         issue.user_id = "5"
         issue.name = "Greg McCoy"
-        self.assertEqual(issue.get_taskwarrior_record(), expected_data)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected_data)
         self.assertEqual(issue.get_owner(), "Greg McCoy")

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,6 +1,7 @@
 from .base import ServiceTest
 from .test_service import DumbIssue
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.config.schema import ServiceConfig, MainSectionConfig
 
 
@@ -37,7 +38,7 @@ class TestTemplates(ServiceTest):
     def test_default_taskwarrior_record(self):
         issue = self.get_issue({})
 
-        record = issue.get_taskwarrior_record()
+        record = TaskConstructor(issue).get_taskwarrior_record()
         expected_record = self.arbitrary_issue.copy()
         expected_record.update({
             'description': self.arbitrary_default_description,
@@ -53,7 +54,7 @@ class TestTemplates(ServiceTest):
             'description': description_template
         })
 
-        record = issue.get_taskwarrior_record()
+        record = TaskConstructor(issue).get_taskwarrior_record()
         expected_record = self.arbitrary_issue.copy()
         expected_record.update({
             'description': '%s - %s' % (
@@ -72,7 +73,7 @@ class TestTemplates(ServiceTest):
             'project': project_template
         })
 
-        record = issue.get_taskwarrior_record()
+        record = TaskConstructor(issue).get_taskwarrior_record()
         expected_record = self.arbitrary_issue.copy()
         expected_record.update({
             'description': self.arbitrary_default_description,
@@ -85,7 +86,7 @@ class TestTemplates(ServiceTest):
     def test_tag_templates(self):
         issue = self.get_issue(add_tags=['one', '{{ project }}'])
 
-        record = issue.get_taskwarrior_record()
+        record = TaskConstructor(issue).get_taskwarrior_record()
         expected_record = self.arbitrary_issue.copy()
         expected_record.update({
             'description': self.arbitrary_default_description,

--- a/tests/test_trac.py
+++ b/tests/test_trac.py
@@ -1,3 +1,4 @@
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.trac import TracService
 
 from .base import ServiceTest, AbstractServiceTest
@@ -93,4 +94,4 @@ class TestTracIssue(AbstractServiceTest, ServiceTest):
             'tracurl': 'https://ljlkajsdfl.com/ticket/1',
             'traccomponent': 'testcomponent'}
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)

--- a/tests/test_trello.py
+++ b/tests/test_trello.py
@@ -1,8 +1,9 @@
 from dateutil.parser import parse as parse_date
 import responses
 
-from bugwarrior.services.trello import TrelloConfig, TrelloService, TrelloIssue
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.config.schema import MainSectionConfig
+from bugwarrior.services.trello import TrelloConfig, TrelloService, TrelloIssue
 
 from .base import ConfigTest, ServiceTest
 
@@ -215,7 +216,7 @@ class TestTrelloService(ConfigTest):
                 "@luidgi - Preums",
                 "@mario - Deuz"],
             'tags': []}
-        actual = next(issues).get_taskwarrior_record()
+        actual = TaskConstructor(next(issues)).get_taskwarrior_record()
         self.assertEqual(expected, actual)
 
     maxDiff = None

--- a/tests/test_youtrak.py
+++ b/tests/test_youtrak.py
@@ -1,5 +1,6 @@
 import responses
 
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.youtrack import YoutrackService
 
 from .base import ConfigTest, ServiceTest, AbstractServiceTest
@@ -101,4 +102,4 @@ class TestYoutrackIssue(AbstractServiceTest, ServiceTest):
             'youtracknumber': 1,
         }
 
-        self.assertEqual(issue.get_taskwarrior_record(), expected)
+        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)


### PR DESCRIPTION
In preparation for stabilizing the base classes (#791), I'm moving these methods which child classes never need to call to a separate class in the collect module.

We *could* leave them where they are and just make them private methods, but at this point I think slimming down the base classes as much as possible is our best bet to being disciplined about their stabilization. This not only removes lines of code but I believe the entire class of would-be private methods.

I also removed the __str__ and __repr__ methods, which depended on the get_taskwarrior_record method. These used to be used in logging messages in db.synchronize but since #1037 db.synchronize is receiving dict's and not Issue's. (The usages in that method are presently mixed between logging `issue` and logging `issue['description']`. The logs could be improved by switching the remainder to the latter.)