### PR TITLE
Remove get_default_%s instrumentation

### DIFF
--- a/bugwarrior/collect.py
+++ b/bugwarrior/collect.py
@@ -148,6 +148,6 @@ class TaskConstructor:
             if field in self.issue.config.templates:
                 template = Template(self.issue.config.templates[field])
                 record[field] = template.render(self.get_template_context())
-            elif hasattr(self.issue, 'get_default_%s' % field):
-                record[field] = getattr(self.issue, 'get_default_%s' % field)()
+            elif field == 'description':
+                record['description'] = self.issue.get_default_description()
         return record


### PR DESCRIPTION
This allowed services to override any field, but it was never documented and AFAIK never needed for anything other than the description. For everything else, modifying the template has proven sufficient.

This is in progress of minimizing the service API in order to stabilize it, per #791.