### PR TITLE
Remove private/property attributes from Issue

### DIFF
--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -153,13 +153,10 @@ class Issue(abc.ABC):
     PRIORITY_MAP = {}
 
     def __init__(self, foreign_record, config, main_config, extra=None):
-        self._foreign_record = foreign_record
+        self.record = foreign_record
         self.config = config
         self.main_config = main_config
-        self._extra = extra if extra else {}
-
-    def update_extra(self, extra):
-        self._extra.update(extra)
+        self.extra = extra if extra else {}
 
     @abc.abstractmethod
     def to_taskwarrior(self):
@@ -238,14 +235,6 @@ class Issue(abc.ABC):
             url_separator if url else '',
             url,
         )
-
-    @property
-    def record(self):
-        return self._foreign_record
-
-    @property
-    def extra(self):
-        return self._extra
 
 
 class ServiceClient:

--- a/bugwarrior/services/activecollab.py
+++ b/bugwarrior/services/activecollab.py
@@ -247,5 +247,5 @@ class ActiveCollabService(IssueService):
             extra = {
                 'annotations': self.annotations(issue, issue_obj)
             }
-            issue_obj.update_extra(extra)
+            issue_obj.extra.update(extra)
             yield issue_obj

--- a/bugwarrior/services/azuredevops.py
+++ b/bugwarrior/services/azuredevops.py
@@ -246,7 +246,7 @@ class AzureDevopsService(IssueService):
                 "namespace": (
                     f"{self.config.organization}\\{self.config.project}"),
             }
-            issue_obj.update_extra(extra)
+            issue_obj.extra.update(extra)
             yield issue_obj
 
     def get_owner(self, issue):

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -210,7 +210,7 @@ class BitbucketService(IssueService, ServiceClient):
                 'url': url,
                 'annotations': self.get_annotations(tag, issue, issue_obj, url)
             }
-            issue_obj.update_extra(extras)
+            issue_obj.extra.update(extras)
             yield issue_obj
 
         if self.config.include_merge_requests:
@@ -239,5 +239,5 @@ class BitbucketService(IssueService, ServiceClient):
                     'annotations': self.get_annotations(
                         tag, issue, issue_obj, url)
                 }
-                issue_obj.update_extra(extras)
+                issue_obj.extra.update(extras)
                 yield issue_obj

--- a/bugwarrior/services/bts.py
+++ b/bugwarrior/services/bts.py
@@ -228,5 +228,5 @@ class BTSService(IssueService, ServiceClient):
             extra = {
                 'annotations': self.annotations(issue)
             }
-            issue_obj.update_extra(extra)
+            issue_obj.extra.update(extra)
             yield issue_obj

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -302,7 +302,7 @@ class BugzillaService(IssueService):
             else:
                 extra['assigned_on'] = None
 
-            issue_obj.update_extra(extra)
+            issue_obj.extra.update(extra)
             yield issue_obj
 
     def _get_assigned_date(self, issue):

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -498,5 +498,5 @@ class GithubService(IssueService):
                 'body': self.body(issue),
                 'namespace': self.config.username,
             }
-            issue_obj.update_extra(extra)
+            issue_obj.extra.update(extra)
             yield issue_obj

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -620,7 +620,7 @@ class GitlabService(IssueService):
                 'annotations': self.annotations(repo, issue_url, type_plural, issue),
                 'description': self.description(issue),
             }
-            issue_obj.update_extra(extra)
+            issue_obj.extra.update(extra)
             yield issue_obj
 
     def _get_todo_objs(self, todos):
@@ -645,7 +645,7 @@ class GitlabService(IssueService):
                 'type': 'todo',
                 'annotations': [],
             }
-            todo_obj.update_extra(extra)
+            todo_obj.extra.update(extra)
             yield todo_obj
 
     def include(self, issue):

--- a/bugwarrior/services/gmail.py
+++ b/bugwarrior/services/gmail.py
@@ -215,7 +215,7 @@ class GmailService(IssueService):
             extra = {
                 'annotations': self.annotations(issue),
             }
-            issue.update_extra(extra)
+            issue.extra.update(extra)
             yield issue
 
 

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -456,5 +456,5 @@ class JiraService(IssueService):
                 extra.update({
                     'annotations': self.annotations(case, issue)
                 })
-            issue.update_extra(extra)
+            issue.extra.update(extra)
             yield issue

--- a/bugwarrior/services/pagure.py
+++ b/bugwarrior/services/pagure.py
@@ -200,5 +200,5 @@ class PagureService(IssueService):
                 'type': 'pull_request' if 'branch' in issue else 'issue',
                 'annotations': self.annotations(issue)
             }
-            issue_obj.update_extra(extra)
+            issue_obj.extra.update(extra)
             yield issue_obj

--- a/bugwarrior/services/teamwork_projects.py
+++ b/bugwarrior/services/teamwork_projects.py
@@ -159,5 +159,5 @@ class TeamworkService(IssueService):
                     "host": self.config.host,
                     'annotations': self.get_comments(issue),
                 }
-                issue_obj.update_extra(extra)
+                issue_obj.extra.update(extra)
                 yield issue_obj

--- a/bugwarrior/services/trac.py
+++ b/bugwarrior/services/trac.py
@@ -170,5 +170,5 @@ class TracService(IssueService):
                 'annotations': self.annotations(issue),
                 'project': project,
             }
-            issue_obj.update_extra(extra)
+            issue_obj.extra.update(extra)
             yield issue_obj

--- a/bugwarrior/services/trello.py
+++ b/bugwarrior/services/trello.py
@@ -102,7 +102,7 @@ class TrelloService(IssueService, ServiceClient):
                 listextra = dict(boardname=board['name'], listname=lst['name'])
                 for card in self.get_cards(lst['id']):
                     issue = self.get_issue_for_record(card, extra=listextra)
-                    issue.update_extra({"annotations": self.annotations(card)})
+                    issue.extra.update({"annotations": self.annotations(card)})
                     yield issue
 
     def annotations(self, card_json):

--- a/tests/test_azuredevops.py
+++ b/tests/test_azuredevops.py
@@ -186,7 +186,7 @@ class TestAzureDevopsService(AbstractServiceTest, ServiceTest):
             "annotations": [],
             "namespace": "test_organization\\test_project",
         }
-        issue.update_extra(extra)
+        issue.extra.update(extra)
 
         expected = {
             issue.TITLE: TEST_ISSUE["fields"]["System.Title"],


### PR DESCRIPTION
AFAIK we've never used these property decorators to diverge behavior from the underlying data structures and they are thus superfluous. We could always reintroduce them if they are needed.

This is to further slim down the base classes in order to stabilize them, per #791.