### PR TITLE
Rename IssueService -> Service, ServiceClient -> Client

### DIFF
--- a/bugwarrior/docs/contributing/new-service.rst
+++ b/bugwarrior/docs/contributing/new-service.rst
@@ -44,7 +44,7 @@ Fire up your favorite editor and import the base classes and whatever library yo
   import typing_extensions
 
   from bugwarrior import config
-  from bugwarrior.services import Service, Issue, ServiceClient
+  from bugwarrior.services import Service, Issue, Client
 
   log = logging.getLogger(__name__)
 
@@ -85,7 +85,7 @@ Unless you're using a library that closely aligns with the needs of your service
 
 .. code:: python
 
-  class GitBugClient(ServiceClient):
+  class GitBugClient(Client):
       def __init__(self, path, port):
           self.path = path
           self.port = port

--- a/bugwarrior/docs/contributing/new-service.rst
+++ b/bugwarrior/docs/contributing/new-service.rst
@@ -44,7 +44,7 @@ Fire up your favorite editor and import the base classes and whatever library yo
   import typing_extensions
 
   from bugwarrior import config
-  from bugwarrior.services import IssueService, Issue, ServiceClient
+  from bugwarrior.services import Service, Issue, ServiceClient
 
   log = logging.getLogger(__name__)
 
@@ -178,7 +178,7 @@ Now for the main service class which bugwarrior will invoke to fetch issues.
 
 .. code:: python
 
-  class GitBugService(IssueService):
+  class GitBugService(Service):
       ISSUE_CLASS = GitBugIssue
       CONFIG_SCHEMA = GitBugConfig
 

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -58,7 +58,7 @@ def get_processed_url(main_config: schema.MainSectionConfig, url: str):
     return url
 
 
-class IssueService(abc.ABC):
+class Service(abc.ABC):
     """ Abstract base class for each service """
     # Which class should this service instantiate for holding these issues?
     ISSUE_CLASS = None

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -266,7 +266,7 @@ class Issue(abc.ABC):
         )
 
 
-class ServiceClient:
+class Client:
     """ Abstract class responsible for making requests to service API's. """
     @staticmethod
     def json_response(response):

--- a/bugwarrior/services/activecollab.py
+++ b/bugwarrior/services/activecollab.py
@@ -3,7 +3,7 @@ import re
 import pypandoc
 from pyac.library import activeCollab
 import typing_extensions
-from bugwarrior.services import IssueService, Issue
+from bugwarrior.services import Service, Issue
 from bugwarrior import config
 
 import logging
@@ -166,7 +166,7 @@ class ActiveCollabIssue(Issue):
         )
 
 
-class ActiveCollabService(IssueService):
+class ActiveCollabService(Service):
     ISSUE_CLASS = ActiveCollabIssue
     CONFIG_SCHEMA = ActiveCollabConfig
 

--- a/bugwarrior/services/activecollab2.py
+++ b/bugwarrior/services/activecollab2.py
@@ -4,7 +4,7 @@ import time
 import requests
 import typing_extensions
 
-from bugwarrior.services import Service, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, Client
 from bugwarrior import config
 
 import logging
@@ -38,7 +38,7 @@ class ActiveCollab2Config(config.ServiceConfig):
     projects: ActiveCollabProjects
 
 
-class ActiveCollab2Client(ServiceClient):
+class ActiveCollab2Client(Client):
     def __init__(self, url, key, user_id, projects, target):
         self.url = url
         self.key = key

--- a/bugwarrior/services/activecollab2.py
+++ b/bugwarrior/services/activecollab2.py
@@ -4,7 +4,7 @@ import time
 import requests
 import typing_extensions
 
-from bugwarrior.services import IssueService, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, ServiceClient
 from bugwarrior import config
 
 import logging
@@ -191,7 +191,7 @@ class ActiveCollab2Issue(Issue):
         )
 
 
-class ActiveCollab2Service(IssueService):
+class ActiveCollab2Service(Service):
     ISSUE_CLASS = ActiveCollab2Issue
     CONFIG_SCHEMA = ActiveCollab2Config
 

--- a/bugwarrior/services/azuredevops.py
+++ b/bugwarrior/services/azuredevops.py
@@ -8,7 +8,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import Service, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, Client
 
 log = logging.getLogger(__name__)
 
@@ -51,7 +51,7 @@ def format_item(item):
     return
 
 
-class AzureDevopsClient(ServiceClient):
+class AzureDevopsClient(Client):
     def __init__(self, pat, org, project, host):
         if pat[0] != ":":
             pat = f":{pat}"

--- a/bugwarrior/services/azuredevops.py
+++ b/bugwarrior/services/azuredevops.py
@@ -8,7 +8,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import IssueService, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, ServiceClient
 
 log = logging.getLogger(__name__)
 
@@ -179,7 +179,7 @@ class AzureDevopsIssue(Issue):
         )
 
 
-class AzureDevopsService(IssueService):
+class AzureDevopsService(Service):
     ISSUE_CLASS = AzureDevopsIssue
     CONFIG_SCHEMA = AzureDevopsConfig
 

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -6,7 +6,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import IssueService, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, ServiceClient
 
 log = logging.getLogger(__name__)
 
@@ -89,7 +89,7 @@ class BitbucketIssue(Issue):
         )
 
 
-class BitbucketService(IssueService, ServiceClient):
+class BitbucketService(Service, ServiceClient):
     ISSUE_CLASS = BitbucketIssue
     CONFIG_SCHEMA = BitbucketConfig
 

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -6,7 +6,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import Service, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, Client
 
 log = logging.getLogger(__name__)
 
@@ -89,7 +89,7 @@ class BitbucketIssue(Issue):
         )
 
 
-class BitbucketService(Service, ServiceClient):
+class BitbucketService(Service, Client):
     ISSUE_CLASS = BitbucketIssue
     CONFIG_SCHEMA = BitbucketConfig
 

--- a/bugwarrior/services/bts.py
+++ b/bugwarrior/services/bts.py
@@ -5,7 +5,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import Issue, IssueService, ServiceClient
+from bugwarrior.services import Issue, Service, ServiceClient
 
 import logging
 log = logging.getLogger(__name__)
@@ -138,7 +138,7 @@ class BTSIssue(Issue):
         )
 
 
-class BTSService(IssueService, ServiceClient):
+class BTSService(Service, ServiceClient):
     ISSUE_CLASS = BTSIssue
     CONFIG_SCHEMA = BTSConfig
 

--- a/bugwarrior/services/bts.py
+++ b/bugwarrior/services/bts.py
@@ -5,7 +5,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import Issue, Service, ServiceClient
+from bugwarrior.services import Issue, Service, Client
 
 import logging
 log = logging.getLogger(__name__)
@@ -138,7 +138,7 @@ class BTSIssue(Issue):
         )
 
 
-class BTSService(Service, ServiceClient):
+class BTSService(Service, Client):
     ISSUE_CLASS = BTSIssue
     CONFIG_SCHEMA = BTSConfig
 

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -11,7 +11,7 @@ import pytz
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import IssueService, Issue
+from bugwarrior.services import Service, Issue
 
 log = logging.getLogger(__name__)
 
@@ -143,7 +143,7 @@ class BugzillaIssue(Issue):
         )
 
 
-class BugzillaService(IssueService):
+class BugzillaService(Service):
     ISSUE_CLASS = BugzillaIssue
     CONFIG_SCHEMA = BugzillaConfig
 

--- a/bugwarrior/services/deck.py
+++ b/bugwarrior/services/deck.py
@@ -6,7 +6,7 @@ import typing_extensions
 from dateutil.tz import tzutc
 
 from bugwarrior import config
-from bugwarrior.services import Service, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, Client
 
 log = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ class NextcloudDeckConfig(config.ServiceConfig):
 # * Stacks will be mapped to an UDA
 # * Cards will be mapped to tasks
 # * Labels will be mapped to tags
-class NextcloudDeckClient(ServiceClient):
+class NextcloudDeckClient(Client):
     def __init__(self, base_uri, username, password):
         self.api_base_path = f'{base_uri}/index.php/apps/deck/api/v1.0'
         self.ocs_base_path = f'{base_uri}/ocs/v2.php/apps/deck/api/v1.0'

--- a/bugwarrior/services/deck.py
+++ b/bugwarrior/services/deck.py
@@ -6,7 +6,7 @@ import typing_extensions
 from dateutil.tz import tzutc
 
 from bugwarrior import config
-from bugwarrior.services import IssueService, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, ServiceClient
 
 log = logging.getLogger(__name__)
 
@@ -150,7 +150,7 @@ class NextcloudDeckIssue(Issue):
         return self.build_default_description(title=self.record['title'])
 
 
-class NextcloudDeckService(IssueService):
+class NextcloudDeckService(Service):
     ISSUE_CLASS = NextcloudDeckIssue
     CONFIG_SCHEMA = NextcloudDeckConfig
 

--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -5,7 +5,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import Service, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, Client
 
 
 class GerritConfig(config.ServiceConfig):
@@ -84,7 +84,7 @@ class GerritIssue(Issue):
         )
 
 
-class GerritService(Service, ServiceClient):
+class GerritService(Service, Client):
     ISSUE_CLASS = GerritIssue
     CONFIG_SCHEMA = GerritConfig
 

--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -5,7 +5,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import IssueService, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, ServiceClient
 
 
 class GerritConfig(config.ServiceConfig):
@@ -84,7 +84,7 @@ class GerritIssue(Issue):
         )
 
 
-class GerritService(IssueService, ServiceClient):
+class GerritService(Service, ServiceClient):
     ISSUE_CLASS = GerritIssue
     CONFIG_SCHEMA = GerritConfig
 

--- a/bugwarrior/services/gitbug.py
+++ b/bugwarrior/services/gitbug.py
@@ -8,7 +8,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import IssueService, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, ServiceClient
 
 log = logging.getLogger(__name__)
 
@@ -145,7 +145,7 @@ class GitBugIssue(Issue):
             title=self.record['title'], cls='bug')
 
 
-class GitBugService(IssueService):
+class GitBugService(Service):
     ISSUE_CLASS = GitBugIssue
     CONFIG_SCHEMA = GitBugConfig
 

--- a/bugwarrior/services/gitbug.py
+++ b/bugwarrior/services/gitbug.py
@@ -8,7 +8,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import Service, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, Client
 
 log = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ class Webui:
         return False
 
 
-class GitBugClient(ServiceClient):
+class GitBugClient(Client):
     def __init__(self, path, port, annotation_comments):
         self.path = path
         self.port = port

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -7,7 +7,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import Service, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, Client
 
 import logging
 log = logging.getLogger(__name__)
@@ -79,7 +79,7 @@ class GithubConfig(config.ServiceConfig):
         return values
 
 
-class GithubClient(ServiceClient):
+class GithubClient(Client):
     def __init__(self, host, auth):
         self.host = host
         self.auth = auth

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -7,7 +7,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import IssueService, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, ServiceClient
 
 import logging
 log = logging.getLogger(__name__)
@@ -315,7 +315,7 @@ class GithubIssue(Issue):
         )
 
 
-class GithubService(IssueService):
+class GithubService(Service):
     ISSUE_CLASS = GithubIssue
     CONFIG_SCHEMA = GithubConfig
 

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -7,7 +7,7 @@ import sys
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import Service, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, Client
 
 import logging
 log = logging.getLogger(__name__)
@@ -117,7 +117,7 @@ class GitlabConfig(config.ServiceConfig):
         return v
 
 
-class GitlabClient(ServiceClient):
+class GitlabClient(Client):
     """Abstraction of Gitlab API v4"""
 
     def __init__(self, host, token, only_if_assigned, also_unassigned, use_https, verify_ssl):

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -7,7 +7,7 @@ import sys
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import IssueService, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, ServiceClient
 
 import logging
 log = logging.getLogger(__name__)
@@ -525,7 +525,7 @@ class GitlabIssue(Issue):
         )
 
 
-class GitlabService(IssueService):
+class GitlabService(Service):
     ISSUE_CLASS = GitlabIssue
     CONFIG_SCHEMA = GitlabConfig
 

--- a/bugwarrior/services/gmail.py
+++ b/bugwarrior/services/gmail.py
@@ -12,7 +12,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import IssueService, Issue
+from bugwarrior.services import Service, Issue
 
 log = logging.getLogger(__name__)
 
@@ -113,7 +113,7 @@ class GmailIssue(Issue):
         return self.parse_date(date_string)
 
 
-class GmailService(IssueService):
+class GmailService(Service):
     APPLICATION_NAME = 'Bugwarrior Gmail Service'
     SCOPES = ['https://www.googleapis.com/auth/gmail.readonly']
 

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -10,7 +10,7 @@ from jira.client import JIRA as BaseJIRA
 from requests.cookies import RequestsCookieJar
 
 from bugwarrior import config
-from bugwarrior.services import Issue, IssueService
+from bugwarrior.services import Issue, Service
 
 log = logging.getLogger(__name__)
 
@@ -362,7 +362,7 @@ class JiraIssue(Issue):
         return self.record['fields']['issuetype']['name']
 
 
-class JiraService(IssueService):
+class JiraService(Service):
     ISSUE_CLASS = JiraIssue
     CONFIG_SCHEMA = JiraConfig
 

--- a/bugwarrior/services/kanboard.py
+++ b/bugwarrior/services/kanboard.py
@@ -8,7 +8,7 @@ from kanboard import Client
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import Issue, IssueService
+from bugwarrior.services import Issue, Service
 
 log = logging.getLogger(__name__)
 
@@ -110,7 +110,7 @@ class KanboardIssue(Issue):
             )
 
 
-class KanboardService(IssueService):
+class KanboardService(Service):
     ISSUE_CLASS = KanboardIssue
     CONFIG_SCHEMA = KanboardConfig
 

--- a/bugwarrior/services/logseq.py
+++ b/bugwarrior/services/logseq.py
@@ -7,7 +7,7 @@ import re
 from datetime import datetime
 
 from bugwarrior import config
-from bugwarrior.services import Service, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, Client
 
 log = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ class LogseqConfig(config.ServiceConfig):
     inline_links: bool = True
 
 
-class LogseqClient(ServiceClient):
+class LogseqClient(Client):
     def __init__(self, host, port, token, filter):
         self.host = host
         self.port = port

--- a/bugwarrior/services/logseq.py
+++ b/bugwarrior/services/logseq.py
@@ -7,7 +7,7 @@ import re
 from datetime import datetime
 
 from bugwarrior import config
-from bugwarrior.services import IssueService, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, ServiceClient
 
 log = logging.getLogger(__name__)
 
@@ -282,7 +282,7 @@ class LogseqIssue(Issue):
         )
 
 
-class LogseqService(IssueService):
+class LogseqService(Service):
     ISSUE_CLASS = LogseqIssue
     CONFIG_SCHEMA = LogseqConfig
 

--- a/bugwarrior/services/pagure.py
+++ b/bugwarrior/services/pagure.py
@@ -6,7 +6,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import IssueService, Issue
+from bugwarrior.services import Service, Issue
 
 import logging
 log = logging.getLogger(__name__)
@@ -106,7 +106,7 @@ class PagureIssue(Issue):
         )
 
 
-class PagureService(IssueService):
+class PagureService(Service):
     ISSUE_CLASS = PagureIssue
     CONFIG_SCHEMA = PagureConfig
 

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -6,7 +6,7 @@ import pydantic
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import IssueService, Issue
+from bugwarrior.services import Service, Issue
 
 log = logging.getLogger(__name__)
 
@@ -87,7 +87,7 @@ class PhabricatorIssue(Issue):
             or self.config.default_priority
 
 
-class PhabricatorService(IssueService):
+class PhabricatorService(Service):
     ISSUE_CLASS = PhabricatorIssue
     CONFIG_SCHEMA = PhabricatorConfig
 

--- a/bugwarrior/services/pivotaltracker.py
+++ b/bugwarrior/services/pivotaltracker.py
@@ -6,7 +6,7 @@ from jinja2 import Template
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import IssueService, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, ServiceClient
 
 import logging
 log = logging.getLogger(__name__)
@@ -116,7 +116,7 @@ class PivotalTrackerIssue(Issue):
         )
 
 
-class PivotalTrackerService(IssueService, ServiceClient):
+class PivotalTrackerService(Service, ServiceClient):
     ISSUE_CLASS = PivotalTrackerIssue
     CONFIG_SCHEMA = PivotalTrackerConfig
 

--- a/bugwarrior/services/pivotaltracker.py
+++ b/bugwarrior/services/pivotaltracker.py
@@ -6,7 +6,7 @@ from jinja2 import Template
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import Service, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, Client
 
 import logging
 log = logging.getLogger(__name__)
@@ -116,7 +116,7 @@ class PivotalTrackerIssue(Issue):
         )
 
 
-class PivotalTrackerService(Service, ServiceClient):
+class PivotalTrackerService(Service, Client):
     ISSUE_CLASS = PivotalTrackerIssue
     CONFIG_SCHEMA = PivotalTrackerConfig
 

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -5,7 +5,7 @@ from taskw import TaskWarriorShellout
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import Issue, Service, ServiceClient
+from bugwarrior.services import Issue, Service, Client
 
 import logging
 log = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ class RedMineConfig(config.ServiceConfig):
     verify_ssl: bool = True
 
 
-class RedMineClient(ServiceClient):
+class RedMineClient(Client):
     def __init__(self, url, key, auth, issue_limit, verify_ssl):
         self.url = url
         self.key = key

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -5,7 +5,7 @@ from taskw import TaskWarriorShellout
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import Issue, IssueService, ServiceClient
+from bugwarrior.services import Issue, Service, ServiceClient
 
 import logging
 log = logging.getLogger(__name__)
@@ -242,7 +242,7 @@ class RedMineIssue(Issue):
         )
 
 
-class RedMineService(IssueService):
+class RedMineService(Service):
     ISSUE_CLASS = RedMineIssue
     CONFIG_SCHEMA = RedMineConfig
 

--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -2,7 +2,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import IssueService, Issue, ServiceClient, CACHE_REGION as cache
+from bugwarrior.services import Service, Issue, ServiceClient, CACHE_REGION as cache
 
 import logging
 log = logging.getLogger(__name__)
@@ -62,7 +62,7 @@ class TaigaIssue(Issue):
         )
 
 
-class TaigaService(IssueService, ServiceClient):
+class TaigaService(Service, ServiceClient):
     ISSUE_CLASS = TaigaIssue
     CONFIG_SCHEMA = TaigaConfig
 

--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -2,7 +2,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import Service, Issue, ServiceClient, CACHE_REGION as cache
+from bugwarrior.services import Service, Issue, Client, CACHE_REGION as cache
 
 import logging
 log = logging.getLogger(__name__)
@@ -62,7 +62,7 @@ class TaigaIssue(Issue):
         )
 
 
-class TaigaService(Service, ServiceClient):
+class TaigaService(Service, Client):
     ISSUE_CLASS = TaigaIssue
     CONFIG_SCHEMA = TaigaConfig
 

--- a/bugwarrior/services/teamlab.py
+++ b/bugwarrior/services/teamlab.py
@@ -3,7 +3,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import Issue, Service, ServiceClient
+from bugwarrior.services import Issue, Service, Client
 
 import logging
 log = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ class TeamLabConfig(config.ServiceConfig):
         return values
 
 
-class TeamLabClient(ServiceClient):
+class TeamLabClient(Client):
     def __init__(self, hostname, verbose=False):
         self.hostname = hostname
         self.verbose = verbose

--- a/bugwarrior/services/teamlab.py
+++ b/bugwarrior/services/teamlab.py
@@ -3,7 +3,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import Issue, IssueService, ServiceClient
+from bugwarrior.services import Issue, Service, ServiceClient
 
 import logging
 log = logging.getLogger(__name__)
@@ -117,7 +117,7 @@ class TeamLabIssue(Issue):
         return self.config.default_priority
 
 
-class TeamLabService(IssueService):
+class TeamLabService(Service):
     ISSUE_CLASS = TeamLabIssue
     CONFIG_SCHEMA = TeamLabConfig
 

--- a/bugwarrior/services/teamwork_projects.py
+++ b/bugwarrior/services/teamwork_projects.py
@@ -2,7 +2,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import Service, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, Client
 
 import logging
 log = logging.getLogger(__name__)
@@ -14,7 +14,7 @@ class TeamworkConfig(config.ServiceConfig):
     token: str
 
 
-class TeamworkClient(ServiceClient):
+class TeamworkClient(Client):
 
     def __init__(self, host, token):
         self.host = host

--- a/bugwarrior/services/teamwork_projects.py
+++ b/bugwarrior/services/teamwork_projects.py
@@ -2,7 +2,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import IssueService, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, ServiceClient
 
 import logging
 log = logging.getLogger(__name__)
@@ -118,7 +118,7 @@ class TeamworkIssue(Issue):
         }
 
 
-class TeamworkService(IssueService):
+class TeamworkService(Service):
     ISSUE_CLASS = TeamworkIssue
     CONFIG_SCHEMA = TeamworkConfig
 

--- a/bugwarrior/services/trac.py
+++ b/bugwarrior/services/trac.py
@@ -7,7 +7,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import Issue, IssueService
+from bugwarrior.services import Issue, Service
 
 import logging
 log = logging.getLogger(__name__)
@@ -90,7 +90,7 @@ class TracIssue(Issue):
         )
 
 
-class TracService(IssueService):
+class TracService(Service):
     ISSUE_CLASS = TracIssue
     CONFIG_SCHEMA = TracConfig
 

--- a/bugwarrior/services/trello.py
+++ b/bugwarrior/services/trello.py
@@ -8,7 +8,7 @@ Trello API documentation available at https://developers.trello.com/
 import requests
 import typing_extensions
 
-from bugwarrior.services import Service, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, Client
 from bugwarrior import config
 
 
@@ -81,7 +81,7 @@ class TrelloIssue(Issue):
         }
 
 
-class TrelloService(Service, ServiceClient):
+class TrelloService(Service, Client):
     ISSUE_CLASS = TrelloIssue
     CONFIG_SCHEMA = TrelloConfig
 

--- a/bugwarrior/services/trello.py
+++ b/bugwarrior/services/trello.py
@@ -8,7 +8,7 @@ Trello API documentation available at https://developers.trello.com/
 import requests
 import typing_extensions
 
-from bugwarrior.services import IssueService, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, ServiceClient
 from bugwarrior import config
 
 
@@ -81,7 +81,7 @@ class TrelloIssue(Issue):
         }
 
 
-class TrelloService(IssueService, ServiceClient):
+class TrelloService(Service, ServiceClient):
     ISSUE_CLASS = TrelloIssue
     CONFIG_SCHEMA = TrelloConfig
 

--- a/bugwarrior/services/versionone.py
+++ b/bugwarrior/services/versionone.py
@@ -5,7 +5,7 @@ from v1pysdk.none_deref import NoneDeref
 from urllib import parse
 
 from bugwarrior import config
-from bugwarrior.services import IssueService, Issue
+from bugwarrior.services import Service, Issue
 
 
 class VersionOneConfig(config.ServiceConfig):
@@ -163,7 +163,7 @@ class VersionOneIssue(Issue):
         )
 
 
-class VersionOneService(IssueService):
+class VersionOneService(Service):
     ISSUE_CLASS = VersionOneIssue
     CONFIG_SCHEMA = VersionOneConfig
 

--- a/bugwarrior/services/youtrack.py
+++ b/bugwarrior/services/youtrack.py
@@ -5,7 +5,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import Service, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, Client
 
 import logging
 
@@ -125,7 +125,7 @@ class YoutrackIssue(Issue):
         )
 
 
-class YoutrackService(Service, ServiceClient):
+class YoutrackService(Service, Client):
     ISSUE_CLASS = YoutrackIssue
     CONFIG_SCHEMA = YoutrackConfig
 

--- a/bugwarrior/services/youtrack.py
+++ b/bugwarrior/services/youtrack.py
@@ -5,7 +5,7 @@ import requests
 import typing_extensions
 
 from bugwarrior import config
-from bugwarrior.services import IssueService, Issue, ServiceClient
+from bugwarrior.services import Service, Issue, ServiceClient
 
 import logging
 
@@ -125,7 +125,7 @@ class YoutrackIssue(Issue):
         )
 
 
-class YoutrackService(IssueService, ServiceClient):
+class YoutrackService(Service, ServiceClient):
     ISSUE_CLASS = YoutrackIssue
     CONFIG_SCHEMA = YoutrackConfig
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -32,7 +32,7 @@ class DumbIssue(services.Issue):
         raise NotImplementedError
 
 
-class DumbIssueService(services.IssueService):
+class DumbService(services.Service):
     """
     Implement the required methods but they shouldn't be called.
     """
@@ -60,16 +60,16 @@ class ServiceBase(ConfigTest):
 
     def makeService(self):
         with unittest.mock.patch('bugwarrior.config.schema.get_service',
-                                 lambda x: DumbIssueService):
+                                 lambda x: DumbService):
             conf = schema.validate_config(self.config, 'general', 'configpath')
-        return DumbIssueService(conf['test'], conf['general'])
+        return DumbService(conf['test'], conf['general'])
 
     def makeIssue(self):
         service = self.makeService()
         return service.get_issue_for_record({})
 
 
-class TestIssueService(ServiceBase):
+class TestService(ServiceBase):
 
     def test_build_annotations_default(self):
         service = self.makeService()


### PR DESCRIPTION
IMO this was always confusing when the sister class is named "Issue". This is a good time to make the breaking change as the service API is stabilized for #791.