### PR TITLE
Update entry points access

### DIFF
--- a/bugwarrior/collect.py
+++ b/bugwarrior/collect.py
@@ -3,8 +3,8 @@ import logging
 import multiprocessing
 import time
 
+from importlib_metadata import entry_points
 from jinja2 import Template
-from pkg_resources import iter_entry_points
 
 from taskw.task import Task
 
@@ -15,14 +15,13 @@ SERVICE_FINISHED_OK = 0
 SERVICE_FINISHED_ERROR = 1
 
 
-def get_service(service_name):
-    epoint = iter_entry_points(group='bugwarrior.service', name=service_name)
+def get_service(service_name: str):
     try:
-        epoint = next(epoint)
-    except StopIteration:
-        return None
-
-    return epoint.load()
+        (service,) = entry_points(group='bugwarrior.service', name=service_name)
+    except ValueError as e:
+        raise ValueError(f"Configured service '{service_name}' not found. "
+                         "Is it installed? Or misspelled?") from e
+    return service.load()
 
 
 def _aggregate_issues(conf, main_section, target, queue):

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -2,12 +2,13 @@ import docutils.core
 import glob
 import os.path
 import pathlib
-import pkg_resources
 import re
 import socket
 import subprocess
 import tempfile
 import unittest
+
+from importlib_metadata import entry_points
 
 DOCS_PATH = pathlib.Path(__file__).parent / '../bugwarrior/docs'
 
@@ -69,7 +70,7 @@ class DocsTest(unittest.TestCase):
     def test_registered_services_are_documented(self):
         registered_services = set(
             e.name for e in
-            pkg_resources.iter_entry_points(group='bugwarrior.service'))
+            entry_points(group='bugwarrior.service'))
 
         documented_services = set()
         services_paths = os.listdir(DOCS_PATH / 'services')


### PR DESCRIPTION
Switch from pkg_resources (deprecated) to importlib-metadata, and give a more helpful error when a service plugin isn't found.