### PR TITLE
jira: eliminate unnecessary 'extra' fields

### DIFF
--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -246,11 +246,11 @@ class JiraIssue(Issue):
         return {**fixed_fields, **extra_fields}
 
     def get_extra_fields(self):
-        if self.extra['extra_fields'] is None:
+        if self.config.extra_fields is None:
             return {}
 
         return {extra_field.label: extra_field.extract_value(
-            self.record['fields']) for extra_field in self.extra['extra_fields']}
+            self.record['fields']) for extra_field in self.config.extra_fields}
 
     def get_entry(self):
         created_at = self.record['fields']['created']
@@ -308,12 +308,12 @@ class JiraIssue(Issue):
         return self.config.base_uri + '/browse/' + self.record['key']
 
     def get_summary(self):
-        if self.extra.get('jira_version') == 4:
+        if self.config.version == 4:
             return self.record['fields']['summary']['value']
         return self.record['fields']['summary']
 
     def get_estimate(self):
-        if self.extra.get('jira_version') == 4:
+        if self.config.version == 4:
             return self.record['fields']['timeestimate']['value']
         try:
             return self.record['fields']['timeestimate'] / 60 / 60
@@ -431,21 +431,15 @@ class JiraService(Service):
             issue_obj.get_url()
         )
 
-    def get_issue_for_record(self, record, extra=None):
-        if extra is None:
-            extra = {}
-        extra.setdefault('sprint_field_names', self.sprint_field_names)
-        return super().get_issue_for_record(record, extra=extra)
-
     def issues(self):
         cases = self.jira.search_issues(self.query, maxResults=None)
 
         for case in cases:
-            issue = self.get_issue_for_record(case.raw)
+            issue = self.get_issue_for_record(
+                case.raw,
+                extra={'sprint_field_names': self.sprint_field_names})
             extra = {
-                'jira_version': self.config.version,
                 'body': self.body(issue),
-                'extra_fields': self.config.extra_fields,
             }
             if self.config.version > 4:
                 extra.update({

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -58,7 +58,6 @@ class testJiraService(ConfigTest):
         service = JiraService(
             conf['myjira'], conf['general'], _skip_server=True)
         issue = mock.Mock()
-        issue = mock.Mock()
         issue.record = dict(fields=dict(description=description))
         self.assertEqual(description, service.body(issue))
 
@@ -123,10 +122,9 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
     def test_to_taskwarrior(self):
         arbitrary_url = 'http://one'
         arbitrary_extra = {
-            'jira_version': 5,
             'annotations': ['an annotation'],
             'body': 'issue body',
-            'extra_fields': self.get_extra_fields(),
+            'sprint_field_names': [],
         }
 
         issue = self.service.get_issue_for_record(
@@ -175,9 +173,8 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
         ]
         arbitrary_url = 'http://one'
         arbitrary_extra = {
-            'jira_version': 5,
             'annotations': ['an annotation'],
-            'extra_fields': self.get_extra_fields()
+            'sprint_field_names': self.service.sprint_field_names,
         }
 
         issue = self.service.get_issue_for_record(
@@ -245,7 +242,8 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
 
     def test_get_due(self):
         issue = self.service.get_issue_for_record(
-            self.arbitrary_record_with_due
+            self.arbitrary_record_with_due,
+            extra={'sprint_field_names': self.service.sprint_field_names},
         )
         self.assertEqual(issue.get_due(), datetime.datetime(
             2016, 9, 23, 16, 8, tzinfo=tzutc()))


### PR DESCRIPTION
Also, don't override get_issue_for_record. Jira was the only service doing this and the only advantage was a marginal convenience in testing.