### PR TITLE
Services reference common configuration options

### DIFF
--- a/bugwarrior/config/__init__.py
+++ b/bugwarrior/config/__init__.py
@@ -11,7 +11,8 @@ from .schema import (ConfigList,  # noqa: F401
                      NoSchemeUrl,  # noqa: F401
                      ServiceConfig,
                      StrippedTrailingSlashUrl,  # noqa: F401
-                     TaskrcPath)  # noqa: F401
+                     TaskrcPath,  # noqa: F401
+                     UnsupportedOption)  # noqa: F401
 from .secrets import get_keyring  # noqa: F401
 
 # NOTE: __all__ determines the stable, public API.

--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -94,6 +94,21 @@ class TaskrcPath(ExpandedPath):
         return expanded_path
 
 
+T = typing.TypeVar('T')
+
+
+class UnsupportedOption(typing.Generic[T]):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v: T):
+        if v:
+            raise ValueError("Option is unsupported by service.")
+        return v
+
+
 class PydanticConfig(pydantic.v1.BaseConfig):
     allow_mutation = False  # config is faux-immutable
     extra = 'forbid'  # do not allow undeclared fields

--- a/bugwarrior/services/activecollab.py
+++ b/bugwarrior/services/activecollab.py
@@ -16,6 +16,9 @@ class ActiveCollabConfig(config.ServiceConfig):
     key: str
     user_id: int
 
+    only_if_assigned: config.UnsupportedOption[str] = ''
+    also_unassigned: config.UnsupportedOption[bool] = False
+
 
 class ActiveCollabClient:
     def __init__(self, url, key, user_id):

--- a/bugwarrior/services/activecollab2.py
+++ b/bugwarrior/services/activecollab2.py
@@ -37,6 +37,9 @@ class ActiveCollab2Config(config.ServiceConfig):
     user_id: int
     projects: ActiveCollabProjects
 
+    only_if_assigned: config.UnsupportedOption[str] = ''
+    also_unassigned: config.UnsupportedOption[bool] = False
+
 
 class ActiveCollab2Client(Client):
     def __init__(self, url, key, user_id, projects, target):

--- a/bugwarrior/services/bts.py
+++ b/bugwarrior/services/bts.py
@@ -33,6 +33,9 @@ class BTSConfig(config.ServiceConfig):
     ignore_pkg: config.ConfigList = config.ConfigList([])
     ignore_src: config.ConfigList = config.ConfigList([])
 
+    only_if_assigned: config.UnsupportedOption[str] = ''
+    also_unassigned: config.UnsupportedOption[bool] = False
+
     @pydantic.v1.root_validator
     def require_email_or_packages(cls, values):
         if not values['email'] and not values['packages']:

--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -16,6 +16,9 @@ class GerritConfig(config.ServiceConfig):
     ssl_ca_path: typing.Optional[config.ExpandedPath] = None
     query: str = 'is:open+is:reviewer'
 
+    only_if_assigned: config.UnsupportedOption[str] = ''
+    also_unassigned: config.UnsupportedOption[bool] = False
+
 
 class GerritIssue(Issue):
     SUMMARY = 'gerritsummary'

--- a/bugwarrior/services/gitbug.py
+++ b/bugwarrior/services/gitbug.py
@@ -22,6 +22,9 @@ class GitBugConfig(config.ServiceConfig):
     label_template: str = '{{label}}'
     port: int = 43915
 
+    only_if_assigned: config.UnsupportedOption[str] = ''
+    also_unassigned: config.UnsupportedOption[bool] = False
+
 
 class Webui:
     def __init__(self, path, port):

--- a/bugwarrior/services/gmail.py
+++ b/bugwarrior/services/gmail.py
@@ -26,6 +26,9 @@ class GmailConfig(config.ServiceConfig):
     login_name: str = 'me'
     thread_limit: int = 100
 
+    only_if_assigned: config.UnsupportedOption[str] = ''
+    also_unassigned: config.UnsupportedOption[bool] = False
+
 
 class GmailIssue(Issue):
     THREAD_ID = 'gmailthreadid'

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -93,6 +93,9 @@ class JiraConfig(config.ServiceConfig):
     verify_ssl: bool = True
     version: int = 5
 
+    only_if_assigned: config.UnsupportedOption[str] = ''
+    also_unassigned: config.UnsupportedOption[bool] = False
+
     @pydantic.v1.root_validator
     def require_password_xor_PAT(cls, values):
         if ((values['password'] and values['PAT'])

--- a/bugwarrior/services/kanboard.py
+++ b/bugwarrior/services/kanboard.py
@@ -21,6 +21,9 @@ class KanboardConfig(config.ServiceConfig):
 
     query: str = ''
 
+    only_if_assigned: config.UnsupportedOption[str] = ''
+    also_unassigned: config.UnsupportedOption[bool] = False
+
 
 class KanboardIssue(Issue):
     TASK_ID = "kanboardtaskid"

--- a/bugwarrior/services/logseq.py
+++ b/bugwarrior/services/logseq.py
@@ -27,6 +27,9 @@ class LogseqConfig(config.ServiceConfig):
     char_close_bracket: str = "〉"
     inline_links: bool = True
 
+    only_if_assigned: config.UnsupportedOption[str] = ''
+    also_unassigned: config.UnsupportedOption[bool] = False
+
 
 class LogseqClient(Client):
     def __init__(self, host, port, token, filter):
@@ -255,11 +258,7 @@ class LogseqIssue(Issue):
         wait_date = min([d for d in [scheduled_date, deadline_date, self.SOMEDAY] if d is not None])
         return {
             "project": self.extra["graph"],
-            "priority": (
-                self.PRIORITY_MAP[self.record["priority"]]
-                if "priority" in self.record
-                else None
-            ),
+            "priority": self.get_priority(),
             "annotations": annotations,
             "tags": self.get_tags_from_content(),
             "due": deadline_date,

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -24,6 +24,8 @@ class PhabricatorConfig(config.ServiceConfig):
     # XXX Override common service configuration
     only_if_assigned: bool = False
 
+    also_unassigned: config.UnsupportedOption[bool] = False
+
 
 class PhabricatorIssue(Issue):
     TITLE = 'phabricatortitle'

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -25,6 +25,8 @@ class RedMineConfig(config.ServiceConfig):
     password: str = ''
     verify_ssl: bool = True
 
+    also_unassigned: config.UnsupportedOption[bool] = False
+
 
 class RedMineClient(Client):
     def __init__(self, url, key, auth, issue_limit, verify_ssl):

--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -17,6 +17,9 @@ class TaigaConfig(config.ServiceConfig):
     include_tasks: bool = False
     label_template: str = '{{label}}'
 
+    only_if_assigned: config.UnsupportedOption[str] = ''
+    also_unassigned: config.UnsupportedOption[bool] = False
+
 
 class TaigaIssue(Issue):
     SUMMARY = 'taigasummary'

--- a/bugwarrior/services/teamlab.py
+++ b/bugwarrior/services/teamlab.py
@@ -19,6 +19,8 @@ class TeamLabConfig(config.ServiceConfig):
     login: str
     password: str
 
+    also_unassigned: config.UnsupportedOption[bool] = False
+
     @pydantic.v1.root_validator
     def default_project_name(cls, values):
         if values['project_name'] == '':

--- a/bugwarrior/services/teamwork_projects.py
+++ b/bugwarrior/services/teamwork_projects.py
@@ -14,6 +14,9 @@ class TeamworkConfig(config.ServiceConfig):
     host: config.StrippedTrailingSlashUrl
     token: str
 
+    only_if_assigned: config.UnsupportedOption[str] = ''
+    also_unassigned: config.UnsupportedOption[bool] = False
+
 
 class TeamworkClient(Client):
 

--- a/bugwarrior/services/versionone.py
+++ b/bugwarrior/services/versionone.py
@@ -21,6 +21,9 @@ class VersionOneConfig(config.ServiceConfig):
     timebox_name: str = ''
     timezone: str = ''
 
+    only_if_assigned: config.UnsupportedOption[str] = ''
+    also_unassigned: config.UnsupportedOption[bool] = False
+
 
 class VersionOneIssue(Issue):
     TASK_NAME = 'versiononetaskname'

--- a/bugwarrior/services/youtrack.py
+++ b/bugwarrior/services/youtrack.py
@@ -27,6 +27,9 @@ class YoutrackConfig(config.ServiceConfig):
     import_tags: bool = True
     tag_template: str = '{{tag|lower}}'
 
+    only_if_assigned: config.UnsupportedOption[str] = ''
+    also_unassigned: config.UnsupportedOption[bool] = False
+
     # added during validation (computed field support will land in pydantic-2)
     base_url: str = ''
 


### PR DESCRIPTION
- Add a test that all services reference the common configuration options (at least vicariously). The exception is add_tags, which is done during the issue aggregation phase.
- Add an UnsupportedOption type to the configuration schema which throws a validation error if the given value is changed from it's default.
- Set the unimplemented options to this UnsupportedOption value.

One of the effects of no longer requiring the get_owner method in #1070 which I wasn't pleased with is that there is no longer an impetus for the service developer to implement these common configuration options. However, I also learned in that PR that making imperfect but nonetheless useful tests by regexing the code can cheaply make some loose guarantees that software follows some basic guidelines.

So this should restore the virtue that unimplemented features need to be noticed and suggests an even more explicit statement that they are unsupported. Furthermore, this gives users a validation error when they configure one of these unsupported features, rather than failing silently as the #1070 commit notes was always the case:

> One might suspect that eliminating these NotImplementedError's would eliminate the warnings from services that do not support only_if_assigned, but in fact these would only get raised if the service itself called self.include, which they do not. So a user trying to use these options already would find them silently ignored, which isn't great but is a problem for another day.

Today is that day!