### PR TITLE
Remove redundant state marker from logseq task description

### DIFF
--- a/bugwarrior/services/logseq.py
+++ b/bugwarrior/services/logseq.py
@@ -168,10 +168,11 @@ class LogseqIssue(Issue):
 
     # get an optimized and formatted title
     def get_formatted_title(self):
-        # use first line only and remove priority
+        # use first line only and remove state and priority
         first_line = (
             self.record["content"]
             .split("\n")[0]  # only use first line
+            .split(self.get_logseq_state() + " ")[1]  # remove state marker
             .replace("[#A] ", "")  # remove priority markers
             .replace("[#B] ", "")
             .replace("[#C] ", "")

--- a/tests/test_logseq.py
+++ b/tests/test_logseq.py
@@ -68,7 +68,7 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
             issue.ID: int(self.test_record["id"]),
             issue.UUID: self.test_record["uuid"],
             issue.STATE: self.test_record["marker"],
-            issue.TITLE: "DOING Do something #【Test tag】 #【TestTag】 #TestTag",
+            issue.TITLE: "Do something #【Test tag】 #【TestTag】 #TestTag",
             issue.URI: self.test_extra["baseURI"] + self.test_record["uuid"],
         }
 
@@ -84,7 +84,7 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
         expected = {
             "annotations": [],
             "description": f"(bw)Is#{self.test_record['id']}"
-            + " - DOING Do something #【Test tag】 #【TestTag】 #TestTag"
+            + " - Do something #【Test tag】 #【TestTag】 #TestTag"
             + " .. " + self.test_extra["baseURI"] + self.test_record["uuid"],
             "due": None,
             "scheduled": None,
@@ -96,7 +96,7 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
             issue.ID: int(self.test_record["id"]),
             issue.UUID: self.test_record["uuid"],
             issue.STATE: self.test_record["marker"],
-            issue.TITLE: "DOING Do something #【Test tag】 #【TestTag】 #TestTag",
+            issue.TITLE: "Do something #【Test tag】 #【TestTag】 #TestTag",
             issue.URI: self.test_extra["baseURI"] + self.test_record["uuid"],
         }
 


### PR DESCRIPTION
`logseqstate` is already a provided UDA field and thus can be inserted into the description via templating at the user's discretion.