### PR TITLE
Improve logseq tag handling

### DIFF
--- a/bugwarrior/docs/services/logseq.rst
+++ b/bugwarrior/docs/services/logseq.rst
@@ -149,10 +149,10 @@ From the command line you can open a specific task using taskwarior task id, e.g
 Tags
 ++++
 
-LogSeq tasks with ``#tag`` style tag entries in the description are added to the Taskwarrior tags.
-Multi and single word tags using the Logseq ``#[[Tag]]`` or ``#[[Multi Word]]`` format are
-condenced to a ``#Tag`` and ``#MultiWord`` style before adding the Taskwarrior tags. The format of 
-the tag content in task desciption is unchanged.
+Logseq tasks with ``#tag`` style tag entries in the description are added to the Taskwarrior tags.
+Single- and multi-word tags using the Logseq ``#[[Tag]]`` or ``#[[Multi Word]]`` format are
+condensed to a ``Tag`` and ``MultiWord`` style before adding the Taskwarrior tags. The format of
+the tag content in the task description is unchanged.
 
 
 Troubleshooting

--- a/bugwarrior/services/logseq.py
+++ b/bugwarrior/services/logseq.py
@@ -190,8 +190,8 @@ class LogseqIssue(Issue):
             r"(#[" + self.config.char_open_link + r"].*[" + self.config.char_close_link + r"])",
             self.get_formatted_title()
         ))
-        # compress format to single words
-        tags = [self._compress_tag_format(t) for t in tags]
+        # compress format to single words and strip leading `#`
+        tags = [self._compress_tag_format(t).lstrip('#') for t in tags]
         return tags
 
     # get a list of annotations from the content

--- a/bugwarrior/services/logseq.py
+++ b/bugwarrior/services/logseq.py
@@ -187,7 +187,7 @@ class LogseqIssue(Issue):
         )
         # and this adds the #[[multi word]] formatted tags
         tags.extend(re.findall(
-            r"(#[" + self.config.char_open_link + r"].*[" + self.config.char_close_link + r"])",
+            r"(#[" + self.config.char_open_link + r"].*?[" + self.config.char_close_link + r"])",
             self.get_formatted_title()
         ))
         # compress format to single words and strip leading `#`

--- a/tests/test_logseq.py
+++ b/tests/test_logseq.py
@@ -40,6 +40,7 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
     }
 
     test_extra = {
+        "baseURI": "logseq://graph/Test?block-id=",
         "graph": "Test",
     }
 
@@ -68,7 +69,7 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
             issue.UUID: self.test_record["uuid"],
             issue.STATE: self.test_record["marker"],
             issue.TITLE: "DOING Do something #【Test tag】 #【TestTag】 #TestTag",
-            issue.URI: "logseq://graph/Test?block-id=66699a83-3ee0-4edc-81c6-a24c9b80bec6",
+            issue.URI: self.test_extra["baseURI"] + self.test_record["uuid"],
         }
 
         actual = issue.to_taskwarrior()
@@ -84,7 +85,7 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
             "annotations": [],
             "description": f"(bw)Is#{self.test_record['id']}"
             + " - DOING Do something #【Test tag】 #【TestTag】 #TestTag"
-            + " .. logseq://graph/Test?block-id=66699a83-3ee0-4edc-81c6-a24c9b80bec6",
+            + " .. " + self.test_extra["baseURI"] + self.test_record["uuid"],
             "due": None,
             "scheduled": None,
             "wait": None,
@@ -96,7 +97,7 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
             issue.UUID: self.test_record["uuid"],
             issue.STATE: self.test_record["marker"],
             issue.TITLE: "DOING Do something #【Test tag】 #【TestTag】 #TestTag",
-            issue.URI: "logseq://graph/Test?block-id=66699a83-3ee0-4edc-81c6-a24c9b80bec6",
+            issue.URI: self.test_extra["baseURI"] + self.test_record["uuid"],
         }
 
         self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)

--- a/tests/test_logseq.py
+++ b/tests/test_logseq.py
@@ -30,7 +30,7 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
             {"id": 1777},
             {"id": 7070},
         ],
-        "content": "DOING [#A] Do something",
+        "content": "DOING [#A] Do something #[[Test tag]] #[[TestTag]] #TestTag",
         "properties-text-values": {"duration": '{"TODO":[0,1699562197346]}'},
         "marker": "DOING",
         "page": {"id": 7070},
@@ -63,11 +63,11 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
             "status": "pending",
             "priority": "L",
             "project": self.test_extra["graph"],
-            "tags": [],
+            "tags": ['TestTag', 'Testtag', 'TestTag'],
             issue.ID: int(self.test_record["id"]),
             issue.UUID: self.test_record["uuid"],
             issue.STATE: self.test_record["marker"],
-            issue.TITLE: "DOING Do something",
+            issue.TITLE: "DOING Do something #【Test tag】 #【TestTag】 #TestTag",
             issue.URI: "logseq://graph/Test?block-id=66699a83-3ee0-4edc-81c6-a24c9b80bec6",
         }
 
@@ -83,7 +83,7 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
         expected = {
             "annotations": [],
             "description": f"(bw)Is#{self.test_record['id']}"
-            + " - DOING Do something"
+            + " - DOING Do something #【Test tag】 #【TestTag】 #TestTag"
             + " .. logseq://graph/Test?block-id=66699a83-3ee0-4edc-81c6-a24c9b80bec6",
             "due": None,
             "scheduled": None,
@@ -91,11 +91,11 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
             "status": "pending",
             "priority": "L",
             "project": self.test_extra["graph"],
-            "tags": [],
+            "tags": ['TestTag', 'Testtag', 'TestTag'],
             issue.ID: int(self.test_record["id"]),
             issue.UUID: self.test_record["uuid"],
             issue.STATE: self.test_record["marker"],
-            issue.TITLE: "DOING Do something",
+            issue.TITLE: "DOING Do something #【Test tag】 #【TestTag】 #TestTag",
             issue.URI: "logseq://graph/Test?block-id=66699a83-3ee0-4edc-81c6-a24c9b80bec6",
         }
 


### PR DESCRIPTION
This PR includes two fixes:

- Remove the `#` tag prefix to avoid "Malformed entry" errors in Taskwarrior when applying coefficients to tags.
- Use non-greedy regex to ensure page link-style tags are extracted separately.

The relevant documentation is also updated.