### PR TITLE
Fixes: #1085 - Do not yield on AttributeError

### DIFF
--- a/bugwarrior/collect.py
+++ b/bugwarrior/collect.py
@@ -100,7 +100,7 @@ def aggregate_issues(conf, main_section, debug):
                     log.error(f"Aborted [{target}] due to critical error.")
                     yield ('SERVICE FAILED', target)
                 continue
-            yield issue
+            raise
 
     log.info("Done aggregating remote issues.")
 


### PR DESCRIPTION
Previously, when there is an AttributeError in a service, the service will return its issue object instead of a dictionary representation of the issue. This fixes it by raising an error if this happens.