### PR TITLE
Migrate to new datetime API

### DIFF
--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -12,12 +12,12 @@ from .base import ServiceTest, AbstractServiceTest
 
 
 ARBITRARY_CREATED = (
-    datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+    datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
 ).replace(tzinfo=pytz.UTC, microsecond=0)
 ARBITRARY_CLOSED = (
-    datetime.datetime.utcnow() - datetime.timedelta(minutes=30)
+    datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=30)
 ).replace(tzinfo=pytz.UTC, microsecond=0)
-ARBITRARY_UPDATED = datetime.datetime.utcnow().replace(
+ARBITRARY_UPDATED = datetime.datetime.now(datetime.timezone.utc).replace(
     tzinfo=pytz.UTC, microsecond=0)
 ARBITRARY_ISSUE = {
     'title': 'Hallo',

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -12,9 +12,9 @@ from .base import ConfigTest, ServiceTest, AbstractServiceTest
 class TestData():
     def __init__(self):
         self.arbitrary_created = (
-            datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
         ).replace(tzinfo=pytz.UTC, microsecond=0)
-        self.arbitrary_updated = datetime.datetime.utcnow().replace(
+        self.arbitrary_updated = datetime.datetime.now(datetime.timezone.utc).replace(
             tzinfo=pytz.UTC, microsecond=0)
         self.arbitrary_duedate = (
             datetime.datetime.combine(datetime.date.today(),

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -1,7 +1,7 @@
 import os.path
 import pickle
 from copy import copy
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 from unittest.mock import patch
 
@@ -52,7 +52,7 @@ class TestGmailService(ConfigTest):
 
     def test_get_credentials_with_refresh(self):
         expired_credential = Credentials(**copy(TEST_CREDENTIAL))
-        expired_credential.expiry = datetime.utcnow()
+        expired_credential.expiry = datetime.now(timezone.utc)
         self.assertEqual(expired_credential.valid, False)
         with open(self.service.credentials_path, "wb") as token:
             pickle.dump(expired_credential, token)
@@ -60,7 +60,7 @@ class TestGmailService(ConfigTest):
         with patch("google.oauth2.reauth.refresh_grant") as mock_refresh_grant:
             access_token = "newaccesstoken"
             refresh_token = "newrefreshtoken"
-            expiry = datetime.utcnow() + timedelta(hours=24)
+            expiry = datetime.now(timezone.utc) + timedelta(hours=24)
             grant_response = {"id_token": "idtoken"}
             rapt_token = "reauthprooftoken"
             mock_refresh_grant.return_value = (

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -52,7 +52,7 @@ class TestGmailService(ConfigTest):
 
     def test_get_credentials_with_refresh(self):
         expired_credential = Credentials(**copy(TEST_CREDENTIAL))
-        expired_credential.expiry = datetime.now(timezone.utc)
+        expired_credential.expiry = datetime.now(timezone.utc).replace(tzinfo=None)
         self.assertEqual(expired_credential.valid, False)
         with open(self.service.credentials_path, "wb") as token:
             pickle.dump(expired_credential, token)
@@ -60,7 +60,7 @@ class TestGmailService(ConfigTest):
         with patch("google.oauth2.reauth.refresh_grant") as mock_refresh_grant:
             access_token = "newaccesstoken"
             refresh_token = "newrefreshtoken"
-            expiry = datetime.now(timezone.utc) + timedelta(hours=24)
+            expiry = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(hours=24)
             grant_response = {"id_token": "idtoken"}
             rapt_token = "reauthprooftoken"
             mock_refresh_grant.return_value = (

--- a/tests/test_phab.py
+++ b/tests/test_phab.py
@@ -19,9 +19,9 @@ class TestPhabricatorIssue(AbstractServiceTest, ServiceTest):
         super().setUp()
         self.service = self.get_mock_service(PhabricatorService)
         self.arbitrary_created = (
-            datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
         ).replace(tzinfo=pytz.UTC, microsecond=0)
-        self.arbitrary_updated = datetime.datetime.utcnow().replace(
+        self.arbitrary_updated = datetime.datetime.now(datetime.timezone.utc).replace(
             tzinfo=pytz.UTC, microsecond=0)
         self.arbitrary_duedate = (
             datetime.datetime.combine(datetime.date.today(),

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -18,9 +18,9 @@ class TestRedmineIssue(AbstractServiceTest, ServiceTest):
         'key': 'something_else',
         'issue_limit': '100',
     }
-    arbitrary_created = datetime.datetime.utcnow().replace(
+    arbitrary_created = datetime.datetime.now(datetime.timezone.utc).replace(
         tzinfo=dateutil.tz.tz.tzutc(), microsecond=0) - datetime.timedelta(1)
-    arbitrary_updated = datetime.datetime.utcnow().replace(
+    arbitrary_updated = datetime.datetime.now(datetime.timezone.utc).replace(
         tzinfo=dateutil.tz.tz.tzutc(), microsecond=0)
     arbitrary_issue = {
         "assigned_to": {


### PR DESCRIPTION
# PR Summary
This small PR migrates the `datetime` library in order to resolve the deprecation warnings which you can find in the [CI logs](https://github.com/GothenburgBitFactory/bugwarrior/actions/runs/14794815250/job/41539450794#step:4:1808):
```python
    /home/runner/work/bugwarrior/bugwarrior/tests/test_github.py:15: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
      datetime.datetime.utcnow() - datetime.timedelta(hours=1)

  tests/test_github.py:18
    /home/runner/work/bugwarrior/bugwarrior/tests/test_github.py:18: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
      datetime.datetime.utcnow() - datetime.timedelta(minutes=30)
  
  tests/test_github.py:20
    /home/runner/work/bugwarrior/bugwarrior/tests/test_github.py:20: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
      ARBITRARY_UPDATED = datetime.datetime.utcnow().replace(
...
```