### PR TITLE
More robust deadline parsing for logseq

### DIFF
--- a/bugwarrior/services/logseq.py
+++ b/bugwarrior/services/logseq.py
@@ -224,6 +224,7 @@ class LogseqIssue(Issue):
             scheduled.replace("DEADLINE: <", "")
             .replace("SCHEDULED: <", "")
             .replace(">", "")
+            .strip()
             .split(" ")
         )
         if len(date_split) == 2:  # <date day>


### PR DESCRIPTION
If there are additional spaces either inside or outside the enclosing angled brackets, ignore them.