### PR TITLE
Don't add annotations for Logseq-specific lines

### DIFF
--- a/bugwarrior/services/logseq.py
+++ b/bugwarrior/services/logseq.py
@@ -200,7 +200,22 @@ class LogseqIssue(Issue):
         annotations = []
         scheduled_date = None
         deadline_date = None
+        in_logbook = False
         for line in self.record["content"].split("\n"):
+            # Ignore things which are only useful within Logseq
+            if in_logbook:
+                if line.startswith(":END:"):
+                    in_logbook = False
+
+                continue
+
+            if line.startswith(":LOGBOOK:"):
+                in_logbook = True
+                continue
+
+            if line.startswith("id::"):
+                continue
+
             # handle special annotations
             if line.startswith("SCHEDULED: "):
                 scheduled_date = self.get_scheduled_date(line)

--- a/tests/test_logseq.py
+++ b/tests/test_logseq.py
@@ -15,9 +15,12 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
     }
 
     test_record = {
-        "properties": {"duration": '{"TODO":[0,1699562197346]}'},
+        "properties": {
+            "id": "67dae9ea-8e4d-4ad1-91dc-72aacc72a802",
+            "duration": '{"TODO":[0,1699562197346]}',
+        },
         "priority": "C",
-        "properties-order": ["duration"],
+        "properties-order": ["duration", "id"],
         "parent": {"id": 7083},
         "id": 7146,
         "uuid": "66699a83-3ee0-4edc-81c6-a24c9b80bec6",
@@ -30,8 +33,15 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
             {"id": 1777},
             {"id": 7070},
         ],
-        "content": "DOING [#A] Do something #[[Test tag]] #[[TestTag]] #TestTag",
-        "properties-text-values": {"duration": '{"TODO":[0,1699562197346]}'},
+        "content": ("DOING [#C] Do something #[[Test tag]] #[[TestTag]] #TestTag\n"
+                    "id:: 67dae9ea-8e4d-4ad1-91dc-72aacc72a802\n"
+                    ":LOGBOOK:\n"
+                    "CLOCK: [2025-06-03 Tue 13:56:47]--[2025-06-03 Tue 13:56:49] =>  00:00:02\n"
+                    ":END:"),
+        "properties-text-values": {
+            "duration": '{"TODO":[0,1699562197346]}',
+            "id": "67dae9ea-8e4d-4ad1-91dc-72aacc72a802",
+        },
         "marker": "DOING",
         "page": {"id": 7070},
         "left": {"id": 7109},


### PR DESCRIPTION
The `:LOGBOOK:` lines, as well as `id::` strings, are only useful within Logseq. Importing them into Taskwarrior just adds clutter.