### PR TITLE
Logseq service updates

### DIFF
--- a/bugwarrior/docs/services/logseq.rst
+++ b/bugwarrior/docs/services/logseq.rst
@@ -117,6 +117,35 @@ You can override this default behaviour to use alternative custom characters by 
     logseq.char_open_bracket = (
     logseq.char_close_bracket = )
 
+Import Labels as Tags
++++++++++++++++++++++
+
+Logseq tasks with ``#tag`` style page references in the description can be added to Taskwarrior as tags
+using the use the ``import_labels_as_tags`` option.
+
+.. config::
+    :fragment: logseq
+
+    logseq.import_labels_as_tags = True
+
+Single- and multi-word tags using the Logseq ``#[[Tag]]`` or ``#[[Multi Word]]`` format are always
+condensed to ``Tag`` and ``MultiWord`` before adding as Taskwarrior tags. The format of
+the page reference in the task description is unchanged.
+
+To futher control how labels are formatted, you can specify a template used for converting the Logseq tagged page
+reference into a Taskwarrior tag. For example, to force all tags to be in lower case, and retain the `#` prefiex 
+you could add the following configuration option:
+
+.. config::
+    :fragment: logseq
+
+        logseq.label_template = #{{label|lower}}
+
+If you change the tag format you may also need to set the general option ``replace_tags = True`` to replace existing
+tags that used the previous format.
+
+See :ref:`field_templates` for more more details on building templates.
+
 Logseq URI links
 ++++++++++++++++
 
@@ -145,15 +174,6 @@ Logseq URI in MacOS add the following to your ``~/..zshrc``
     }
 
 From the command line you can open a specific task using taskwarior task id, e.g. ``taskopen 1234``.
-
-Tags
-++++
-
-Logseq tasks with ``#tag`` style tag entries in the description are added to the Taskwarrior tags.
-Single- and multi-word tags using the Logseq ``#[[Tag]]`` or ``#[[Multi Word]]`` format are
-condensed to a ``Tag`` and ``MultiWord`` style before adding the Taskwarrior tags. The format of
-the tag content in the task description is unchanged.
-
 
 Troubleshooting
 ---------------

--- a/bugwarrior/docs/services/logseq.rst
+++ b/bugwarrior/docs/services/logseq.rst
@@ -139,7 +139,7 @@ you could add the following configuration option:
 .. config::
     :fragment: logseq
 
-        logseq.label_template = #{{label|lower}}
+    logseq.label_template = #{{label|lower}}
 
 If you change the tag format you may also need to set the general option ``replace_tags = True`` to replace existing
 tags that used the previous format.

--- a/bugwarrior/services/logseq.py
+++ b/bugwarrior/services/logseq.py
@@ -372,11 +372,9 @@ class LogseqService(Service):
     def issues(self):
         graph_name = self.client.get_graph_name()
         for issue in self.client.get_issues():
-            print(issue[0])
-            print(issue[0]["parent"]["id"])
             parent_page = self.client.get_page(issue[0]["parent"]["id"])
             extra = {
                 "graph": graph_name,
-                "page_title": parent_page["originalName"],
+                "page_title": parent_page["originalName"] if parent_page else None,
             }
             yield self.get_issue_for_record(issue[0], extra)

--- a/bugwarrior/services/logseq.py
+++ b/bugwarrior/services/logseq.py
@@ -32,6 +32,8 @@ class LogseqConfig(config.ServiceConfig):
     char_open_bracket: str = "〈"
     char_close_bracket: str = "〉"
     inline_links: bool = True
+    import_labels_as_tags: bool = False
+    label_template: str = '{{label}}'
 
     only_if_assigned: config.UnsupportedOption[str] = ""
     also_unassigned: config.UnsupportedOption[bool] = False
@@ -77,6 +79,18 @@ class LogseqClient(Client):
         graph = self._get_current_graph()
         return graph["name"] if graph else None
 
+    def get_page(self, page_id):
+        try:
+            response = requests.post(
+                f"http://{self.host}:{self.port}/api",
+                headers=self.headers,
+                json={"method": "logseq.getPage", "args": [page_id]},
+            )
+            return self.json_response(response)
+        except requests.exceptions.ConnectionError as ce:
+            log.fatal("Unable to connect to Logseq HTTP APIs server. %s", ce)
+            exit(1)
+
     def get_issues(self):
         query = f"""
             [:find (pull ?b [*])
@@ -100,6 +114,9 @@ class LogseqIssue(Issue):
     TITLE = "logseqtitle"
     DONE = "logseqdone"
     URI = "logsequri"
+    SCHEDULED = "logseqscheduled"
+    DEADLINE = "logseqdeadline"
+    PAGE = "logseqpage"
 
     # Local 2038-01-18, with time 00:00:00.
     # A date far away, with semantically meaningful to GTD users.
@@ -131,6 +148,18 @@ class LogseqIssue(Issue):
             "type": "string",
             "label": "Logseq URI",
         },
+        SCHEDULED: {
+            "type": "date",
+            "label": "Logseq Scheduled"
+        },
+        DEADLINE: {
+            "type": "date",
+            "label": "Logseq Deadline"
+        },
+        PAGE: {
+            "type": "string",
+            "label": "Logseq Page"
+        }
     }
 
     UNIQUE_KEY = (ID, UUID)
@@ -297,7 +326,7 @@ class LogseqIssue(Issue):
             "project": self.extra["graph"],
             "priority": self.get_priority(),
             "annotations": annotations,
-            "tags": self.get_tags_from_content(),
+            "tags": self.get_tags_from_labels(self.get_tags_from_content()),
             "due": deadline_date,
             "scheduled": scheduled_date,
             "wait": wait_date if self._is_waiting() else None,
@@ -307,6 +336,9 @@ class LogseqIssue(Issue):
             self.STATE: self.record["marker"],
             self.TITLE: self.get_formatted_title(),
             self.URI: self.get_url(),
+            self.SCHEDULED: scheduled_date,
+            self.DEADLINE: deadline_date,
+            self.PAGE: self.extra["page_title"],
         }
 
     def get_default_description(self):
@@ -324,16 +356,27 @@ class LogseqService(Service):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.token = self.get_password('token')
         filter = '"' + '" "'.join(self.config.task_state) + '"'
         self.client = LogseqClient(
             host=self.config.host,
             port=self.config.port,
-            token=self.config.token,
+            token=self.token,
             filter=filter,
         )
+
+    @staticmethod
+    def get_keyring_service(config):
+        return f"http://{config.host}:{config.port}"
 
     def issues(self):
         graph_name = self.client.get_graph_name()
         for issue in self.client.get_issues():
-            extra = {"graph": graph_name}
+            print(issue[0])
+            print(issue[0]["parent"]["id"])
+            parent_page = self.client.get_page(issue[0]["parent"]["id"])
+            extra = {
+                "graph": graph_name,
+                "page_title": parent_page["originalName"],
+            }
             yield self.get_issue_for_record(issue[0], extra)

--- a/bugwarrior/services/logseq.py
+++ b/bugwarrior/services/logseq.py
@@ -346,7 +346,7 @@ class LogseqIssue(Issue):
             title=self.get_formatted_title(),
             url=self.get_url() if self.config.inline_links else "",
             number=self.record["id"],
-            cls="issue",
+            cls="task",
         )
 
 

--- a/tests/test_logseq.py
+++ b/tests/test_logseq.py
@@ -178,7 +178,7 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
 
         expected = {
             "annotations": [],
-            "description": f"(bw)Is#{self.test_record['id']}"
+            "description": f"(bw)#{self.test_record['id']}"
             + " - Do something http://example.com/page#NotATag `#code`"
             + " #【Test tag one】 #【TestTagTwo】 #TestTagThree"
             + " .. "

--- a/tests/test_logseq.py
+++ b/tests/test_logseq.py
@@ -53,6 +53,20 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
     test_extra = {
         "baseURI": "logseq://graph/Test?block-id=",
         "graph": "Test",
+        "page_title": "TestPageTitle",
+    }
+
+    test_page = {
+        "updatedAt": 1751385600000,
+        "journalDay": 20250701,
+        "createdAt": 1751371200000,
+        "id": 19,
+        "name": "jul 1st, 2025",
+        "uuid": "6692f0c1-f610-40e3-840f-ba763627de40",
+        "journal?": True,
+        "originalName": "Jul 1st, 2025",
+        "file": {"id": 25},
+        "format": "markdown",
     }
 
     def setUp(self):
@@ -60,9 +74,6 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
 
         self.service = self.get_mock_service(LogseqService)
         self.service.client = mock.MagicMock(spec=LogseqClient)
-        self.service.client.get_issues = mock.MagicMock(
-            return_value=[self.test_record, self.test_extra]
-        )
 
     def test_to_taskwarrior(self):
         issue = self.service.get_issue_for_record(self.test_record, self.test_extra)
@@ -75,22 +86,36 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
             "status": "pending",
             "priority": "L",
             "project": self.test_extra["graph"],
-            "tags": ["Testtagone", "TestTagTwo", "TestTagThree"],
+            "tags": [],
             issue.ID: int(self.test_record["id"]),
             issue.UUID: self.test_record["uuid"],
             issue.STATE: self.test_record["marker"],
             issue.TITLE: "Do something http://example.com/page#NotATag `#code`"
             + " #【Test tag one】 #【TestTagTwo】 #TestTagThree",
             issue.URI: self.test_extra["baseURI"] + self.test_record["uuid"],
+            issue.SCHEDULED: None,
+            issue.DEADLINE: None,
+            issue.PAGE: "TestPageTitle",
         }
 
         actual = issue.to_taskwarrior()
 
         self.assertEqual(actual, expected)
 
+    def test_to_taskwarrior_with_tags(self):
+        overrides = {
+            "import_labels_as_tags": "True",
+        }
+        service = self.get_mock_service(LogseqService, config_overrides=overrides)
+        issue = service.get_issue_for_record(self.test_record, self.test_extra)
+
+        actual = issue.to_taskwarrior()
+        self.assertEqual(actual["tags"], ["Testtagone", "TestTagTwo", "TestTagThree"])
+
     def test_issues(self):
         self.service.client.get_graph_name.return_value = self.test_extra["graph"]
         self.service.client.get_issues.return_value = [[self.test_record]]
+        self.service.client.get_page.return_value = self.test_page
         issue = next(self.service.issues())
 
         expected = {
@@ -107,13 +132,16 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
             "status": "pending",
             "priority": "L",
             "project": self.test_extra["graph"],
-            "tags": ["Testtagone", "TestTagTwo", "TestTagThree"],
+            "tags": [],
             issue.ID: int(self.test_record["id"]),
             issue.UUID: self.test_record["uuid"],
             issue.STATE: self.test_record["marker"],
             issue.TITLE: "Do something http://example.com/page#NotATag `#code`"
             + " #【Test tag one】 #【TestTagTwo】 #TestTagThree",
             issue.URI: self.test_extra["baseURI"] + self.test_record["uuid"],
+            issue.SCHEDULED: None,
+            issue.DEADLINE: None,
+            issue.PAGE: "Jul 1st, 2025",
         }
 
         self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)

--- a/tests/test_logseq.py
+++ b/tests/test_logseq.py
@@ -1,9 +1,12 @@
 from unittest import mock
 
 from bugwarrior.collect import TaskConstructor
-from bugwarrior.services.logseq import LogseqService, LogseqClient
+from bugwarrior.services.logseq import LogseqService, LogseqClient, LogseqIssue
 
 from .base import AbstractServiceTest, ServiceTest
+
+import datetime
+import copy
 
 
 class TestLogseqIssue(AbstractServiceTest, ServiceTest):
@@ -35,6 +38,8 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
         ],
         "content": ("DOING [#C] Do something http://example.com/page#NotATag `#code`"
                     " #[[Test tag one]] #[[TestTagTwo]] #TestTagThree\n"
+                    "SCHEDULED: <2025-07-01 Tue>\n"
+                    "DEADLINE: <2025-07-31 Thu>\n"
                     "id:: 67dae9ea-8e4d-4ad1-91dc-72aacc72a802\n"
                     ":LOGBOOK:\n"
                     "CLOCK: [2025-06-03 Tue 13:56:47]--[2025-06-03 Tue 13:56:49] =>  00:00:02\n"
@@ -80,8 +85,8 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
 
         expected = {
             "annotations": [],
-            "due": None,
-            "scheduled": None,
+            "due": datetime.datetime(year=2025, month=7, day=31),
+            "scheduled": datetime.datetime(year=2025, month=7, day=1),
             "wait": None,
             "status": "pending",
             "priority": "L",
@@ -93,8 +98,8 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
             issue.TITLE: "Do something http://example.com/page#NotATag `#code`"
             + " #【Test tag one】 #【TestTagTwo】 #TestTagThree",
             issue.URI: self.test_extra["baseURI"] + self.test_record["uuid"],
-            issue.SCHEDULED: None,
-            issue.DEADLINE: None,
+            issue.SCHEDULED: datetime.datetime(year=2025, month=7, day=1),
+            issue.DEADLINE: datetime.datetime(year=2025, month=7, day=31),
             issue.PAGE: "TestPageTitle",
         }
 
@@ -112,6 +117,59 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
         actual = issue.to_taskwarrior()
         self.assertEqual(actual["tags"], ["Testtagone", "TestTagTwo", "TestTagThree"])
 
+    def test_to_taskwarrior_todo(self):
+        test_record = copy.copy(self.test_record)
+        test_record["content"] = ("TODO test task in todo state\n")
+        test_record["marker"] = "TODO"
+        issue = self.service.get_issue_for_record(test_record, self.test_extra)
+        actual = issue.to_taskwarrior()
+        self.assertEqual(actual["status"], "pending")
+
+    def test_to_taskwarrior_waiting(self):
+        test_record = copy.copy(self.test_record)
+        test_record["content"] = ("WAITING test task in waiting state\n")
+        test_record["marker"] = "WAITING"
+        issue = self.service.get_issue_for_record(test_record, self.test_extra)
+        actual = issue.to_taskwarrior()
+        self.assertEqual(actual["status"], "pending")
+        self.assertEqual(actual["wait"], LogseqIssue.SOMEDAY)
+
+    def test_to_taskwarrior_dates_with_time(self):
+        test_record = copy.copy(self.test_record)
+        test_record["content"] = ("DOING test schedule and deadline dates with times\n"
+                                  "SCHEDULED: <2025-07-01 Tue 12:30>\n"
+                                  "DEADLINE: <2025-07-31 Thu 12:30>"
+                                  )
+        print(test_record)
+
+        issue = self.service.get_issue_for_record(test_record, self.test_extra)
+        actual = issue.to_taskwarrior()
+
+        scheduled = datetime.datetime(year=2025, month=7, day=1, hour=12, minute=30)
+        deadline = datetime.datetime(year=2025, month=7, day=31, hour=12, minute=30)
+        self.assertEqual(actual["scheduled"], scheduled)
+        self.assertEqual(actual["due"], deadline)
+        self.assertEqual(actual[issue.SCHEDULED], scheduled)
+        self.assertEqual(actual[issue.DEADLINE], deadline)
+
+    def test_to_taskwarrior_dates_with_repeat(self):
+        test_record = copy.copy(self.test_record)
+        test_record["content"] = ("DOING test schedule and deadline dates with times\n"
+                                  "SCHEDULED: <2025-07-01 Tue 12:30 .+1d>\n"
+                                  "DEADLINE: <2025-07-31 Thu .+1d>"
+                                  )
+        print(test_record)
+
+        issue = self.service.get_issue_for_record(test_record, self.test_extra)
+        actual = issue.to_taskwarrior()
+
+        scheduled = datetime.datetime(year=2025, month=7, day=1, hour=12, minute=30)
+        deadline = datetime.datetime(year=2025, month=7, day=31)
+        self.assertEqual(actual["scheduled"], scheduled)
+        self.assertEqual(actual["due"], deadline)
+        self.assertEqual(actual[issue.SCHEDULED], scheduled)
+        self.assertEqual(actual[issue.DEADLINE], deadline)
+
     def test_issues(self):
         self.service.client.get_graph_name.return_value = self.test_extra["graph"]
         self.service.client.get_issues.return_value = [[self.test_record]]
@@ -126,8 +184,8 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
             + " .. "
             + self.test_extra["baseURI"]
             + self.test_record["uuid"],
-            "due": None,
-            "scheduled": None,
+            "due": datetime.datetime(year=2025, month=7, day=31),
+            "scheduled": datetime.datetime(year=2025, month=7, day=1),
             "wait": None,
             "status": "pending",
             "priority": "L",
@@ -139,8 +197,8 @@ class TestLogseqIssue(AbstractServiceTest, ServiceTest):
             issue.TITLE: "Do something http://example.com/page#NotATag `#code`"
             + " #【Test tag one】 #【TestTagTwo】 #TestTagThree",
             issue.URI: self.test_extra["baseURI"] + self.test_record["uuid"],
-            issue.SCHEDULED: None,
-            issue.DEADLINE: None,
+            issue.SCHEDULED: datetime.datetime(year=2025, month=7, day=1),
+            issue.DEADLINE: datetime.datetime(year=2025, month=7, day=31),
             issue.PAGE: "Jul 1st, 2025",
         }
 


### PR DESCRIPTION
Multiple updates to the Logseq service:

- update Logseq service to use `self.get_password()` for the API token setting, enabling the [password management](https://bugwarrior.readthedocs.io/en/latest/common_configuration.html#password-management) options for storing the token. Fixes #1063
- adds Logseq Page title as a UDA. Fixes #1064 
- adds UDAs to Logseq for Scheduled Date and Deadline Date, allowing for the date fields to be used in custom `due_template` and `scheduled_template` configuration.
- update Logseq service to use `Issue.get_tags_from_labels()` to enable support for standard tag handling configuration options. **BREAKING CHANGE** Tags will now only get updated if the `logseq.import_labels_as_tags` configuration option is enabled.
- changed record type from `issue` to `task` - removes the `Is` prefix on the id in the generated description 
- Updated tests to remove some redundant code and improve test coverage