### PR TITLE
Use an email address for the assignee and creator

### DIFF
--- a/bugwarrior/services/linear.py
+++ b/bugwarrior/services/linear.py
@@ -89,8 +89,8 @@ class LinearIssue(Issue):
             self.STATE: get(get(self.record, "state", {}), "name"),
             self.IDENTIFIER: get(self.record, "identifier"),
             self.TEAM: get(get(self.record, "team", {}), "name"),
-            self.CREATOR: get(get(self.record, "creator", {}), "name"),
-            self.ASSIGNEE: get(get(self.record, "assignee", {}), "name"),
+            self.CREATOR: get(get(self.record, "creator", {}), "email"),
+            self.ASSIGNEE: get(get(self.record, "assignee", {}), "email"),
             self.CREATED_AT: created,
             self.UPDATED_AT: modified,
             self.CLOSED_AT: closed,
@@ -136,9 +136,11 @@ class LinearService(Service, Client):
                   title
                   description
                   assignee {
-                    name
+                    email
                   }
-                  creator {name}
+                  creator {
+                    email
+                  }
                   completedAt
                   updatedAt
                   createdAt

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -20,10 +20,10 @@ RESPONSE = json.loads(
                     "title": "DO STUFF",
                     "description": "Better get started",
                     "assignee": {
-                        "name": "djmitche@gmail.com"
+                        "email": "djmitche@gmail.com"
                     },
                     "creator": {
-                        "name": "djmitche@gmail.com"
+                        "email": "djmitche@gmail.com"
                     },
                     "createdAt": "2025-07-24T17:03:04.239Z",
                     "updatedAt": "2025-07-25T17:03:04.239Z",
@@ -45,7 +45,7 @@ RESPONSE = json.loads(
                     "title": "Interface Bugwarrior to Linear",
                     "description": "Make a PR",
                     "assignee": {
-                        "name": "djmitche@gmail.com"
+                        "email": "djmitche@gmail.com"
                     },
                     "creator": null,
                     "completedAt": null,


### PR DESCRIPTION
These UDAs had the assignee / creator shown as user name ("Dustin Mitchell") but email is probably more appropriate.