### PR TITLE
fix: 🚑️ config_filename was missing

### DIFF
--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -220,7 +220,7 @@ class RedMineIssue(Issue):
         return self.config.url + "/issues/" + str(self.record["id"])
 
     def get_converted_hours(self, estimated_hours):
-        tw = TaskWarriorShellout()
+        tw = TaskWarriorShellout(config_filename=self.main_config.taskrc)
         calc = tw._execute('calc', estimated_hours)
         return (
             calc[0].rstrip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ todoist = "bugwarrior.services.todoist:TodoistService"
 bugwarrior = "bugwarrior.config.ini2toml_plugin:activate"
 
 [tool.setuptools]
-packages = ["bugwarrior"]
+packages = ["bugwarrior", "bugwarrior.config", "bugwarrior.services"]
 
 [build-system]
 requires = ["setuptools"]


### PR DESCRIPTION
In my setup, `taskrc` was located as `${XDG_CONFIG_HOME}/task/taskrc` and the `get_converted_hours` function was panic'ing because it couldn't open `${HOME}/.taskrc` ... 