### PR TITLE
Fix setuptools package discovery.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,8 +94,8 @@ todoist = "bugwarrior.services.todoist:TodoistService"
 [project.entry-points."ini2toml.processing"]
 bugwarrior = "bugwarrior.config.ini2toml_plugin:activate"
 
-[tool.setuptools]
-packages = ["bugwarrior"]
+[tool.setuptools.packages.find]
+where = ["bugwarrior"]
 
 [build-system]
 requires = ["setuptools"]


### PR DESCRIPTION
Per
<https://setuptools.pypa.io/en/latest/userguide/package_discovery.html>, subpackages need to be explicitly defined in `packages`. While pip and uv somehow worked anyway, uvx did not (as reported in #1117). Rather than listing all subpackages or relying on automatic discovery, let's use the "find directive".