### PR TITLE
Trello sync fix error if card members is empty

### DIFF
--- a/bugwarrior/services/trello.py
+++ b/bugwarrior/services/trello.py
@@ -158,7 +158,7 @@ class TrelloService(Service, Client):
             f"/1/lists/{list_id}/cards/open",
             **params)
         for card in cards:
-            cardmembers = [m['username'] for m in card['members']]
+            cardmembers = [m['username'] for m in card.get('members', [])]
             if (not self.config.only_if_assigned
                     or self.config.only_if_assigned in cardmembers
                     or (self.config.also_unassigned and not cardmembers)):


### PR DESCRIPTION
If a Trello board is not shared with other users it can have no members which causes sync to fail with an error:

```txt
INFO:bugwarrior.collect:Spawning 1 workers.
Worker for [trello] failed: 'members'
Traceback (most recent call last):
  File "/Users/stephen/Development/bugwarrior/bugwarrior/collect.py", line 42, in _aggregate_issues
    for issue in service.issues():
                 ^^^^^^^^^^^^^^^^
  File "/Users/stephen/Development/bugwarrior/bugwarrior/services/trello.py", line 100, in issues
    for card in self.get_cards(lst['id']):
                ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stephen/Development/bugwarrior/bugwarrior/services/trello.py", line 162, in get_cards
    cardmembers = [m['username'] for m in card['members']]
                                          ~~~~^^^^^^^^^^^
KeyError: 'members'
ERROR:bugwarrior.collect:Aborted [trello] due to critical error.
```

This fix handles the case where the `members` attribute is not present in the returned card details.