### PR TITLE
Fix setuptools find package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ todoist = "bugwarrior.services.todoist:TodoistService"
 bugwarrior = "bugwarrior.config.ini2toml_plugin:activate"
 
 [tool.setuptools.packages.find]
-where = ["bugwarrior"]
+include = ["bugwarrior*"]
 
 [build-system]
 requires = ["setuptools"]


### PR DESCRIPTION
#1119 seems to have broken the package for me:

```
Traceback (most recent call last):
  File "/home/eri/Code/experiments/bugwarrior/.venv/bin/bugwarrior", line 5, in <module>
    from bugwarrior import cli
ModuleNotFoundError: No module named 'bugwarrior'
```

I think the issue is that `where = ["bugwarrior"]` is removing the `bugwarrior` prefix. I have tested using the base directory (without `where`) and [including](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#finding-simple-packages) the packages in the `bugwarrior` namespace and that seems to work fine.