### PR TITLE
Queries all issues from Jira not just the default 50

### DIFF
--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -434,7 +434,7 @@ class JiraService(Service):
         )
 
     def issues(self):
-        cases = self.jira.search_issues(self.query, maxResults=None)
+        cases = self.jira.search_issues(self.query, maxResults=False)
 
         for case in cases:
             issue = self.get_issue_for_record(


### PR DESCRIPTION
Apparantly the python jira module changed its API and the parameter must evaluate to `false` now.