### PR TITLE
fix(jira): change search_issues() to extended_search_issues()

### DIFF
--- a/.github/workflows/bugwarrior.yml
+++ b/.github/workflows/bugwarrior.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: [3.9, "3.10", 3.11]
+        python-version: ["3.10", 3.11]
         jira-version: [1.0.10, 2.0.0]
     steps:
       - name: Checkout code
@@ -46,7 +46,7 @@ jobs:
         # Fragile way to only run codecov once.
         # See https://github.com/codecov/codecov-action/issues/40.
         if: |
-          matrix.python-version == 3.9 &&
+          matrix.python-version == 3.10 &&
           matrix.jira-version == '2.0.0'
   bugwarrior-multiarch-test:
     runs-on: ubuntu-latest

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -434,7 +434,7 @@ class JiraService(Service):
         )
 
     def issues(self):
-        cases = self.jira.search_issues(self.query, maxResults=False)
+        cases = self.jira.extended_search_issues(self.query, maxResults=False)
 
         for case in cases:
             issue = self.get_issue_for_record(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "bugwarrior"
 version = "2.0.0-alpha"
 description = "a command line utility for updating your local taskwarrior database from your forge issue trackers"
 readme = "bugwarrior/README.rst"
-requires-python = ">3.9,<4"
+requires-python = ">=3.10,<4"
 license = "GPL-3.0-or-later"
 license-files = ["LICENSE.txt"]
 keywords=["task", "taskwarrior", "todo", "github"]
@@ -33,7 +33,7 @@ bts = ["python-debianbts>=2.6.1"]
 bugzilla = ["python-bugzilla>=2.0.0"]
 gmail = ["google-api-python-client", "google-auth-oauthlib"]
 ini2toml = ["ini2toml[full]"]
-jira = ["jira>=0.22"]
+jira = ["jira>=3.10.0"]
 kanboard = ["kanboard"]
 keyring = ["keyring"]
 phabricator = ["phabricator"]

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -15,7 +15,7 @@ class FakeJiraClient:
     def __init__(self, arbitrary_record):
         self.arbitrary_record = arbitrary_record
 
-    def search_issues(self, *args, **kwargs):
+    def extended_search_issues(self, *args, **kwargs):
         Case = namedtuple('Case', ['raw', 'key'])
         return [Case(self.arbitrary_record, self.arbitrary_record['key'])]
 


### PR DESCRIPTION
- also change dep for jira>=3.10.5 (may be able to be earlier, did not check - 0.22 did not have the 'new' api)

- [X] tested this locally as a hotpatch
- [ ] need to test this from packaged build

Fixes: Jira failing with deprecation error
Fixes #1124