### PR TITLE
Rename Service.get_password -> Service.get_secret

### DIFF
--- a/bugwarrior/docs/common_configuration.rst
+++ b/bugwarrior/docs/common_configuration.rst
@@ -170,18 +170,18 @@ regardless of what project was assigned by the service itself:
 
    github.project_template = Office
 
-.. _Password Management:
+.. _Secret Management:
 
-Password Management
--------------------
+Secret Management
+-----------------
 
-You need not store your password in plain text in your `bugwarriorrc` file;
-you can enter the following values to control where to gather your password
+You need not store your secrets in plain text in your `bugwarriorrc` file;
+you can enter the following values to control where to gather your secrets
 from:
 
 ``password = @oracle:use_keyring``
-  Retrieve a password from the system keyring.  The ``bugwarrior vault``
-  command line tool can be used to manage your passwords as stored in your
+  Retrieve a secret from the system keyring.  The ``bugwarrior vault``
+  command line tool can be used to manage your secrets as stored in your
   keyring (say to reset them or clear them).  Extra dependencies must be
   installed with `pip install bugwarrior[keyring]` to enable this feature.
 ``password = @oracle:ask_password``

--- a/bugwarrior/docs/other-services/tutorial.rst
+++ b/bugwarrior/docs/other-services/tutorial.rst
@@ -217,6 +217,10 @@ Here we see two required class attributes (pointing to the classes we previously
 
 The ``issues`` method is a generator which yields individual issue dictionaries.
 
+.. note::
+
+  Sensitive configuration values should be fetched with ``self.get_secret()`` so that they can be optionally retrieved with :ref:`oracles <Secret Management>`.
+
 7. Service Registration
 -----------------------
 

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -234,8 +234,8 @@ class Service(abc.ABC):
 
         log.info("Working on [%s]", self.config.target)
 
-    def get_password(self, key, login='nousername') -> str:
-        """ Get a secret value, potentially from an :ref:`oracle <Password Management>`.
+    def get_secret(self, key, login='nousername') -> str:
+        """ Get a secret value, potentially from an :ref:`oracle <Secret Management>`.
 
         The secret key need not be a *password*, per se.
 

--- a/bugwarrior/services/azuredevops.py
+++ b/bugwarrior/services/azuredevops.py
@@ -186,7 +186,7 @@ class AzureDevopsService(Service):
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
         self.client = AzureDevopsClient(
-            pat=self.get_password('PAT'),
+            pat=self.get_secret('PAT'),
             project=self.config.project,
             org=self.config.organization,
             host=self.config.host

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -98,7 +98,7 @@ class BitbucketService(Service, Client):
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
 
-        oauth = (self.config.key, self.get_password('secret', self.config.key))
+        oauth = (self.config.key, self.get_secret('secret', self.config.key))
         refresh_token = self.main_config.data.get('bitbucket_refresh_token')
 
         if refresh_token:

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -167,7 +167,7 @@ class BugzillaService(Service):
             force_rest_kwargs = {"force_rest": True}
 
         if self.config.api_key:
-            api_key = self.get_password('api_key')
+            api_key = self.get_secret('api_key')
             try:
                 self.bz = bugzilla.Bugzilla(url=self.config.base_uri,
                                             api_key=api_key,
@@ -178,7 +178,7 @@ class BugzillaService(Service):
             self.bz = bugzilla.Bugzilla(url=self.config.base_uri,
                                         **force_rest_kwargs)
             if self.config.password:
-                password = self.get_password('password', self.config.username)
+                password = self.get_secret('password', self.config.username)
                 self.bz.login(self.config.username, password)
 
     @staticmethod

--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -96,7 +96,7 @@ class GerritService(Service, Client):
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
-        self.password = self.get_password('password', self.config.username)
+        self.password = self.get_secret('password', self.config.username)
         self.session = requests.session()
         self.session.headers.update({
             'Accept': 'application/json',

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -323,7 +323,7 @@ class GithubService(Service):
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
 
-        auth = {'token': self.get_password('token', self.config.login)}
+        auth = {'token': self.get_secret('token', self.config.login)}
         self.client = GithubClient(self.config.host, auth)
 
     @staticmethod

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -534,7 +534,7 @@ class GitlabService(Service):
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
 
-        token = self.get_password('token', self.config.login)
+        token = self.get_secret('token', self.config.login)
         self.gitlab_client = GitlabClient(
             host=self.config.host,
             token=token,

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -378,10 +378,10 @@ class JiraService(Service):
         self.query = self.config.query or default_query
 
         if self.config.PAT:
-            pat = self.get_password('PAT', self.config.username)
+            pat = self.get_secret('PAT', self.config.username)
             auth = dict(token_auth=pat)
         else:
-            password = self.get_password('password', self.config.username)
+            password = self.get_secret('password', self.config.username)
             if password == '@kerberos':
                 auth = dict(kerberos=True)
             else:

--- a/bugwarrior/services/kanboard.py
+++ b/bugwarrior/services/kanboard.py
@@ -119,7 +119,7 @@ class KanboardService(Service):
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
-        password = self.get_password("password", self.config.username)
+        password = self.get_secret("password", self.config.username)
         self.client = Client(
             f"{self.config.url}/jsonrpc.php", self.config.username, password)
         default_query = f"status:open assignee:{self.config.username}"

--- a/bugwarrior/services/linear.py
+++ b/bugwarrior/services/linear.py
@@ -131,7 +131,7 @@ class LinearService(Service, Client):
 
         self.session = requests.Session()
         self.session.headers.update(
-            {"Authorization": self.get_password("api_token"), "Content-Type": "application/json"}
+            {"Authorization": self.get_secret("api_token"), "Content-Type": "application/json"}
         )
 
         self.filter = []

--- a/bugwarrior/services/logseq.py
+++ b/bugwarrior/services/logseq.py
@@ -356,7 +356,7 @@ class LogseqService(Service):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.token = self.get_password('token')
+        self.token = self.get_secret('token')
         filter = '"' + '" "'.join(self.config.task_state) + '"'
         self.client = LogseqClient(
             host=self.config.host,

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -251,9 +251,9 @@ class RedMineService(Service):
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
 
-        self.key = self.get_password('key')
+        self.key = self.get_secret('key')
 
-        password = (self.get_password('password', self.config.login)
+        password = (self.get_secret('password', self.config.login)
                     if self.config.login else None)
         auth = ((self.config.login, password)
                 if (self.config.login and password) else None)

--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -72,7 +72,7 @@ class TaigaService(Service, Client):
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
-        self.auth_token = self.get_password('auth_token')
+        self.auth_token = self.get_secret('auth_token')
         self.session = requests.session()
         self.session.headers.update({
             'Accept': 'application/json',

--- a/bugwarrior/services/todoist.py
+++ b/bugwarrior/services/todoist.py
@@ -225,7 +225,7 @@ class TodoistService(Service):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.token = self.get_password("token")
+        self.token = self.get_secret("token")
 
         # apply additional filters
         filter = self.config.filter

--- a/bugwarrior/services/trac.py
+++ b/bugwarrior/services/trac.py
@@ -97,7 +97,7 @@ class TracService(Service):
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
         if self.config.username:
-            password = self.get_password('password', self.config.username)
+            password = self.get_secret('password', self.config.username)
 
             auth = urllib.parse.quote_plus(
                 f'{self.config.username}:{password}@')

--- a/bugwarrior/services/trello.py
+++ b/bugwarrior/services/trello.py
@@ -181,6 +181,6 @@ class TrelloService(Service, Client):
         key and token from the configuration
         """
         params['key'] = self.config.api_key,
-        params['token'] = self.get_password('token'),
+        params['token'] = self.get_secret('token'),
         url = "https://api.trello.com" + url
         return self.json_response(requests.get(url, params=params))

--- a/bugwarrior/services/youtrack.py
+++ b/bugwarrior/services/youtrack.py
@@ -143,7 +143,7 @@ class YoutrackService(Service, Client):
             requests.packages.urllib3.disable_warnings()
             self.session.verify = False
 
-        token = self.get_password('token', self.config.login)
+        token = self.get_secret('token', self.config.login)
         self.session.headers['Authorization'] = f'Bearer {token}'
 
     @staticmethod


### PR DESCRIPTION
Passwords are becoming less prevalent as an authentication method. Neglecting to use this feature is a common oversight with new services and hopefully a more relevant name along with more documentation will make this easier to remember.