### PR TITLE
fix(jira): change extended_search_issues() to enhanced_search_issues()

### DIFF
--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -434,7 +434,7 @@ class JiraService(Service):
         )
 
     def issues(self):
-        cases = self.jira.extended_search_issues(self.query, maxResults=False)
+        cases = self.jira.enhanced_search_issues(self.query, maxResults=False)
 
         for case in cases:
             issue = self.get_issue_for_record(

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -15,7 +15,7 @@ class FakeJiraClient:
     def __init__(self, arbitrary_record):
         self.arbitrary_record = arbitrary_record
 
-    def extended_search_issues(self, *args, **kwargs):
+    def enhanced_search_issues(self, *args, **kwargs):
         Case = namedtuple('Case', ['raw', 'key'])
         return [Case(self.arbitrary_record, self.arbitrary_record['key'])]
 


### PR DESCRIPTION
Fixes #1124 again

I don't know how this happened, I thought I was testing the equivalent of #1125 but somehow I wasn't, and in fact the "old" api stopped failing for some reason.

I have really and actually been able to repro the failure reported in #1125 comment, and I am now running my own production bugwarrior out of this PR and it is working.