### PR TITLE
ini2toml: get config types by inspection

### DIFF
--- a/bugwarrior/config/data.py
+++ b/bugwarrior/config/data.py
@@ -42,6 +42,13 @@ class BugwarriorData:
         #: services can manage their own files here.
         self.path = data_path
 
+    @classmethod
+    def __modify_schema__(cls, field_schema: typing.Dict[str, typing.Any]) -> None:
+        """ Fix schema generation in pydantic. """
+        field_schema.update(
+            {"type": "object", "description": "Local data storage"}
+        )
+
     def get_data(self) -> dict:
         """ Return all data from the ``bugwarrior.data`` file. """
         with open(self._datafile) as jsondata:

--- a/bugwarrior/config/ini2toml_plugin.py
+++ b/bugwarrior/config/ini2toml_plugin.py
@@ -1,3 +1,5 @@
+import importlib
+import inspect
 import logging
 import re
 import typing
@@ -6,66 +8,9 @@ from ini2toml.types import IntermediateRepr, Translator
 import pydantic.v1
 from pydantic.v1 import BaseModel
 
-from .schema import ConfigList
+from .schema import ConfigList, Hooks, MainSectionConfig, Notifications, ServiceConfig
 
 log = logging.getLogger(__name__)
-
-BOOLS = {
-    'general': ['interactive', 'shorten', 'inline_links', 'annotation_links',
-                'annotation_comments', 'annotation_newlines',
-                'merge_annotations', 'merge_tags', 'replace_tags'],
-    'bitbucket': ['filter_merge_requests', 'include_merge_requests',
-                  'project_owner_prefix'],
-    'bts': ['udd', 'ignore_pending', 'udd_ignore_sponsor'],
-    'bugzilla': ['ignore_cc', 'include_needinfos', 'force_rest', 'advanced'],
-    'deck': ['import_labels_as_tags'],
-    'gitbug': ['import_labels_as_tags'],
-    'github': ['include_user_repos', 'import_labels_as_tags',
-               'filter_pull_requests', 'exclude_pull_requests',
-               'include_user_issues', 'involved_issues', 'project_owner_prefix'
-               ],
-    'gitlab': ['filter_merge_requests', 'membership', 'owned',
-               'import_labels_as_tags', 'include_merge_requests',
-               'include_issues', 'include_todos', 'include_all_todos',
-               'use_https', 'project_owner_prefix'],
-    'jira': ['import_labels_as_tags', 'import_sprints_as_tags', 'use_cookies',
-             'verify_ssl'],
-    'pagure': ['import_tags'],
-    'phabricator': ['ignore_cc', 'ignore_author', 'ignore_owner',
-                    'ignore_reviewers', 'only_if_assigned'],
-    'pivotaltracker': ['import_blockers', 'import_labels_as_tags',
-                       'only_if_author', 'only_if_assigned'],
-    'redmine': ['verify_ssl'],
-    'taiga': ['include_tasks'],
-    'track': ['no_xmlrpc'],
-    'trello': ['import_labels_as_tags'],
-    'youtrack': ['anonymous', 'use_https', 'verify_ssl', 'incloud_instance',
-                 'import_tags'],
-}
-
-INTEGERS = {
-    'general': ['annotation_length', 'description_length'],
-    'gitbug': ['port'],
-    'github': ['body_length'],
-    'jira': ['body_length', 'version'],
-    'pivotaltracker': ['user_id'],
-    'redmine': ['issue_limit'],
-    'youtrack': ['port', 'query_limit'],
-}
-
-CONFIGLIST = {
-    'general': ['targets', 'static_tags', 'static_fields'],
-    'github': ['include_repos', 'exclude_repos', 'issue_urls'],
-    'pivotaltracker': ['account_ids', 'exclude_projects', 'exclude_stories', 'exclude_tags'],
-    'gitlab': ['include_repos', 'exclude_repos'],
-    'bitbucket': ['include_repos', 'exclude_repos'],
-    'phabricator': ['user_phids', 'project_phids'],
-    'trello': ['include_boards', 'include_lists', 'exclude_lists'],
-    'bts': ['packages', 'ignore_pkg', 'ignore_src'],
-    'deck': ['include_board_ids', 'exclude_board_ids'],
-    'bugzilla': ['open_statuses'],
-    'pagure': ['include_repos', 'exclude_repos'],
-}
 
 
 def to_type(section: IntermediateRepr, key: str, converter: typing.Callable):
@@ -99,31 +44,40 @@ def to_list(section: IntermediateRepr, key: str):
     to_type(section, key, ConfigList.validate)
 
 
+def convert_section(section: IntermediateRepr, schema: BaseModel):
+    for prop, attrs in schema.schema()['properties'].items():
+        try:
+            t = attrs['type']
+        except KeyError:
+            pass  # optional
+        else:
+            if t == 'boolean':
+                to_bool(section, prop)
+            elif t == 'integer':
+                to_int(section, prop)
+            elif t == 'array':
+                to_list(section, prop)
+
+
 def process_values(doc: IntermediateRepr) -> IntermediateRepr:
     for name, section in doc.items():
         if isinstance(name, str):
             if name == 'general' or re.match(r'^flavor\.', name):
-                for k in INTEGERS['general']:
-                    to_int(section, k)
-                for k in CONFIGLIST['general']:
-                    to_list(section, k)
-                for k in BOOLS['general']:
-                    to_bool(section, k)
+                convert_section(section, MainSectionConfig)
                 for k in ['log.level', 'log.file']:
                     if k in section:
                         section.rename(k, k.replace('.', '_'))
             elif name == 'hooks':
-                to_list(section, 'pre_import')
+                convert_section(section, Hooks)
             elif name == 'notifications':
-                to_bool(section, 'notifications')
-                to_bool(section, 'only_on_new_tasks')
+                convert_section(section, Notifications)
             else:  # services
                 service = section['service']
 
                 # Validate and strip prefixes.
                 for key in section.keys():
-                    prefix = 'ado' if service == 'azuredevops' else service
                     if isinstance(key, str) and key != 'service':
+                        prefix = 'ado' if service == 'azuredevops' else service
                         newkey, subs = re.subn(f'^{prefix}\\.', '', key)
                         if subs != 1:
                             option = key.split('.').pop()
@@ -133,14 +87,21 @@ def process_values(doc: IntermediateRepr) -> IntermediateRepr:
                                 f"'{prefix}.{option}'?")
                         section.rename(key, newkey)
 
-                to_bool(section, 'also_unassigned')
-                to_list(section, 'add_tags')
-                for k in INTEGERS.get(service, []):
-                    to_int(section, k)
-                for k in CONFIGLIST.get(service, []):
-                    to_list(section, k)
-                for k in BOOLS.get(service, []):
-                    to_bool(section, k)
+                # Get Config
+                module_name = {'bugzilla': 'bz', 'phabricator': 'phab'}.get(service, service)
+                service_module = importlib.import_module(
+                    f'bugwarrior.services.{module_name}')
+                for name, obj in inspect.getmembers(
+                        service_module, predicate=inspect.isclass):
+                    if issubclass(obj, ServiceConfig):
+                        schema = obj
+                        break
+                else:
+                    raise ValueError(
+                        f"ServiceConfig class not found in {service} module.")
+
+                # Convert Types
+                convert_section(section, schema)
                 if service == 'gitlab' and 'verify_ssl' in section.keys():
                     try:
                         to_bool(section, 'verify_ssl')


### PR DESCRIPTION
The solution of recording these mappings in ini2toml was always fragile and error-prone. I realized that I completely forgot to update it for new services such as Linear and it turns out it's not too difficult to get the types by introspection.

I'm fairly confident this doesn't break existing behavior because `TestIni2Toml.test_bugwarriorrc` assures us that nothing changed in running ini2toml on the example configuration.

This fixes the linear docs where I noticed the list-typed examples are being converted to strings in the toml tabs.