### PR TITLE
Service API: add a version number and enforce it

### DIFF
--- a/bugwarrior/docs/other-services/api.rst
+++ b/bugwarrior/docs/other-services/api.rst
@@ -1,5 +1,5 @@
-Python API
-==========
+Python API v1.0
+===============
 
 The interfaces documented here are considered stable. All other interfaces
 should be considered private to bugwarrior and are subject to change without

--- a/bugwarrior/docs/other-services/tutorial.rst
+++ b/bugwarrior/docs/other-services/tutorial.rst
@@ -199,6 +199,7 @@ Now for the main service class which bugwarrior will invoke to fetch issues.
 .. code:: python
 
   class GitBugService(Service):
+      API_VERSION = 1.0
       ISSUE_CLASS = GitBugIssue
       CONFIG_SCHEMA = GitBugConfig
 
@@ -228,7 +229,9 @@ Now for the main service class which bugwarrior will invoke to fetch issues.
 
               yield self.get_issue_for_record(issue)
 
-Here we see two required class attributes (pointing to the classes we previously defined) and two required methods.
+Here we see three required class attributes and two required methods.
+
+The ``API_VERSION`` is set to the latest, while the other two attributes point to our previously defined classes.
 
 The ``get_keyring_service`` method returns a string identifier for secrets in the keyring. Ideally, this string uniquely identifies a given instance of the service when it is possible to have multiple instances of the service configured.
 

--- a/bugwarrior/services/azuredevops.py
+++ b/bugwarrior/services/azuredevops.py
@@ -180,6 +180,7 @@ class AzureDevopsIssue(Issue):
 
 
 class AzureDevopsService(Service):
+    API_VERSION = 1.0
     ISSUE_CLASS = AzureDevopsIssue
     CONFIG_SCHEMA = AzureDevopsConfig
 

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -89,6 +89,7 @@ class BitbucketIssue(Issue):
 
 
 class BitbucketService(Service, Client):
+    API_VERSION = 1.0
     ISSUE_CLASS = BitbucketIssue
     CONFIG_SCHEMA = BitbucketConfig
 

--- a/bugwarrior/services/bts.py
+++ b/bugwarrior/services/bts.py
@@ -142,6 +142,7 @@ class BTSIssue(Issue):
 
 
 class BTSService(Service, Client):
+    API_VERSION = 1.0
     ISSUE_CLASS = BTSIssue
     CONFIG_SCHEMA = BTSConfig
 

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -143,6 +143,7 @@ class BugzillaIssue(Issue):
 
 
 class BugzillaService(Service):
+    API_VERSION = 1.0
     ISSUE_CLASS = BugzillaIssue
     CONFIG_SCHEMA = BugzillaConfig
 

--- a/bugwarrior/services/deck.py
+++ b/bugwarrior/services/deck.py
@@ -153,6 +153,7 @@ class NextcloudDeckIssue(Issue):
 
 
 class NextcloudDeckService(Service):
+    API_VERSION = 1.0
     ISSUE_CLASS = NextcloudDeckIssue
     CONFIG_SCHEMA = NextcloudDeckConfig
 

--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -91,6 +91,7 @@ class GerritIssue(Issue):
 
 
 class GerritService(Service, Client):
+    API_VERSION = 1.0
     ISSUE_CLASS = GerritIssue
     CONFIG_SCHEMA = GerritConfig
 

--- a/bugwarrior/services/gitbug.py
+++ b/bugwarrior/services/gitbug.py
@@ -149,6 +149,7 @@ class GitBugIssue(Issue):
 
 
 class GitBugService(Service):
+    API_VERSION = 1.0
     ISSUE_CLASS = GitBugIssue
     CONFIG_SCHEMA = GitBugConfig
 

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -317,6 +317,7 @@ class GithubIssue(Issue):
 
 
 class GithubService(Service):
+    API_VERSION = 1.0
     ISSUE_CLASS = GithubIssue
     CONFIG_SCHEMA = GithubConfig
 

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -528,6 +528,7 @@ class GitlabIssue(Issue):
 
 
 class GitlabService(Service):
+    API_VERSION = 1.0
     ISSUE_CLASS = GitlabIssue
     CONFIG_SCHEMA = GitlabConfig
 

--- a/bugwarrior/services/gmail.py
+++ b/bugwarrior/services/gmail.py
@@ -120,6 +120,7 @@ class GmailService(Service):
     APPLICATION_NAME = 'Bugwarrior Gmail Service'
     SCOPES = ['https://www.googleapis.com/auth/gmail.readonly']
 
+    API_VERSION = 1.0
     ISSUE_CLASS = GmailIssue
     CONFIG_SCHEMA = GmailConfig
     AUTHENTICATION_LOCK = multiprocessing.Lock()

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -365,6 +365,7 @@ class JiraIssue(Issue):
 
 
 class JiraService(Service):
+    API_VERSION = 1.0
     ISSUE_CLASS = JiraIssue
     CONFIG_SCHEMA = JiraConfig
 

--- a/bugwarrior/services/kanboard.py
+++ b/bugwarrior/services/kanboard.py
@@ -114,6 +114,7 @@ class KanboardIssue(Issue):
 
 
 class KanboardService(Service):
+    API_VERSION = 1.0
     ISSUE_CLASS = KanboardIssue
     CONFIG_SCHEMA = KanboardConfig
 

--- a/bugwarrior/services/linear.py
+++ b/bugwarrior/services/linear.py
@@ -123,6 +123,7 @@ class LinearIssue(Issue):
 
 
 class LinearService(Service, Client):
+    API_VERSION = 1.0
     ISSUE_CLASS = LinearIssue
     CONFIG_SCHEMA = LinearConfig
 

--- a/bugwarrior/services/logseq.py
+++ b/bugwarrior/services/logseq.py
@@ -351,6 +351,7 @@ class LogseqIssue(Issue):
 
 
 class LogseqService(Service):
+    API_VERSION = 1.0
     ISSUE_CLASS = LogseqIssue
     CONFIG_SCHEMA = LogseqConfig
 

--- a/bugwarrior/services/pagure.py
+++ b/bugwarrior/services/pagure.py
@@ -107,6 +107,7 @@ class PagureIssue(Issue):
 
 
 class PagureService(Service):
+    API_VERSION = 1.0
     ISSUE_CLASS = PagureIssue
     CONFIG_SCHEMA = PagureConfig
 

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -89,6 +89,7 @@ class PhabricatorIssue(Issue):
 
 
 class PhabricatorService(Service):
+    API_VERSION = 1.0
     ISSUE_CLASS = PhabricatorIssue
     CONFIG_SCHEMA = PhabricatorConfig
 

--- a/bugwarrior/services/pivotaltracker.py
+++ b/bugwarrior/services/pivotaltracker.py
@@ -113,6 +113,7 @@ class PivotalTrackerIssue(Issue):
 
 
 class PivotalTrackerService(Service, Client):
+    API_VERSION = 1.0
     ISSUE_CLASS = PivotalTrackerIssue
     CONFIG_SCHEMA = PivotalTrackerConfig
 

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -245,6 +245,7 @@ class RedMineIssue(Issue):
 
 
 class RedMineService(Service):
+    API_VERSION = 1.0
     ISSUE_CLASS = RedMineIssue
     CONFIG_SCHEMA = RedMineConfig
 

--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -67,6 +67,7 @@ class TaigaIssue(Issue):
 
 
 class TaigaService(Service, Client):
+    API_VERSION = 1.0
     ISSUE_CLASS = TaigaIssue
     CONFIG_SCHEMA = TaigaConfig
 

--- a/bugwarrior/services/teamwork_projects.py
+++ b/bugwarrior/services/teamwork_projects.py
@@ -123,6 +123,7 @@ class TeamworkIssue(Issue):
 
 
 class TeamworkService(Service):
+    API_VERSION = 1.0
     ISSUE_CLASS = TeamworkIssue
     CONFIG_SCHEMA = TeamworkConfig
 

--- a/bugwarrior/services/todoist.py
+++ b/bugwarrior/services/todoist.py
@@ -220,6 +220,7 @@ class TodoistIssue(Issue):
 
 
 class TodoistService(Service):
+    API_VERSION = 1.0
     ISSUE_CLASS = TodoistIssue
     CONFIG_SCHEMA = TodoistConfig
 

--- a/bugwarrior/services/trac.py
+++ b/bugwarrior/services/trac.py
@@ -91,6 +91,7 @@ class TracIssue(Issue):
 
 
 class TracService(Service):
+    API_VERSION = 1.0
     ISSUE_CLASS = TracIssue
     CONFIG_SCHEMA = TracConfig
 

--- a/bugwarrior/services/trello.py
+++ b/bugwarrior/services/trello.py
@@ -83,6 +83,7 @@ class TrelloIssue(Issue):
 
 
 class TrelloService(Service, Client):
+    API_VERSION = 1.0
     ISSUE_CLASS = TrelloIssue
     CONFIG_SCHEMA = TrelloConfig
 

--- a/bugwarrior/services/youtrack.py
+++ b/bugwarrior/services/youtrack.py
@@ -129,6 +129,7 @@ class YoutrackIssue(Issue):
 
 
 class YoutrackService(Service, Client):
+    API_VERSION = 1.0
     ISSUE_CLASS = YoutrackIssue
     CONFIG_SCHEMA = YoutrackConfig
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,7 +1,7 @@
+import pathlib
 import re
 import typing
 import unittest.mock
-
 
 from bugwarrior import config, services
 from bugwarrior.config import schema
@@ -37,6 +37,7 @@ class DumbService(services.Service):
     """
     Implement the required methods but they shouldn't be called.
     """
+    API_VERSION = 1.0
     ISSUE_CLASS = DumbIssue
     CONFIG_SCHEMA = DumbConfig
 
@@ -124,6 +125,23 @@ class TestService(ServiceBase):
             (('some_author', LONG_MESSAGE),), 'example.com')
         self.assertEqual(annotations, [
             f'@some_author - {LONG_MESSAGE}'])
+
+    def test_api_incompatibility_error(self):
+        with unittest.mock.patch.object(
+                DumbService, 'API_VERSION', new=services.LATEST_API_VERSION+1):
+            with self.assertRaisesRegex(ValueError, "Incompatible Service"):
+                self.makeService()
+
+    def test_api_latest_version(self):
+        basedir = pathlib.Path(__file__).parent.parent
+        with open(
+                basedir / 'bugwarrior/docs/other-services/api.rst', 'r') as f:
+            header = f.readline().strip('\n')
+            match = re.fullmatch(
+                r'Python API v(?P<version>[0-9]+\.[0-9]+)', header)
+            latest_documented = float(match.groupdict()['version'])
+
+        self.assertEqual(latest_documented, services.LATEST_API_VERSION)
 
 
 class TestIssue(ServiceBase):


### PR DESCRIPTION
One of the lessons I've learned from observing taskchampion development is that "lazy spec versioning" isn't always such a great idea. Analogous is https://github.com/GothenburgBitFactory/taskchampion/issues/477, in which the concern is that older versions of taskchampion don't know how to handle newer versions of the database. Likewise, older versions of bugwarrior might not handle newer implementations of the service spec properly. We also adopt a comparable major/minor version scheme.