### PR TITLE
config: Disable INI interpolation

### DIFF
--- a/bugwarrior/config/load.py
+++ b/bugwarrior/config/load.py
@@ -115,7 +115,8 @@ def load_config(main_section, interactive, quiet) -> dict:
 # ConfigParser is not a new-style class, so inherit from object to fix super().
 class BugwarriorConfigParser(configparser.ConfigParser):
     def __init__(self, *args, allow_no_value=True, **kwargs):
-        super().__init__(*args, allow_no_value=allow_no_value, **kwargs)
+        super().__init__(*args, allow_no_value=allow_no_value,
+                         interpolation=None, **kwargs)
 
     def getint(self, section, option):
         """ Accepts both integers and empty values. """


### PR DESCRIPTION
Resolve #1018.

Interpolation can cause errors when users use literal `%` signs in their configuration, which isn't unusual in urls. Furthermore:

- Interpolation is less useful now that we have strict validation which doesn't allow arbitrary variables.
- The only use case I've seen presented for interpolation in bugwarrior configuration is to reuse secrets, but I don't think we should encourage writing plaintext secrets in the config file anyway.