### PR TITLE
pyproject: limit python<3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "bugwarrior"
 version = "2.0.0"
 description = "a command line utility for updating your local taskwarrior database from your forge issue trackers"
 readme = "bugwarrior/README.rst"
-requires-python = ">=3.10,<4"
+# pydantic.v1 does not support python-3.14 See <https://github.com/GothenburgBitFactory/bugwarrior/issues/998>.
+requires-python = ">=3.10,<3.14"
 license = "GPL-3.0-or-later"
 license-files = ["LICENSE.txt"]
 keywords=["task", "taskwarrior", "todo", "github"]


### PR DESCRIPTION
Resolve #1146.

Until #998 is fully resolved and we support pydantic-2, python-3.14 will not work.