### PR TITLE
fix: require setuptools for pipx/uvx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ test = [
 
    # Workaround https://github.com/python/importlib_metadata/issues/406
    "importlib-metadata<5",
+   # To make this installable with uvx/pipx and no additional options needed.
+   "setuptools",
 ]
 todoist = ["todoist_api_python>=3.0.0"]
 trac = ["offtrac"]


### PR DESCRIPTION
Needed to make an install with uvx as seamless as possible.

This command installs bugwarrior without this PR on any platform uv supports:

```sh
uvx -q --with setuptools git+https://github.com/GothenburgBitFactory/bugwarrior
```

After a merge it should be possible to do:

```sh
uvx git+https://github.com/GothenburgBitFactory/bugwarrior
```

P.s.: sorry for the noise in #1149, changed my tooling.