### PR TITLE
pyproject: limit sphinx<9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ test = [
    "pytest-subtests",
    "responses",
    "ruff",
-   "sphinx>=1.0",
+   # sphinx-click doesn't yet support sphinx-9.0. https://github.com/click-contrib/sphinx-click/issues/157
+   "sphinx>=1.0,<9.0",
    "sphinx-click",
    "sphinx-inline-tabs",
 


### PR DESCRIPTION
Sphinx-click is incompatible which breaks the docs build.