### PR TITLE
pyproject: allow sphinx>=9.0.3

### DIFF
--- a/bugwarrior/docs/services/pagure.rst
+++ b/bugwarrior/docs/services/pagure.rst
@@ -81,7 +81,7 @@ Also, if you would like to control how these taskwarrior tags are created, you
 can specify a template used for converting the Pagure tag into a Taskwarrior
 tag.
 
-For example, to prefix all incoming labels with the string 'pagure_' (perhaps
+For example, to prefix all incoming labels with the string 'pagure\_' (perhaps
 to differentiate them from any existing tags you might have), you could
 add the following configuration option:
 

--- a/bugwarrior/docs/services/todoist.rst
+++ b/bugwarrior/docs/services/todoist.rst
@@ -113,7 +113,7 @@ Also, if you would like to control how these labels are created, you can
 specify a template used for converting the Todoist label into a Taskwarrior
 tag.
 
-For example, to prefix all incoming labels with the string 'todoist_' (perhaps
+For example, to prefix all incoming labels with the string 'todoist\_' (perhaps
 to differentiate them from any existing tags you might have), you could
 add the following configuration option:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,13 +39,14 @@ kanboard = ["kanboard"]
 keyring = ["keyring"]
 phabricator = ["phabricator"]
 test = [
-   "docutils",
+   # sphinx-inline-tabs is incompatible with docutils-0.22 https://github.com/pradyunsg/sphinx-inline-tabs/pull/51
+   "docutils<0.22",
    "pytest",
    "pytest-subtests",
    "responses",
    "ruff",
-   # sphinx-click doesn't yet support sphinx-9.0. https://github.com/click-contrib/sphinx-click/issues/157
-   "sphinx>=1.0,<9.0",
+   "sphinx>=1.0,<9.0 ; python_version <= '3.10'",
+   "sphinx>=9.0.3 ; python_version >= '3.11'",
    "sphinx-click",
    "sphinx-inline-tabs",
 


### PR DESCRIPTION
Turns out sphinx considers the breaking change a bug after all and fixed it in a patch.