### PR TITLE
pyproject: require importlib-metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers=[
 dependencies = [
   "click",
   "dogpile.cache>=0.5.3",
+  "importlib-metadata",
   "jinja2>=2.7.2",
   "lockfile>=0.9.1",
   "pydantic[email]>=2",
@@ -48,9 +49,6 @@ test = [
    "sphinx>=1.0,<9.0",
    "sphinx-click",
    "sphinx-inline-tabs",
-
-   # Workaround https://github.com/python/importlib_metadata/issues/406
-   "importlib-metadata<5",
    # To make this installable with uvx/pipx and no additional options needed.
    "setuptools",
 ]


### PR DESCRIPTION
This actually became a required dependency in #1073 and I didn't notice.
So this is a packaging regression in 2.0.0.

The pinning was a workaround for a flake8 issue and we're no longer
using flake8.