### PR TITLE
chore: remove pytz dependency

### DIFF
--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -4,12 +4,13 @@ Service API
 """
 
 import abc
-from datetime import datetime, timezone
+import datetime
 import logging
 import math
 import os
 import re
 import typing
+import zoneinfo
 
 from dateutil.parser import parse as parse_date
 import dogpile.cache
@@ -170,18 +171,31 @@ class Issue(abc.ABC):
             self.record.get('priority'), self.config.default_priority
         )
 
-    def parse_date(self, date: str | None) -> datetime | None:
+    def parse_date(
+        self, date: str | None, timezone='deprecated'
+    ) -> datetime.datetime | None:
         """Parse a date string into a datetime object.
 
-        If the parsed date does not have a timezone, the UTC timezone is added
+        If the parsed date does not have a timezone, the UTC timezone is added.
+
         :param `date`: A time string parseable by `dateutil.parser.parse`
         """
+        if timezone != 'deprecated':
+            log.warning(
+                "Deprecation Warning: Issue.parse_date's timezone parameter is deprecated and will "
+                "be removed in a future API version."
+            )
+
         if not date:
             return None
 
         _date = parse_date(date)
         if not _date.tzinfo:
-            _date = _date.replace(tzinfo=timezone.utc)
+            _date = _date.replace(
+                tzinfo=datetime.timezone.utc
+                if timezone == 'deprecated'
+                else zoneinfo.ZoneInfo(timezone)
+            )
 
         return _date.replace(microsecond=0)
 

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -4,6 +4,7 @@ Service API
 """
 
 import abc
+from datetime import datetime, timezone
 import logging
 import math
 import os
@@ -11,10 +12,8 @@ import re
 import typing
 
 from dateutil.parser import parse as parse_date
-from dateutil.tz import tzlocal
 import dogpile.cache
 from jinja2 import Template
-import pytz
 import requests
 
 from bugwarrior.config import schema, secrets
@@ -171,25 +170,20 @@ class Issue(abc.ABC):
             self.record.get('priority'), self.config.default_priority
         )
 
-    def parse_date(self, date, timezone='UTC'):
+    def parse_date(self, date: str | None) -> datetime | None:
         """Parse a date string into a datetime object.
 
+        If the parsed date does not have a timezone, the UTC timezone is added
         :param `date`: A time string parseable by `dateutil.parser.parse`
-        :param `timezone`: The string timezone name (from `pytz.all_timezones`)
-            to use as a default should the parsed time string not include
-            timezone information.
-
         """
-        if date:
-            date = parse_date(date)
-            if not date.tzinfo:
-                if timezone == '':
-                    tzinfo = tzlocal()
-                else:
-                    tzinfo = pytz.timezone(timezone)
-                date = date.replace(tzinfo=tzinfo)
-            return date.replace(microsecond=0)
-        return None
+        if not date:
+            return None
+
+        _date = parse_date(date)
+        if not _date.tzinfo:
+            _date = _date.replace(tzinfo=timezone.utc)
+
+        return _date.replace(microsecond=0)
 
     def build_default_description(
         self, title='', url='', number='', cls="issue"

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -9,7 +9,6 @@ import xmlrpc.client
 import bugzilla
 import pydantic
 from pydantic import BeforeValidator
-import pytz
 
 from bugwarrior import config
 from bugwarrior.config.schema import StrippedTrailingSlashUrl
@@ -328,8 +327,7 @@ def _ensure_datetime(
         return datetime.datetime.fromisoformat(timestamp)
     elif isinstance(timestamp, xmlrpc.client.DateTime):
         structured = time.mktime(timestamp.timetuple())
-        naive = datetime.datetime.fromtimestamp(structured)
-        return pytz.UTC.localize(naive)
+        return datetime.datetime.fromtimestamp(structured, tz=datetime.timezone.utc)
     else:
         raise TypeError(
             "Timestamp conversion from `{0!r}` is not supported.".format(timestamp)

--- a/bugwarrior/services/deck.py
+++ b/bugwarrior/services/deck.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 import typing
 
-from dateutil.tz import tzutc
 import requests
 
 from bugwarrior import config
@@ -96,7 +95,7 @@ class NextcloudDeckIssue(Issue):
             'annotations': self.extra['annotations'],
             'tags': self.get_tags(),
             'entry': datetime.datetime.fromtimestamp(
-                self.record.get('createdAt'), tz=tzutc()
+                self.record.get('createdAt'), tz=datetime.timezone.utc
             ),
             'due': self.parse_date(self.record.get('duedate')),
             self.AUTHOR: self.record['owner']['uid'],

--- a/bugwarrior/services/gmail.py
+++ b/bugwarrior/services/gmail.py
@@ -1,10 +1,10 @@
+from datetime import datetime, timezone
 import email
 import logging
 import multiprocessing
 import os
 import pickle
 import re
-import time
 import typing
 
 from google.auth.transport.requests import Request
@@ -93,10 +93,9 @@ class GmailIssue(Issue):
         return self.extra.get('annotations', [])
 
     def get_entry(self):
-        date_string = time.strftime(
-            '%Y-%m-%d %H:%M:%S', time.gmtime(int(self.extra['internal_date']) / 1000)
-        )
-        return self.parse_date(date_string)
+        # internal_date is in milliseconds, convert to seconds and create UTC datetime
+        timestamp_seconds = int(self.extra['internal_date']) / 1000
+        return datetime.fromtimestamp(timestamp_seconds, tz=timezone.utc)
 
 
 class GmailService(Service):

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -4,7 +4,6 @@ import logging
 import sys
 import typing
 
-from dateutil.tz.tz import tzutc
 from jira.client import JIRA as BaseJIRA
 from pydantic import BeforeValidator, model_validator
 from requests.cookies import RequestsCookieJar
@@ -223,7 +222,7 @@ class JiraIssue(Issue):
     def get_entry(self):
         created_at = self.record['fields']['created']
         # Convert timestamp to an offset-aware datetime
-        date = self.parse_date(created_at).astimezone(tzutc())
+        date = self.parse_date(created_at)
         return date
 
     def get_tags(self):

--- a/bugwarrior/services/kanboard.py
+++ b/bugwarrior/services/kanboard.py
@@ -4,7 +4,6 @@ import re
 import typing
 from urllib.parse import urlparse
 
-from dateutil.tz.tz import tzutc
 from kanboard import Client
 
 from bugwarrior import config
@@ -104,7 +103,7 @@ class KanboardIssue(Issue):
     def _convert_timestamp_from_field(self, field):
         timestamp = int(self.record.get(field, 0))
         if timestamp:
-            return datetime.datetime.fromtimestamp(timestamp).astimezone(tzutc())
+            return datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
 
 
 class KanboardService(Service):

--- a/bugwarrior/services/pagure.py
+++ b/bugwarrior/services/pagure.py
@@ -3,7 +3,6 @@ import logging
 import typing
 
 from pydantic import model_validator
-import pytz
 import requests
 
 from bugwarrior import config
@@ -69,7 +68,7 @@ class PagureIssue(Issue):
             self.TITLE: self.record['title'],
             self.ID: self.record['id'],
             self.DATE_CREATED: datetime.datetime.fromtimestamp(
-                int(self.record['date_created']), pytz.UTC
+                int(self.record['date_created']), datetime.timezone.utc
             ),
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
   "lockfile>=0.9.1",
   "pydantic[email]>=2",
   "python-dateutil",
-  "pytz",
   "requests",
   "taskw>=0.8",
   "tomli ; python_version <= '3.10'",

--- a/tests/test_azuredevops.py
+++ b/tests/test_azuredevops.py
@@ -1,7 +1,5 @@
-import datetime
+from datetime import datetime, timezone
 from unittest import mock
-
-from dateutil.tz.tz import tzutc
 
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.azuredevops import AzureDevopsService, striphtml
@@ -190,8 +188,8 @@ class TestAzureDevopsService(AbstractServiceTest, ServiceTest):
             "project": None,
             "annotations": [],
             "adonamespace": "test_organization\\test_project",
-            "entry": datetime.datetime(2020, 7, 8, 17, 31, 46, 0, tzinfo=tzutc()),
-            "end": datetime.datetime(2020, 7, 8, 19, 55, 46, 0, tzinfo=tzutc()),
+            "entry": datetime(2020, 7, 8, 17, 31, 46, 0, tzinfo=timezone.utc),
+            "end": datetime(2020, 7, 8, 19, 55, 46, 0, tzinfo=timezone.utc),
             "adoactivity": "",
             "adoremainingwork": None,
             "adoparent": None,
@@ -204,8 +202,8 @@ class TestAzureDevopsService(AbstractServiceTest, ServiceTest):
             "project": None,
             "priority": "M",
             "annotations": [],
-            "entry": datetime.datetime(2020, 7, 8, 17, 31, 46, 0, tzinfo=tzutc()),
-            "end": datetime.datetime(2020, 7, 8, 19, 55, 46, 0, tzinfo=tzutc()),
+            "entry": datetime(2020, 7, 8, 17, 31, 46, 0, tzinfo=timezone.utc),
+            "end": datetime(2020, 7, 8, 19, 55, 46, 0, tzinfo=timezone.utc),
             "adotitle": "Example Title",
             "adodescription": " This Description has some html in it ",
             "adoid": 1,
@@ -228,8 +226,8 @@ class TestAzureDevopsService(AbstractServiceTest, ServiceTest):
             "project": None,
             "priority": "M",
             "annotations": [],
-            "entry": datetime.datetime(2020, 7, 8, 17, 31, 46, 0, tzinfo=tzutc()),
-            "end": datetime.datetime(2020, 7, 8, 19, 55, 46, 0, tzinfo=tzutc()),
+            "entry": datetime(2020, 7, 8, 17, 31, 46, 0, tzinfo=timezone.utc),
+            "end": datetime(2020, 7, 8, 19, 55, 46, 0, tzinfo=timezone.utc),
             "adotitle": "Example Title",
             "adodescription": " This Description has some html in it ",
             "adoid": 1,

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -1,8 +1,6 @@
 import dataclasses
-import datetime
+from datetime import datetime, timezone
 from unittest import mock
-
-from dateutil.tz import tzutc
 
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.deck import NextcloudDeckClient, NextcloudDeckService
@@ -126,8 +124,8 @@ class TestNextcloudDeckIssue(AbstractServiceTest, ServiceTest):
 
         expected = {
             'annotations': ['@Lena - testcomment'],
-            'entry': datetime.datetime(2022, 8, 17, 20, 16, 22, tzinfo=tzutc()),
-            'due': datetime.datetime(2022, 11, 20, 23, 0, tzinfo=tzutc()),
+            'entry': datetime(2022, 8, 17, 20, 16, 22, tzinfo=timezone.utc),
+            'due': datetime(2022, 11, 20, 23, 0, tzinfo=timezone.utc),
             'nextclouddeckassignee': 'rainbow',
             'nextclouddeckauthor': 'unicorn',
             'nextclouddeckboardid': 5,
@@ -151,8 +149,8 @@ class TestNextcloudDeckIssue(AbstractServiceTest, ServiceTest):
 
         expected = {
             'annotations': ['@Lena - testcomment'],
-            'entry': datetime.datetime(2022, 8, 17, 20, 16, 22, tzinfo=tzutc()),
-            'due': datetime.datetime(2022, 11, 20, 23, 0, tzinfo=tzutc()),
+            'entry': datetime(2022, 8, 17, 20, 16, 22, tzinfo=timezone.utc),
+            'due': datetime(2022, 11, 20, 23, 0, tzinfo=timezone.utc),
             'description': '(bw)Is# - check that nextcloud deck integration works',
             'nextclouddeckassignee': 'rainbow',
             'nextclouddeckauthor': 'unicorn',

--- a/tests/test_gitbug.py
+++ b/tests/test_gitbug.py
@@ -1,8 +1,6 @@
 import dataclasses
-import datetime
+from datetime import datetime, timedelta, timezone
 from unittest import mock
-
-import dateutil
 
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.gitbug import GitBugClient, GitBugConfig, GitBugService
@@ -49,8 +47,8 @@ class TestGitBugIssue(AbstractServiceTest, ServiceTest):
 
         expected = {
             'annotations': [],
-            'entry': datetime.datetime(
-                2022, 5, 5, 23, 6, 52, tzinfo=dateutil.tz.tzoffset(None, -14400)
+            'entry': datetime(
+                2022, 5, 5, 23, 6, 52, tzinfo=timezone(timedelta(seconds=-14400))
             ),
             'gitbugauthor': 'ryneeverett',
             'gitbugid': '032d911695cc68d9881aabc24a6c62853f90f834',
@@ -70,8 +68,8 @@ class TestGitBugIssue(AbstractServiceTest, ServiceTest):
         expected = {
             'annotations': [],
             'description': '(bw)Bug# - Some Issue',
-            'entry': datetime.datetime(
-                2022, 5, 5, 23, 6, 52, tzinfo=dateutil.tz.tzoffset(None, -14400)
+            'entry': datetime(
+                2022, 5, 5, 23, 6, 52, tzinfo=timezone(timedelta(seconds=-14400))
             ),
             'gitbugauthor': 'ryneeverett',
             'gitbugid': '032d911695cc68d9881aabc24a6c62853f90f834',

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,7 +1,6 @@
-import datetime
+from datetime import datetime, timedelta, timezone
 from unittest import TestCase
 
-import pytz
 import responses
 
 from bugwarrior.collect import TaskConstructor
@@ -9,14 +8,14 @@ from bugwarrior.services.github import GithubClient, GithubConfig, GithubService
 
 from .base import AbstractServiceTest, ServiceTest
 
-ARBITRARY_CREATED = (
-    datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
-).replace(tzinfo=pytz.UTC, microsecond=0)
-ARBITRARY_CLOSED = (
-    datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=30)
-).replace(tzinfo=pytz.UTC, microsecond=0)
-ARBITRARY_UPDATED = datetime.datetime.now(datetime.timezone.utc).replace(
-    tzinfo=pytz.UTC, microsecond=0
+ARBITRARY_CREATED = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(
+    tzinfo=timezone.utc, microsecond=0
+)
+ARBITRARY_CLOSED = (datetime.now(timezone.utc) - timedelta(minutes=30)).replace(
+    tzinfo=timezone.utc, microsecond=0
+)
+ARBITRARY_UPDATED = datetime.now(timezone.utc).replace(
+    tzinfo=timezone.utc, microsecond=0
 )
 ARBITRARY_ISSUE = {
     'title': 'Hallo',

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -1,6 +1,5 @@
-import datetime
+from datetime import date, datetime, timedelta, timezone
 
-import pytz
 import responses
 
 from bugwarrior.collect import TaskConstructor
@@ -12,16 +11,12 @@ from .base import AbstractServiceTest, ConfigTest, ServiceTest
 class TestData:
     def __init__(self):
         self.arbitrary_created = (
-            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
-        ).replace(tzinfo=pytz.UTC, microsecond=0)
-        self.arbitrary_updated = datetime.datetime.now(datetime.timezone.utc).replace(
-            tzinfo=pytz.UTC, microsecond=0
+            datetime.now(timezone.utc) - timedelta(hours=1)
+        ).replace(microsecond=0)
+        self.arbitrary_updated = datetime.now(timezone.utc).replace(microsecond=0)
+        self.arbitrary_duedate = datetime.combine(
+            date.today(), datetime.min.time(), tzinfo=timezone.utc
         )
-        self.arbitrary_duedate = (
-            datetime.datetime.combine(
-                datetime.date.today(), datetime.datetime.min.time()
-            )
-        ).replace(tzinfo=pytz.UTC)
         self.arbitrary_issue = {
             "id": 42,
             "iid": 3,

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -5,7 +5,6 @@ import pickle
 from unittest import mock
 from unittest.mock import patch
 
-from dateutil.tz import tzutc
 from google.oauth2.credentials import Credentials
 
 from bugwarrior.collect import TaskConstructor
@@ -142,7 +141,7 @@ class TestGmailIssue(AbstractServiceTest, ServiceTest):
         )
         expected = {
             'annotations': [],
-            'entry': datetime(2019, 1, 5, 21, 7, 47, tzinfo=tzutc()),
+            'entry': datetime(2019, 1, 5, 21, 7, 47, tzinfo=timezone.utc),
             'gmailthreadid': '1234',
             'gmaillastmessageid': 'CMCRSF+6r=x5JtW4wlRYR5qdfRq+iAtSoec5NqrHvRpvVgHbHdg@mail.gmail.com',  # noqa: E501
             'gmailsnippet': 'Bugwarrior is great',
@@ -164,7 +163,7 @@ class TestGmailIssue(AbstractServiceTest, ServiceTest):
         issue = next(self.service.issues())
         expected = {
             'annotations': ['@Foo Bar - Regarding Bugwarrior'],
-            'entry': datetime(2019, 1, 5, 21, 7, 47, tzinfo=tzutc()),
+            'entry': datetime(2019, 1, 5, 21, 7, 47, tzinfo=timezone.utc),
             'gmailthreadid': '1234',
             'gmaillastmessageid': 'CMCRSF+6r=x5JtW4wlRYR5qdfRq+iAtSoec5NqrHvRpvVgHbHdg@mail.gmail.com',  # noqa: E501
             'gmailsnippet': 'Bugwarrior is great',

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -1,8 +1,6 @@
 from collections import namedtuple
+from datetime import datetime, timezone
 from unittest import mock
-
-from dateutil.tz import datetime
-from dateutil.tz.tz import tzutc
 
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.config import schema
@@ -141,7 +139,7 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
             'annotations': arbitrary_extra['annotations'],
             'due': None,
             'tags': [],
-            'entry': datetime.datetime(2016, 6, 6, 13, 7, 8, tzinfo=tzutc()),
+            'entry': datetime(2016, 6, 6, 13, 7, 8, tzinfo=timezone.utc),
             'jirafixversion': '1.2.3',
             'jiraissuetype': 'Epic',
             'jirastatus': 'Open',
@@ -184,9 +182,9 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
             'project': self.arbitrary_project,
             'priority': (issue.PRIORITY_MAP[record_with_goal['fields']['priority']]),
             'annotations': arbitrary_extra['annotations'],
-            'due': datetime.datetime(2016, 9, 23, 16, 8, tzinfo=tzutc()),
+            'due': datetime(2016, 9, 23, 16, 8, tzinfo=timezone.utc),
             'tags': [],
-            'entry': datetime.datetime(2016, 6, 6, 13, 7, 8, tzinfo=tzutc()),
+            'entry': datetime(2016, 6, 6, 13, 7, 8, tzinfo=timezone.utc),
             'jirafixversion': '1.2.3',
             'jiraissuetype': 'Epic',
             'jirastatus': 'Open',
@@ -218,7 +216,7 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
             'description': (
                 '(bw)Is#10 - lkjaldsfjaldf .. https://two.org/browse/DONUT-10'
             ),
-            'entry': datetime.datetime(2016, 6, 6, 13, 7, 8, tzinfo=tzutc()),
+            'entry': datetime(2016, 6, 6, 13, 7, 8, tzinfo=timezone.utc),
             'jiradescription': None,
             'jiraestimate': 1,
             'jirafixversion': '1.2.3',
@@ -244,5 +242,5 @@ class TestJiraIssue(AbstractServiceTest, ServiceTest):
             extra={'sprint_field_names': self.service.sprint_field_names},
         )
         self.assertEqual(
-            issue.get_due(), datetime.datetime(2016, 9, 23, 16, 8, tzinfo=tzutc())
+            issue.get_due(), datetime(2016, 9, 23, 16, 8, tzinfo=timezone.utc)
         )

--- a/tests/test_kanboard.py
+++ b/tests/test_kanboard.py
@@ -1,7 +1,5 @@
-import datetime
+from datetime import datetime, timezone
 from unittest import mock
-
-from dateutil.tz.tz import tzutc
 
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.kanboard import KanboardService
@@ -113,7 +111,7 @@ class TestKanboardService(AbstractServiceTest, ServiceTest):
             "annotations": extra["annotations"],
             "tags": extra["tags"],
             "due": None,
-            "entry": datetime.datetime(2015, 6, 13, 20, 30, 46, tzinfo=tzutc()),
+            "entry": datetime(2015, 6, 13, 20, 30, 46, tzinfo=timezone.utc),
             issue.TASK_ID: int(record["id"]),
             issue.TASK_TITLE: record["title"],
             issue.TASK_DESCRIPTION: record["description"],
@@ -195,7 +193,7 @@ class TestKanboardService(AbstractServiceTest, ServiceTest):
         expected = {
             "description": "(bw)Is#3 - T3 .. http://example.com?task_id=3&project_id=1",
             "due": None,
-            "entry": datetime.datetime(2016, 4, 22, 22, 46, 4, tzinfo=tzutc()),
+            "entry": datetime(2016, 4, 22, 22, 46, 4, tzinfo=timezone.utc),
             "annotations": [],
             "project": "project",
             "tags": ["tag1", "tag2"],

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1,7 +1,6 @@
-import datetime
+from datetime import datetime, timezone
 import json
 
-from dateutil.tz import tzutc
 import responses
 
 from bugwarrior.collect import TaskConstructor
@@ -139,9 +138,9 @@ class TestLinearIssue(AbstractServiceTest, ServiceTest):
         issue = RESPONSE["data"]["issues"]["nodes"][0]
         issue = self.service.get_issue_for_record(issue, {})
 
-        created_timestamp = datetime.datetime(2025, 7, 24, 17, 3, 4, 0, tzinfo=tzutc())
-        updated_timestamp = datetime.datetime(2025, 7, 25, 17, 3, 4, 0, tzinfo=tzutc())
-        closed_timestamp = datetime.datetime(2025, 7, 26, 17, 3, 4, 0, tzinfo=tzutc())
+        created_timestamp = datetime(2025, 7, 24, 17, 3, 4, 0, tzinfo=timezone.utc)
+        updated_timestamp = datetime(2025, 7, 25, 17, 3, 4, 0, tzinfo=timezone.utc)
+        closed_timestamp = datetime(2025, 7, 26, 17, 3, 4, 0, tzinfo=timezone.utc)
         expected_output = {
             "project": "prj",
             "priority": "M",
@@ -166,8 +165,8 @@ class TestLinearIssue(AbstractServiceTest, ServiceTest):
         issue = RESPONSE["data"]["issues"]["nodes"][1]
         issue = self.service.get_issue_for_record(issue, {})
 
-        created_timestamp = datetime.datetime(2025, 7, 24, 15, 34, 7, 0, tzinfo=tzutc())
-        updated_timestamp = datetime.datetime(2025, 7, 24, 17, 8, 33, 0, tzinfo=tzutc())
+        created_timestamp = datetime(2025, 7, 24, 15, 34, 7, 0, tzinfo=timezone.utc)
+        updated_timestamp = datetime(2025, 7, 24, 17, 8, 33, 0, tzinfo=timezone.utc)
         expected_output = {
             "project": None,
             "priority": "M",
@@ -192,9 +191,9 @@ class TestLinearIssue(AbstractServiceTest, ServiceTest):
     @responses.activate
     def test_issues(self):
         issue = next(self.service.issues())
-        created_timestamp = datetime.datetime(2025, 7, 24, 17, 3, 4, 0, tzinfo=tzutc())
-        updated_timestamp = datetime.datetime(2025, 7, 25, 17, 3, 4, 0, tzinfo=tzutc())
-        closed_timestamp = datetime.datetime(2025, 7, 26, 17, 3, 4, 0, tzinfo=tzutc())
+        created_timestamp = datetime(2025, 7, 24, 17, 3, 4, 0, tzinfo=timezone.utc)
+        updated_timestamp = datetime(2025, 7, 25, 17, 3, 4, 0, tzinfo=timezone.utc)
+        closed_timestamp = datetime(2025, 7, 26, 17, 3, 4, 0, tzinfo=timezone.utc)
         expected = {
             "annotations": [],
             "description": "(bw)#DUS-5 - DO STUFF .. "

--- a/tests/test_phab.py
+++ b/tests/test_phab.py
@@ -1,7 +1,5 @@
-import datetime
+from datetime import date, datetime, timedelta, timezone
 import unittest
-
-import pytz
 
 from bugwarrior.services.phab import PhabricatorService
 
@@ -19,16 +17,12 @@ class TestPhabricatorIssue(AbstractServiceTest, ServiceTest):
         super().setUp()
         self.service = self.get_mock_service(PhabricatorService)
         self.arbitrary_created = (
-            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
-        ).replace(tzinfo=pytz.UTC, microsecond=0)
-        self.arbitrary_updated = datetime.datetime.now(datetime.timezone.utc).replace(
-            tzinfo=pytz.UTC, microsecond=0
+            datetime.now(timezone.utc) - timedelta(hours=1)
+        ).replace(microsecond=0)
+        self.arbitrary_updated = datetime.now(timezone.utc).replace(microsecond=0)
+        self.arbitrary_duedate = datetime.combine(
+            date.today(), datetime.min.time(), tzinfo=timezone.utc
         )
-        self.arbitrary_duedate = (
-            datetime.datetime.combine(
-                datetime.date.today(), datetime.datetime.min.time()
-            )
-        ).replace(tzinfo=pytz.UTC)
         self.arbitrary_issue = {
             "id": 42,
             "uri": "https://phabricator.example.com/arbitrary_username/project/issues/3",

--- a/tests/test_pivotaltracker.py
+++ b/tests/test_pivotaltracker.py
@@ -1,6 +1,5 @@
-import datetime
+from datetime import datetime, timezone
 
-from dateutil.tz import tzutc
 import responses
 
 from bugwarrior.collect import TaskConstructor
@@ -266,9 +265,9 @@ class TestPivotalTrackerIssue(AbstractServiceTest, ServiceTest):
                     'updated_at': '2019-05-14T12:00:00Z',
                 },
             ],
-            'pivotalclosed': datetime.datetime(2019, 5, 14, 12, 0, tzinfo=tzutc()),
-            'pivotalcreated': datetime.datetime(2019, 5, 14, 12, 0, tzinfo=tzutc()),
-            'pivotalupdated': datetime.datetime(2019, 5, 14, 12, 0, tzinfo=tzutc()),
+            'pivotalclosed': datetime(2019, 5, 14, 12, 0, tzinfo=timezone.utc),
+            'pivotalcreated': datetime(2019, 5, 14, 12, 0, tzinfo=timezone.utc),
+            'pivotalupdated': datetime(2019, 5, 14, 12, 0, tzinfo=timezone.utc),
             'pivotalurl': 'http://localhost/story/show/561',
             'pivotalblockers': [
                 {
@@ -300,7 +299,7 @@ class TestPivotalTrackerIssue(AbstractServiceTest, ServiceTest):
     @responses.activate
     def test_issues(self):
         story = next(self.service.issues())
-        story_date = datetime.datetime(2019, 5, 14, 12, 0, tzinfo=tzutc())
+        story_date = datetime(2019, 5, 14, 12, 0, tzinfo=timezone.utc)
         expected = {
             'annotations': [
                 '@task - status: False - Port 0',

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -1,7 +1,6 @@
-import datetime
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
-import dateutil
 import responses
 
 from bugwarrior.collect import TaskConstructor
@@ -18,12 +17,8 @@ class TestRedmineIssue(AbstractServiceTest, ServiceTest):
         'key': 'something_else',
         'issue_limit': '100',
     }
-    arbitrary_created = datetime.datetime.now(datetime.timezone.utc).replace(
-        tzinfo=dateutil.tz.tz.tzutc(), microsecond=0
-    ) - datetime.timedelta(1)
-    arbitrary_updated = datetime.datetime.now(datetime.timezone.utc).replace(
-        tzinfo=dateutil.tz.tz.tzutc(), microsecond=0
-    )
+    arbitrary_created = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(1)
+    arbitrary_updated = datetime.now(timezone.utc).replace(microsecond=0)
     arbitrary_issue = {
         "assigned_to": {"id": 35546, "name": "Adam Coddington"},
         "author": {"id": 35546, "name": "Adam Coddington"},

--- a/tests/test_teamwork_projects.py
+++ b/tests/test_teamwork_projects.py
@@ -1,6 +1,5 @@
-import datetime
+from datetime import datetime, timezone
 
-from dateutil.tz import tzutc
 import responses
 
 from bugwarrior.collect import TaskConstructor
@@ -90,10 +89,10 @@ class TestTeamworkIssue(AbstractServiceTest, ServiceTest):
         expected_data = {
             'project': data["project-name"],
             'priority': "H",
-            'due': datetime.datetime(2019, 12, 12, 10, 6, 31, tzinfo=tzutc()),
-            'entry': datetime.datetime(2018, 12, 12, 10, 6, 31, tzinfo=tzutc()),
+            'due': datetime(2019, 12, 12, 10, 6, 31, tzinfo=timezone.utc),
+            'entry': datetime(2018, 12, 12, 10, 6, 31, tzinfo=timezone.utc),
             'end': "",
-            'modified': datetime.datetime(2019, 1, 16, 11, 0, 44, tzinfo=tzutc()),
+            'modified': datetime(2019, 1, 16, 11, 0, 44, tzinfo=timezone.utc),
             issue.URL: "https://test.teamwork_projects.com/#/tasks/5",
             issue.TITLE: data["content"],
             issue.DESCRIPTION_LONG: data["description"],
@@ -119,10 +118,10 @@ class TestTeamworkIssue(AbstractServiceTest, ServiceTest):
         expected_data = {
             'project': data["project-name"],
             'priority': "H",
-            'due': datetime.datetime(2019, 12, 12, 10, 6, 31, tzinfo=tzutc()),
-            'entry': datetime.datetime(2018, 12, 12, 10, 6, 31, tzinfo=tzutc()),
+            'due': datetime(2019, 12, 12, 10, 6, 31, tzinfo=timezone.utc),
+            'entry': datetime(2018, 12, 12, 10, 6, 31, tzinfo=timezone.utc),
             'end': "",
-            'modified': datetime.datetime(2019, 1, 16, 11, 0, 44, tzinfo=tzutc()),
+            'modified': datetime(2019, 1, 16, 11, 0, 44, tzinfo=timezone.utc),
             'description': '(bw)Is#5 - This is a test issue .. https://test.teamwork_projects.com/#/tasks/5',  # noqa: E501
             issue.URL: "https://test.teamwork_projects.com/#/tasks/5",
             issue.TITLE: data["content"],


### PR DESCRIPTION
Some context about this MR:

I stumbled the `Issue.parse_date`, and noticed the `timezone` behaviour is really ambiguous:
```
    def parse_date(self, date, timezone='UTC'):


        """
        if date:
            date = parse_date(date)
            if not date.tzinfo:
                if timezone == '':
                    tzinfo = tzlocal()
                else:
                    tzinfo = pytz.timezone(timezone)
                date = date.replace(tzinfo=tzinfo)
            return date.replace(microsecond=0)
        return None
```

from looking at the function body, we could think the default timezone is `tzlocal()`, but the default value is actually `UTC`. Someone would need to pass `timezone=''` to enter this if block, which seems unlikely. 

I checked, and the `timezone` parameter is actually never used. 
There are only two places (based on the tests) where the `date` string does not already have a timezone, it's:
* Gitlab `duedate`, which is actually a date, not a datetime, so we don't really care about the timezone
* Gmail's get_entry. As the InternalDate is actually a timestamp, I switch to use `datetime.fromtimestamp` (already used in multiple places)

So I ended up removing the `timezone` parameter of `Issue.parse_date` (which should be called `parse_datetime` IMO)

I then noticed we were using `pytz` in several places, just to get the utc timezone, so I replaced them with `timezone.utc`, so pytz can be removed as a dependency.

If we actually want to keep the `timezone` parameter in `Issue.parse_date`, I suggest using `zoneinfo.ZoneInfo` which in the standard library, instead of relying on the third party lib. 
