### PR TITLE
pyproject: Enforce 100 character max line length

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,12 +99,15 @@ quote-style = "preserve"
 skip-magic-trailing-comma = true
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "W", "I"]
+select = ["E4", "E7", "E9", "F", "W", "I", "E501"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
 force-sort-within-sections = true
 split-on-trailing-comma = false
+
+[tool.ruff.lint.pycodestyle]
+max-line-length = 100
 
 [tool.setuptools.packages.find]
 include = ["bugwarrior*"]

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -223,7 +223,9 @@ class TestData:
                 "avatar_url": None,
                 "web_url": "https://my-git.org/groups/arbitrary_namespace",
             },
-            "container_registry_image_prefix": "my-git.org:5555/arbitrary_namespace/arbitrary_project",
+            "container_registry_image_prefix": (
+                "my-git.org:5555/arbitrary_namespace/arbitrary_project"
+            ),
             "_links": {
                 "self": "https://my-git.org/api/v4/projects/8",
                 "issues": "https://my-git.org/api/v4/projects/8/issues",


### PR DESCRIPTION
We had this before with flake8 and I didn't realize that ruff wasn't enforcing this.