### PR TITLE
Simplify flavors

### DIFF
--- a/bugwarrior/collect.py
+++ b/bugwarrior/collect.py
@@ -33,7 +33,7 @@ def get_service(service_name: str):
     return service.load()
 
 
-def _aggregate_issues(conf, main_section, target, queue):
+def _aggregate_issues(conf, target, queue):
     """This worker function is separated out from the main
     :func:`aggregate_issues` func only so that we can use multiprocessing
     on it for speed reasons.
@@ -42,7 +42,7 @@ def _aggregate_issues(conf, main_section, target, queue):
     start = time.time()
 
     try:
-        service = get_service(conf[target].service)(conf[target], conf[main_section])
+        service = get_service(conf[target].service)(conf[target], conf["general"])
         issue_count = 0
         for issue in service.issues():
             queue.put(issue)
@@ -67,12 +67,12 @@ def _aggregate_issues(conf, main_section, target, queue):
         log.info(f"Done with [{target}] in {duration}.")
 
 
-def aggregate_issues(conf, main_section, debug):
+def aggregate_issues(conf, debug):
     """Return all issues from every target."""
     log.info("Starting to aggregate remote issues.")
 
     # Create and call service objects for every target in the config
-    targets = conf[main_section].targets
+    targets = conf["general"].targets
 
     queue = multiprocessing.Queue()
 
@@ -80,11 +80,11 @@ def aggregate_issues(conf, main_section, debug):
 
     if debug:
         for target in targets:
-            _aggregate_issues(conf, main_section, target, queue)
+            _aggregate_issues(conf, target, queue)
     else:
         for target in targets:
             proc = multiprocessing.Process(
-                target=_aggregate_issues, args=(conf, main_section, target, queue)
+                target=_aggregate_issues, args=(conf, target, queue)
             )
             proc.start()
 

--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -19,15 +19,9 @@ log = logging.getLogger(__name__)
 lst = list
 
 
-def _get_section_name(flavor):
-    if flavor:
-        return 'flavor.' + flavor
-    return 'general'
-
-
-def _try_load_config(main_section, interactive=False, quiet=False):
+def _try_load_config(flavor, interactive=False, quiet=False):
     try:
-        return load_config(main_section, interactive, quiet)
+        return load_config(flavor, interactive, quiet)
     except OSError:
         # Our standard logging configuration depends on the bugwarrior
         # configuration file which just failed to load.
@@ -82,7 +76,7 @@ def cli():
 
 @cli.command()
 @click.option('--dry-run', is_flag=True)
-@click.option('--flavor', default=None, help='The flavor to use')
+@click.option('--flavor', default="general", help='The flavor to use')
 @click.option('--interactive', is_flag=True)
 @click.option(
     '--debug', is_flag=True, help='Do not use multiprocessing (which breaks pdb).'
@@ -96,20 +90,17 @@ def pull(dry_run, flavor, interactive, debug, quiet):
     """
 
     try:
-        main_section = _get_section_name(flavor)
-        config = _try_load_config(main_section, interactive, quiet)
+        config = _try_load_config(flavor, interactive, quiet)
 
-        lockfile_path = os.path.join(
-            config[main_section].data.path, 'bugwarrior.lockfile'
-        )
+        lockfile_path = os.path.join(config["general"].data.path, 'bugwarrior.lockfile')
         lockfile = PIDLockFile(lockfile_path)
         lockfile.acquire(timeout=10)
         try:
             # Get all the issues.  This can take a while.
-            issue_generator = aggregate_issues(config, main_section, debug)
+            issue_generator = aggregate_issues(config, debug)
 
             # Stuff them in the taskwarrior db as necessary
-            synchronize(issue_generator, config, main_section, dry_run)
+            synchronize(issue_generator, config)
         finally:
             lockfile.release()
     except LockTimeout:
@@ -187,7 +178,7 @@ def set(target, username):
 
 
 @cli.command()
-@click.option('--flavor', default=None, help='The flavor to use')
+@click.option('--flavor', default="general", help='The flavor to use')
 @_legacy_cli_deprecation_warning
 def uda(flavor):
     """
@@ -211,10 +202,9 @@ def uda(flavor):
        may prevent you from changing the values of those fields or using them
        in filter expressions.
     """
-    main_section = _get_section_name(flavor)
-    conf = _try_load_config(main_section)
+    conf = _try_load_config(flavor)
     print("# Bugwarrior UDAs")
-    for uda in get_defined_udas_as_strings(conf, main_section):
+    for uda in get_defined_udas_as_strings(conf):
         print(uda)
     print("# END Bugwarrior UDAs")
 

--- a/bugwarrior/config/load.py
+++ b/bugwarrior/config/load.py
@@ -92,14 +92,24 @@ def parse_file(configpath: str) -> dict:
     return config
 
 
-def load_config(main_section, interactive, quiet) -> dict:
+def load_config(flavor, interactive, quiet) -> dict:
     configpath = get_config_path()
     rawconfig = parse_file(configpath)
-    rawconfig[main_section]['interactive'] = interactive
-    config = schema.validate_config(rawconfig, main_section, configpath)
+
+    # NOTE: we could even do that directly in parse_file
+    if flavor != "general":
+        rawconfig["general"] = rawconfig["flavor"][flavor]
+        flavor_name = f"flavor.{flavor}"
+
+    else:
+        flavor_name = "general"
+
+    rawconfig["general"]["flavor_name"] = flavor_name
+    rawconfig["general"]['interactive'] = interactive
+
+    config = schema.validate_config(rawconfig, configpath)
     configure_logging(
-        config[main_section].log_file,
-        'WARNING' if quiet else config[main_section].log_level,
+        config["general"].log_file, 'WARNING' if quiet else config["general"].log_level
     )
     return config
 

--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -145,6 +145,8 @@ class MainSectionConfig(BaseConfig):
     #: Interactive status.
     interactive: bool
 
+    flavor_name: str = "general"
+
     @computed_field
     @property
     def data(self) -> BugwarriorData:
@@ -237,17 +239,27 @@ def get_target_validator(targets):
     return compute_target
 
 
-def validate_config(config: dict, main_section: str, config_path: str) -> dict:
+def validate_config(config: dict, config_path: str) -> dict:
     # Pre-validate the minimum requirements to build our pydantic models.
     try:
-        main = config[main_section]
+        main = config["general"]
     except KeyError:
-        raise_validation_error(f"No section: '{main_section}'", config_path)
+        # NOTE: validate_config is called only from load_config,
+        # which already assumes config["general"] exists.
+        # we could either keep the check here as before,
+        # and add the two lines in this function, after the check:
+        # rawconfig["general"]["flavor_name"] = flavor_name
+        # rawconfig["general"]['interactive'] = interactive
+        # or we can simply get rid of the check.'
+        # For now, the section here is wrong, if the flavor is not 'general'.
+        raise_validation_error("No section: 'general'", config_path)
+
     try:
         targets = TypeAdapter(ConfigList).validate_python(main['targets'])
     except KeyError:
         raise_validation_error(
-            f"No option 'targets' in section: '{main_section}'", config_path
+            f"No option 'targets' in section: '{config['general']['flavor_name']}'",
+            config_path,
         )
     try:
         configmap = {target: config[target] for target in targets}
@@ -267,20 +279,12 @@ def validate_config(config: dict, main_section: str, config_path: str) -> dict:
         target: (get_service(service).CONFIG_SCHEMA, ...)
         for target, service in servicemap.items()
     }
-
     # Construct Validation Model
     bugwarrior_config_model = pydantic.create_model(
         'bugwarriorrc',
         __base__=SchemaBase,
         __validators__={'compute_target': get_target_validator(targets)},
         general=(MainSectionConfig, ...),
-        flavor=(
-            dict[str, MainSectionConfig],
-            {
-                flavor: (MainSectionConfig, ...)
-                for flavor in config.get('flavor', {}).values()
-            },
-        ),
         **target_schemas,
     )
 

--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -240,8 +240,8 @@ def run_hooks(pre_import):
             raise RuntimeError(msg)
 
 
-def synchronize(issue_generator, conf, main_section, dry_run=False):
-    main_config = conf[main_section]
+def synchronize(issue_generator, conf, dry_run=False):
+    main_config = conf["general"]
 
     targets = main_config.targets.copy()
     services = set([conf[target].service for target in targets])
@@ -447,8 +447,8 @@ def build_key_list(targets):
     return keys
 
 
-def get_defined_udas_as_strings(conf, main_section):
-    targets = conf[main_section].targets
+def get_defined_udas_as_strings(conf):
+    targets = conf["general"].targets
     services = set([conf[target].service for target in targets])
     uda_list = build_uda_config_overrides(services)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,6 +2,7 @@ import abc
 import os.path
 import shutil
 import tempfile
+from typing import Any
 import unittest
 
 import pytest
@@ -37,6 +38,8 @@ class ConfigTest(unittest.TestCase):
     Creates config files, configures the environment, and cleans up afterwards.
     """
 
+    config: dict[str, Any]
+
     def setUp(self):
         self.old_environ = os.environ.copy()
         self.tempdir = tempfile.mkdtemp(prefix='bugwarrior')
@@ -63,10 +66,11 @@ class ConfigTest(unittest.TestCase):
     def inject_fixtures(self, caplog):
         self.caplog = caplog
 
-    def validate(self):
+    def validate(self, flavor: str = "general"):
         self.config['general'] = self.config.get('general', {})
         self.config['general']['interactive'] = False
-        return schema.validate_config(self.config, 'general', 'configpath')
+        self.config['general']['flavor_name'] = flavor
+        return schema.validate_config(self.config, 'configpath')
 
     def assertValidationError(self, expected):
         with self.assertRaises(SystemExit):

--- a/tests/config/test_data.py
+++ b/tests/config/test_data.py
@@ -49,7 +49,7 @@ class TestGetDataPath(ConfigTest):
                 'username': 'ralphbean',
             },
         }
-        self.config = schema.validate_config(rawconfig, 'general', 'configpath')
+        self.config = schema.validate_config(rawconfig, 'configpath')
 
     def assertDataPath(self, expected_datapath):
         self.assertEqual(

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -236,3 +236,39 @@ class TestParseFile(LoadTest):
 
         with self.assertRaises(SystemExit):
             load.parse_file(config_path)
+
+    def test_toml_flavors(self):
+        config_path = self.create('.bugwarrior.toml')
+        with open(config_path, 'w') as fout:
+            fout.write(
+                textwrap.dedent("""
+                [general]
+                targets = ["my_github"]
+
+                [flavor.work]
+                targets = ["my_jira"]
+
+                [flavor.personal]
+                targets = ["my_github"]
+                shorten = true
+
+                [my_github]
+                service = "github"
+                login = "test"
+                username = "test"
+                token = "abc"
+
+                [my_jira]
+                service = "jira"
+                base_uri = "https://jira.example.org"
+                username = "test"
+                password = "abc"
+            """)
+            )
+        config = load.parse_file(config_path)
+        self.assertIn('flavor', config)
+        self.assertIn('work', config['flavor'])
+        self.assertIn('personal', config['flavor'])
+        self.assertEqual(config['flavor']['work']['targets'], ['my_jira'])
+        self.assertEqual(config['flavor']['personal']['targets'], ['my_github'])
+        self.assertTrue(config['flavor']['personal']['shorten'])

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -151,7 +151,7 @@ class TestValidation(ConfigTest):
         del self.config['general']
 
         with self.assertRaises(SystemExit):
-            schema.validate_config(self.config, 'general', 'configpath')
+            schema.validate_config(self.config, 'configpath')
 
         self.assertEqual(len(self.caplog.records), 1)
         self.assertIn("No section: 'general'", self.caplog.records[0].message)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -121,7 +121,7 @@ class TestSynchronize(ConfigTest):
             # writing out to taskwarrior.
             # https://github.com/ralphbean/bugwarrior/issues/601
             issue_generator = iter((copy.deepcopy(issue), duplicate_issue))
-            db.synchronize(issue_generator, bwconfig, 'general')
+            db.synchronize(issue_generator, bwconfig)
 
             self.assertEqual(
                 get_tasks(tw),
@@ -149,7 +149,7 @@ class TestSynchronize(ConfigTest):
         # Change static field
         issue['project'] = 'other_project'
 
-        db.synchronize(iter((copy.deepcopy(issue),)), bwconfig, 'general')
+        db.synchronize(iter((copy.deepcopy(issue),)), bwconfig)
 
         self.assertEqual(
             get_tasks(tw),
@@ -172,7 +172,7 @@ class TestSynchronize(ConfigTest):
         )
 
         # TEST CLOSED ISSUE.
-        db.synchronize(iter(()), bwconfig, 'general')
+        db.synchronize(iter(()), bwconfig)
 
         completed_tasks = tw.load_tasks()
 
@@ -199,7 +199,7 @@ class TestSynchronize(ConfigTest):
         )
 
         # TEST REOPENED ISSUE
-        db.synchronize(iter((copy.deepcopy(issue),)), bwconfig, 'general')
+        db.synchronize(iter((copy.deepcopy(issue),)), bwconfig)
 
         tasks = tw.load_tasks()
         self.assertEqual(
@@ -241,7 +241,7 @@ class TestUDAs(ConfigTest):
         }
 
         conf = self.validate()
-        udas = sorted(list(db.get_defined_udas_as_strings(conf, 'general')))
+        udas = sorted(list(db.get_defined_udas_as_strings(conf)))
         self.assertEqual(
             udas,
             [

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -43,7 +43,7 @@ class testJiraService(ConfigTest):
     def test_body_length_no_limit(self):
         description = "A very short issue body.  Fixes #828."
         self.config['myjira']['body_length'] = '5'
-        conf = schema.validate_config(self.config, 'general', 'configpath')
+        conf = schema.validate_config(self.config, 'configpath')
         service = JiraService(conf['myjira'], conf['general'], _skip_server=True)
         issue = mock.Mock()
         issue.record = dict(fields=dict(description=description))
@@ -51,7 +51,7 @@ class testJiraService(ConfigTest):
 
     def test_body_length_limit(self):
         description = "A very short issue body.  Fixes #828."
-        conf = schema.validate_config(self.config, 'general', 'configpath')
+        conf = schema.validate_config(self.config, 'configpath')
         service = JiraService(conf['myjira'], conf['general'], _skip_server=True)
         issue = mock.Mock()
         issue.record = dict(fields=dict(description=description))

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -65,7 +65,7 @@ class ServiceBase(ConfigTest):
         with unittest.mock.patch(
             'bugwarrior.config.schema.get_service', lambda x: DumbService
         ):
-            conf = schema.validate_config(self.config, 'general', 'configpath')
+            conf = schema.validate_config(self.config, 'configpath')
         return DumbService(conf['test'], conf['general'])
 
     def makeIssue(self):


### PR DESCRIPTION
related to #1166 

I noticed the flavors were broken. 

After trying several things, I realized we could simply define the "general" section as the flavor being used, instead of passing the `main_section` param everywhere.

I think it's a huge simplification, the only (small) drawback is we currently don't validate other flavors (i.e if I'm using "work",  I won't validate either "general" nor "personal" are valid). It's not a big loss IMO, but if we really want to validate them all, we could either add a "validate_config" command, or simply iterate over flavors, build a config with each one, and call `validate_config`. 

I think the `flavor_name` field  (used to log errors) I added to the pydantic model will appear in the docs, which we probably don't want, how to change that ? 