### PR TITLE
Fix --flavor feature. Resolve #1166.

### DIFF
--- a/bugwarrior/config/ini2toml_plugin.py
+++ b/bugwarrior/config/ini2toml_plugin.py
@@ -123,7 +123,14 @@ def process_values(doc: IntermediateRepr) -> IntermediateRepr:
     return doc
 
 
+def unquote_flavors(file_contents: str) -> str:
+    return re.sub(
+        r'\n\["flavor\.(?P<flavor>[^"]*)"\]', r'\n[flavor.\g<flavor>]', file_contents
+    )
+
+
 def activate(translator: Translator):
     profile = translator["bugwarriorrc"]
     profile.description = "Convert 'bugwarriorrc' files to 'bugwarrior.toml'"
     profile.intermediate_processors.append(process_values)
+    profile.post_processors.append(unquote_flavors)

--- a/bugwarrior/config/load.py
+++ b/bugwarrior/config/load.py
@@ -56,6 +56,10 @@ def parse_file(configpath: str) -> dict:
     if os.path.splitext(configpath)[-1] == '.toml':
         with open(configpath, 'rb') as f:
             config = tomllib.load(f)
+        # Flatten flavors into top-level sections (if they're unquoted).
+        for k, v in config.get('flavor', {}).items():
+            config[f'flavor.{k}'] = v
+        config.pop('flavor', None)
     else:
         rawconfig = BugwarriorConfigParser()
         with codecs.open(configpath, "r", "utf-8") as buff:
@@ -69,7 +73,7 @@ def parse_file(configpath: str) -> dict:
                     k.replace('log.', 'log_'): v for k, v in rawconfig[section].items()
                 }
             elif section.startswith('flavor.'):
-                config['flavor'][section.split('.')[-1]] = {
+                config[section] = {
                     k.replace('.', '_'): v for k, v in rawconfig[section].items()
                 }
             else:

--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -143,7 +143,7 @@ class MainSectionConfig(BaseConfig):
 
     # added during configuration loading
     #: Interactive status.
-    interactive: bool
+    interactive: bool = False
 
     @computed_field
     @property
@@ -268,19 +268,20 @@ def validate_config(config: dict, main_section: str, config_path: str) -> dict:
         for target, service in servicemap.items()
     }
 
+    # Construct Flavors
+    flavor_schemas = {
+        section: (MainSectionConfig, ...)
+        for section in config.keys()
+        if section.startswith('flavor.')
+    }
+
     # Construct Validation Model
     bugwarrior_config_model = pydantic.create_model(
         'bugwarriorrc',
         __base__=SchemaBase,
         __validators__={'compute_target': get_target_validator(targets)},
         general=(MainSectionConfig, ...),
-        flavor=(
-            dict[str, MainSectionConfig],
-            {
-                flavor: (MainSectionConfig, ...)
-                for flavor in config.get('flavor', {}).values()
-            },
-        ),
+        **flavor_schemas,
         **target_schemas,
     )
 

--- a/tests/config/example-bugwarrior.toml
+++ b/tests/config/example-bugwarrior.toml
@@ -37,6 +37,9 @@ log_level = "DEBUG"
 log_file = "/var/log/bugwarrior.log"
 # Configure the default description or annotation length.
 # annotation_length = 45
+
+[flavor.myflavor]
+targets = ["gitlab_config", "jira_project", "my_github"]
 # Use hooks to run commands prior to importing from `bugwarrior pull`.
 # `bugwarrior pull` will run the commands in the order that they are specified
 # below.

--- a/tests/config/example-bugwarriorrc
+++ b/tests/config/example-bugwarriorrc
@@ -37,6 +37,9 @@ log.file = /var/log/bugwarrior.log
 # Configure the default description or annotation length.
 #annotation_length = 45
 
+[flavor.myflavor]
+targets = gitlab_config, jira_project, my_github
+
 # Use hooks to run commands prior to importing from `bugwarrior pull`.
 # `bugwarrior pull` will run the commands in the order that they are specified
 # below.

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -20,13 +20,16 @@ class ExampleTest(ConfigTest):
         self.basedir = pathlib.Path(__file__).parent
         super().setUp()
 
-    def test_example_bugwarriorrc(self):
-        os.environ['BUGWARRIORRC'] = str(self.basedir / 'example-bugwarriorrc')
-        load.load_config('general', False, False)
+    def test_example(self):
+        for rcfile in ('example-bugwarriorrc', 'example-bugwarrior.toml'):
+            with self.subTest(rcfile=rcfile):
+                os.environ['BUGWARRIORRC'] = str(self.basedir / rcfile)
+                config = load.load_config('general', False, False)
 
-    def test_example_bugwarrior_toml(self):
-        os.environ['BUGWARRIORRC'] = str(self.basedir / 'example-bugwarrior.toml')
-        load.load_config('general', False, False)
+                self.assertEqual(
+                    config['flavor.myflavor'].targets,
+                    ["gitlab_config", "jira_project", "my_github"],
+                )
 
 
 class LoadTest(ConfigTest):
@@ -141,19 +144,6 @@ class TestParseFile(LoadTest):
 
         load.parse_file(config_path)
 
-    def test_toml_invalid(self):
-        config_path = self.create('.bugwarrior.toml')
-        with open(config_path, 'w') as fout:
-            fout.write(
-                textwrap.dedent("""
-                [general
-                foo = "bar"
-            """)
-            )
-
-        with self.assertRaises(tomllib.TOMLDecodeError):
-            load.parse_file(config_path)
-
     def test_ini(self):
         config_path = self.create('.bugwarriorrc')
         with open(config_path, 'w') as fout:
@@ -167,6 +157,19 @@ class TestParseFile(LoadTest):
 
         self.assertEqual(config, {'general': {'foo': 'bar'}})
 
+    def test_toml_invalid(self):
+        config_path = self.create('.bugwarrior.toml')
+        with open(config_path, 'w') as fout:
+            fout.write(
+                textwrap.dedent("""
+                [general
+                foo = "bar"
+            """)
+            )
+
+        with self.assertRaises(tomllib.TOMLDecodeError):
+            load.parse_file(config_path)
+
     def test_ini_invalid(self):
         config_path = self.create('.bugwarriorrc')
         with open(config_path, 'w') as fout:
@@ -179,6 +182,30 @@ class TestParseFile(LoadTest):
 
         with self.assertRaises(configparser.MissingSectionHeaderError):
             load.parse_file(config_path)
+
+    def test_toml_flavors(self):
+        config_path = self.create('.bugwarrior.toml')
+        for section in ('["flavor.myflavor"]', '[flavor.myflavor]'):
+            with self.subTest(section=section):
+                with open(config_path, 'w') as fout:
+                    fout.write(f'{section}\ntargets = ["my_gitlab"]')
+                config = load.parse_file(config_path)
+                self.assertEqual(
+                    config, {'flavor.myflavor': {'targets': ['my_gitlab']}}
+                )
+
+    def test_ini_flavors(self):
+        config_path = self.create('.bugwarriorrc')
+        with open(config_path, 'w') as fout:
+            fout.write(
+                textwrap.dedent("""
+                [flavor.myflavor]
+                targets = my_gitlab
+            """)
+            )
+        config = load.parse_file(config_path)
+
+        self.assertEqual(config, {'flavor.myflavor': {'targets': 'my_gitlab'}})
 
     def test_ini_options_renamed(self):
         """

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -239,6 +239,12 @@ class TestValidation(ConfigTest):
         self.config['my_redmine']['project_name'] = 'myproject'
         self.validate()
 
+    def test_flavors(self):
+        self.config.setdefault('flavor', {})['myflavor'] = {
+            'targets': ['my_service', 'my_gitlab']
+        }
+        self.validate()
+
 
 class TestComputeTemplates(unittest.TestCase):
     def test_template(self):


### PR DESCRIPTION
This regression was probably introduced when adding toml support. The main issue is that the code is "indecisive" about whether flavors should be stored as top-level fields (`"flavor.myflavor"`) or a nested dictionary field (`"flavor": { "myflavor": ... }`). While unquoted sections are parsed into the nested structure in toml, top-level sections seem to be a bit easier to work with, so we now ensure that the data structure is flattened into top-level flavor fields.

Additionally:
- ini2toml now does not result in quoted flavor sections. This makes no functional difference but it does align with the docs and IMO is a bit more attractive.
- `interactive` is now optional because otherwise we'd have to set it for every flavor including "inactive" ones.
- Flavor configuration is now tested in several ways whereas it was not exercised in the test suite at all before.