### PR TITLE
remove dependency to importlib-metadata

### DIFF
--- a/bugwarrior/collect.py
+++ b/bugwarrior/collect.py
@@ -1,9 +1,9 @@
 import copy
+from importlib.metadata import entry_points
 import logging
 import multiprocessing
 import time
 
-from importlib_metadata import entry_points
 from jinja2 import Template
 from taskw.task import Task
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers=[
 dependencies = [
   "click",
   "dogpile.cache>=0.5.3",
-  "importlib-metadata",
   "jinja2>=2.7.2",
   "lockfile>=0.9.1",
   "pydantic[email]>=2",

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -1,10 +1,10 @@
 import importlib
+from importlib.metadata import entry_points
 import os
 from pathlib import Path
 import re
 import unittest
 
-from importlib_metadata import entry_points
 import pydantic
 from pydantic import TypeAdapter
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,4 +1,5 @@
 import glob
+from importlib.metadata import entry_points
 import os.path
 import pathlib
 import re
@@ -8,7 +9,6 @@ import tempfile
 import unittest
 
 import docutils.core
-from importlib_metadata import entry_points
 
 DOCS_PATH = pathlib.Path(__file__).parent / '../bugwarrior/docs'
 


### PR DESCRIPTION
Since python 3.8, this package is in the standard library.