### PR TITLE
docs: generate optional dependency list

### DIFF
--- a/bugwarrior/README.rst
+++ b/bugwarrior/README.rst
@@ -12,7 +12,7 @@ It currently supports the following remote resources:
 - `Azure DevOps <https://azure.microsoft.com/en-us/services/devops/>`_
 - `Bitbucket <https://bitbucket.org>`_
 - `Bugzilla <https://www.bugzilla.org/>`_
-- `Clickup <https://clickup.com/>`_
+- `ClickUp <https://clickup.com/>`_
 - `Debian Bug Tracking System (BTS) <https://bugs.debian.org/>`_
 - `Gerrit <https://www.gerritcodereview.com/>`_
 - `Git-Bug <https://github.com/MichaelMure/git-bug>`_

--- a/bugwarrior/docs/_ext/extras.py
+++ b/bugwarrior/docs/_ext/extras.py
@@ -1,0 +1,28 @@
+import pathlib
+
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+
+try:
+    import tomllib  # python>=3.11
+except ImportError:
+    import tomli as tomllib  # backport
+
+
+class Extras(SphinxDirective):
+    """List extra dependency groups."""
+
+    optional_arguments = 0
+    has_content = False
+
+    def run(self) -> list[nodes.Node]:
+        with open(pathlib.Path(__file__).parent / '../../../pyproject.toml', 'rb') as f:
+            pyproject = tomllib.load(f)
+        list_node = nodes.bullet_list()
+        for extra in pyproject['project']['optional-dependencies'].keys():
+            list_node.append(nodes.list_item('', nodes.paragraph(text=extra)))
+        return [list_node]
+
+
+def setup(app):
+    app.add_directive('extras', Extras)

--- a/bugwarrior/docs/conf.py
+++ b/bugwarrior/docs/conf.py
@@ -42,6 +42,7 @@ extensions = [
     'udas',
     'config',
     'sphinx_inline_tabs',
+    'extras',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/bugwarrior/docs/getting.rst
+++ b/bugwarrior/docs/getting.rst
@@ -28,24 +28,19 @@ Installing from https://pypi.python.org/pypi/bugwarrior is easy with
 
     $ pip install bugwarrior
 
-By default, ``bugwarrior`` will be installed with support for the following
-services: Bitbucket, Clickup, Github, Gitlab, Pagure, Phabricator, Redmine, Teamlab
-and Versionone. There is optional support for Jira, Kanboard, Megaplan.ru, Active Collab,
-Debian BTS, Trac, Bugzilla, and but those require extra dependencies that are
-installed by specifying ``bugwarrior[service]`` in the commands above. For
+Many services are supported by default, but others require extra dependencies that
+are installed by specifying ``bugwarrior[<extra>]`` in the commands above. For
 example, if you want to use bugwarrior with Jira::
 
     $ pip install "bugwarrior[jira]"
 
 The following extra dependency sets are available:
 
-- keyring (See also `linux installation instructions <https://github.com/jaraco/keyring#linux>`_.)
-- jira
-- kanboard
-- bts
-- trac
-- bugzilla
-- gmail
+.. extras::
+
+.. note::
+
+    For keyring, see also `linux installation instructions <https://github.com/jaraco/keyring#linux>`_.
 
 Installing from Distribution Packages
 -------------------------------------

--- a/bugwarrior/docs/services/clickup.rst
+++ b/bugwarrior/docs/services/clickup.rst
@@ -1,4 +1,4 @@
-Clickup
+ClickUp
 =======
 
 You can import tasks from a Clickup space using


### PR DESCRIPTION
These lists in the docs are quite out of date and we can't possibly maintain them manually.

Also, camelcase ClickUp as they do on their website.