### PR TITLE
Static config model

### DIFF
--- a/bugwarrior/collect.py
+++ b/bugwarrior/collect.py
@@ -1,11 +1,17 @@
 import copy
+from functools import cache
 from importlib.metadata import entry_points
 import logging
 import multiprocessing
 import time
+from typing import TYPE_CHECKING
 
 from jinja2 import Template
 from taskw.task import Task
+
+if TYPE_CHECKING:
+    from bugwarrior.config.validation import Config
+    from bugwarrior.services import Service
 
 log = logging.getLogger(__name__)
 
@@ -14,7 +20,8 @@ SERVICE_FINISHED_OK = 0
 SERVICE_FINISHED_ERROR = 1
 
 
-def get_service(service_name: str):
+@cache
+def get_service(service_name: str) -> type["Service"]:
     try:
         (service,) = entry_points(group='bugwarrior.service', name=service_name)
     except ValueError as e:
@@ -33,16 +40,22 @@ def get_service(service_name: str):
     return service.load()
 
 
-def _aggregate_issues(conf, main_section, target, queue):
+def get_service_instances(conf: "Config") -> list["Service"]:
+    return [
+        get_service(service_config.service)(service_config, conf.main)
+        for service_config in conf.service_configs
+    ]
+
+
+def _aggregate_issues(service: "Service", queue: multiprocessing.Queue):
     """This worker function is separated out from the main
     :func:`aggregate_issues` func only so that we can use multiprocessing
     on it for speed reasons.
     """
 
     start = time.time()
-
+    target = service.config.target
     try:
-        service = get_service(conf[target].service)(conf[target], conf[main_section])
         issue_count = 0
         for issue in service.issues():
             queue.put(issue)
@@ -67,24 +80,23 @@ def _aggregate_issues(conf, main_section, target, queue):
         log.info(f"Done with [{target}] in {duration}.")
 
 
-def aggregate_issues(conf, main_section, debug):
+def aggregate_issues(conf: "Config", debug: bool):
     """Return all issues from every target."""
     log.info("Starting to aggregate remote issues.")
 
-    # Create and call service objects for every target in the config
-    targets = conf[main_section].targets
-
     queue = multiprocessing.Queue()
 
-    log.info("Spawning %i workers." % len(targets))
+    services = get_service_instances(conf)
+
+    log.info("Spawning %i workers." % len(services))
 
     if debug:
-        for target in targets:
-            _aggregate_issues(conf, main_section, target, queue)
+        for service in services:
+            _aggregate_issues(service, queue)
     else:
-        for target in targets:
+        for service in services:
             proc = multiprocessing.Process(
-                target=_aggregate_issues, args=(conf, main_section, target, queue)
+                target=_aggregate_issues, args=(service, queue)
             )
             proc.start()
 
@@ -94,7 +106,7 @@ def aggregate_issues(conf, main_section, debug):
             # and tell some of our workers some incomplete things.
             time.sleep(1)
 
-    currently_running = len(targets)
+    currently_running = len(services)
     while currently_running > 0:
         issue = queue.get(True)
         try:

--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -3,6 +3,7 @@ import getpass
 import logging
 import os
 import sys
+from typing import TYPE_CHECKING
 
 import click
 from lockfile import LockTimeout
@@ -12,6 +13,8 @@ from bugwarrior.collect import aggregate_issues, get_service
 from bugwarrior.config import get_config_path, get_keyring, load_config
 from bugwarrior.db import get_defined_udas_as_strings, synchronize
 
+if TYPE_CHECKING:
+    from bugwarrior.config.validation import Config
 log = logging.getLogger(__name__)
 
 
@@ -25,7 +28,9 @@ def _get_section_name(flavor):
     return 'general'
 
 
-def _try_load_config(main_section, interactive=False, quiet=False):
+def _try_load_config(
+    main_section: str, interactive: bool = False, quiet: bool = False
+) -> "Config":
     try:
         return load_config(main_section, interactive, quiet)
     except OSError:
@@ -99,17 +104,15 @@ def pull(dry_run, flavor, interactive, debug, quiet):
         main_section = _get_section_name(flavor)
         config = _try_load_config(main_section, interactive, quiet)
 
-        lockfile_path = os.path.join(
-            config[main_section].data.path, 'bugwarrior.lockfile'
-        )
+        lockfile_path = os.path.join(config.main.data.path, 'bugwarrior.lockfile')
         lockfile = PIDLockFile(lockfile_path)
         lockfile.acquire(timeout=10)
         try:
             # Get all the issues.  This can take a while.
-            issue_generator = aggregate_issues(config, main_section, debug)
+            issue_generator = aggregate_issues(config, debug)
 
             # Stuff them in the taskwarrior db as necessary
-            synchronize(issue_generator, config, main_section, dry_run)
+            synchronize(issue_generator, config, dry_run)
         finally:
             lockfile.release()
     except LockTimeout:
@@ -138,11 +141,12 @@ def vault():
 
 def targets():
     config = _try_load_config('general')
-    for target in config['general'].targets:
-        service_class = get_service(config[target].service)
-        for value in [v for v in dict(config[target]).values() if isinstance(v, str)]:
-            if '@oracle:use_keyring' in value:
-                yield service_class.get_keyring_service(config[target])
+    for service_config in config.service_configs:
+        for value in dict(service_config).values():
+            if isinstance(value, str) and '@oracle:use_keyring' in value:
+                yield get_service(service_config.service).get_keyring_service(
+                    service_config
+                )
 
 
 @vault.command()
@@ -214,7 +218,7 @@ def uda(flavor):
     main_section = _get_section_name(flavor)
     conf = _try_load_config(main_section)
     print("# Bugwarrior UDAs")
-    for uda in get_defined_udas_as_strings(conf, main_section):
+    for uda in get_defined_udas_as_strings(conf):
         print(uda)
     print("# END Bugwarrior UDAs")
 

--- a/bugwarrior/config/load.py
+++ b/bugwarrior/config/load.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     import tomli as tomllib  # backport
 
-from bugwarrior.config.validation import Config, validate_config
+from .validation import Config, validate_config
 
 # The name of the environment variable that can be used to ovewrite the path
 # to the bugwarriorrc file
@@ -54,26 +54,15 @@ def get_config_path():
 
 
 def format_config(config: dict) -> dict[str, Any]:
-    # Build flavors from 'flavor' table
-    flavors = {
-        name: flavor_config for name, flavor_config in config.pop("flavor", {}).items()
-    }
-
-    # Handle 'general' as top-level key (TOML format, tests)
     if "general" in config:
-        flavors["general"] = config.pop("general")
+        config.setdefault("flavor", {})["general"] = config.pop("general")
 
-    services = {
-        section: {**config.pop(section), "target": section}
+    config["services"] = [
+        {**config.pop(section), "target": section}
         for section in list(config)
-        if section not in {"hooks", "notifications"}
-    }
-
-    return {
-        "flavors": flavors,
-        "services": services,
-        **config,  # remaining: "hooks" and "notifications" (if present)
-    }
+        if section not in {"hooks", "notifications", "flavor"}
+    ]
+    return config
 
 
 def parse_toml_file(configpath: str) -> dict:
@@ -130,7 +119,7 @@ def parse_file(configpath: str) -> dict:
 def load_config(main_section, interactive, quiet) -> Config:
     configpath = get_config_path()
     rawconfig = parse_file(configpath)
-    rawconfig['flavors'][main_section]['interactive'] = interactive
+    rawconfig['flavor'][main_section]['interactive'] = interactive
     config = validate_config(rawconfig, main_section, configpath)
     configure_logging(
         config.main.log_file, 'WARNING' if quiet else config.main.log_level

--- a/bugwarrior/config/load.py
+++ b/bugwarrior/config/load.py
@@ -1,14 +1,15 @@
-import codecs
 import configparser
 import logging
 import os
+from pathlib import Path
+from typing import Any
 
 try:
     import tomllib  # python>=3.11
 except ImportError:
     import tomli as tomllib  # backport
 
-from . import schema
+from bugwarrior.config.validation import Config, validate_config
 
 # The name of the environment variable that can be used to ovewrite the path
 # to the bugwarriorrc file
@@ -52,58 +53,87 @@ def get_config_path():
     return paths[0]
 
 
-def parse_file(configpath: str) -> dict:
-    if os.path.splitext(configpath)[-1] == '.toml':
-        with open(configpath, 'rb') as f:
-            config = tomllib.load(f)
-        # Flatten flavors into top-level sections (if they're unquoted).
-        for k, v in config.get('flavor', {}).items():
-            config[f'flavor.{k}'] = v
-        config.pop('flavor', None)
-    else:
-        rawconfig = BugwarriorConfigParser()
-        with codecs.open(configpath, "r", "utf-8") as buff:
-            rawconfig.read_file(buff)
-        config = {}
-        for section in rawconfig.sections():
-            if section in ['hooks', 'notifications']:
-                config[section] = dict(rawconfig[section])
-            elif section == 'general':
-                config[section] = {
-                    k.replace('log.', 'log_'): v for k, v in rawconfig[section].items()
-                }
-            elif section.startswith('flavor.'):
-                config[section] = {
-                    k.replace('.', '_'): v for k, v in rawconfig[section].items()
-                }
-            else:
-                service = rawconfig[section].pop('service')
-                service_prefix = 'ado' if service == 'azuredevops' else service
-                config[section] = {'service': service}
-                for k, v in rawconfig[section].items():
-                    try:
-                        prefix, key = k.split('.')
-                    except ValueError:  # missing prefix
-                        prefix = None
-                        key = k
-                    if prefix != service_prefix:
-                        raise SystemExit(
-                            f"[{section}]\n{k} <-expected prefix "
-                            f"'{service_prefix}': did you mean "
-                            f"'{service_prefix}.{key}'?"
-                        )
-                    config[section][key] = v
+def format_config(config: dict) -> dict[str, Any]:
+    # Build flavors from 'flavor' table
+    flavors = {
+        name: flavor_config for name, flavor_config in config.pop("flavor", {}).items()
+    }
+
+    # Handle 'general' as top-level key (TOML format, tests)
+    if "general" in config:
+        flavors["general"] = config.pop("general")
+
+    services = {
+        section: {**config.pop(section), "target": section}
+        for section in list(config)
+        if section not in {"hooks", "notifications"}
+    }
+
+    return {
+        "flavors": flavors,
+        "services": services,
+        **config,  # remaining: "hooks" and "notifications" (if present)
+    }
+
+
+def parse_toml_file(configpath: str) -> dict:
+    with open(configpath, 'rb') as file:
+        return tomllib.load(file)
+
+
+def parse_ini_file(configpath: str) -> dict:
+    rawconfig = BugwarriorConfigParser()
+    with open(configpath, encoding="utf-8") as buff:
+        rawconfig.read_file(buff)
+
+    config = {"flavor": {}}
+    for section in rawconfig.sections():
+        if section in ['hooks', 'notifications']:
+            config[section] = dict(rawconfig[section])
+        elif section == 'general' or section.startswith('flavor.'):
+            name = section.removeprefix('flavor.')
+            config["flavor"][name] = {
+                key.replace('.', '_'): value
+                for key, value in rawconfig[section].items()
+            }
+
+        # All other sections are assumed to be services
+        else:
+            service = rawconfig[section].pop('service')
+            service_prefix = 'ado' if service == 'azuredevops' else service
+            config[section] = {'service': service}
+            for key, value in rawconfig[section].items():
+                try:
+                    prefix, unprefixed_key = key.split('.')
+                except ValueError:  # missing prefix
+                    prefix = None
+                    unprefixed_key = key
+                if prefix != service_prefix:
+                    raise SystemExit(
+                        f"[{section}]\n{key} <-expected prefix "
+                        f"'{service_prefix}': did you mean "
+                        f"'{service_prefix}.{unprefixed_key}'?"
+                    )
+                config[section][unprefixed_key] = value
+
     return config
 
 
-def load_config(main_section, interactive, quiet) -> dict:
+def parse_file(configpath: str) -> dict:
+    if Path(configpath).suffix == '.toml':
+        config = parse_toml_file(configpath)
+    else:
+        config = parse_ini_file(configpath)
+    return format_config(config)
+
+
+def load_config(main_section, interactive, quiet) -> Config:
     configpath = get_config_path()
     rawconfig = parse_file(configpath)
-    rawconfig[main_section]['interactive'] = interactive
-    config = schema.validate_config(rawconfig, main_section, configpath)
+    rawconfig['flavors'][main_section]['interactive'] = interactive
+    config = validate_config(rawconfig, main_section, configpath)
     configure_logging(
-        config[main_section].log_file,
-        'WARNING' if quiet else config[main_section].log_level,
+        config.main.log_file, 'WARNING' if quiet else config.main.log_level
     )
     return config
 

--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -197,6 +197,7 @@ class ServiceConfig(_ServiceConfig):
     .. _Pydantic: https://docs.pydantic.dev/latest/
     """
 
+    # Added before validation (computed field)
     service: str
     target: str
 

--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -2,7 +2,6 @@ import logging
 import os
 from pathlib import Path
 import re
-import sys
 import typing
 from typing import Annotated, Any, Generic, Literal
 
@@ -13,7 +12,6 @@ from pydantic import (
     BeforeValidator,
     ConfigDict,
     Field,
-    TypeAdapter,
     ValidationInfo,
     computed_field,
     field_validator,
@@ -21,8 +19,6 @@ from pydantic import (
 )
 from pydantic_core import PydanticCustomError
 import taskw
-
-from bugwarrior.collect import get_service
 
 from .data import BugwarriorData, get_data_path
 
@@ -184,117 +180,6 @@ class Notifications(BaseConfig):
     only_on_new_tasks: bool = False
 
 
-class SchemaBase(BaseConfig):
-    # Allow extra top-level sections so all targets don't have to be selected.
-    model_config = ConfigDict(extra="ignore")
-
-    hooks: Hooks = Hooks()
-    notifications: Notifications = Notifications()
-
-
-def get_validation_error_enhanced_messages(
-    error: pydantic.ValidationError,
-) -> list[str]:
-    errors = []
-    for _error in error.errors():
-        msg = _error["msg"]
-        if _error["type"] == "extra_forbidden":
-            msg = "unrecognized option"
-        loc = _error["loc"]
-        loc_len = len(loc)
-
-        if loc_len == 1 or (loc_len > 1 and loc[1] == "__root__"):
-            formatted_error_loc = f"[{loc[0]}]"
-        elif loc_len == 2:
-            formatted_error_loc = f"[{loc[0]}]\n{loc[1]}"
-            if _error["type"] != "missing":
-                formatted_error_loc = f"{formatted_error_loc} = {_error['input']}"
-        else:
-            raise ValueError(
-                "Configuration should not be nested more than two layers deep."
-            )
-        errors.append(f"{formatted_error_loc}  <- {msg}\n")
-    return errors
-
-
-def raise_validation_error(msg, config_path, no_errors=1) -> typing.NoReturn:
-    log.error(
-        ("Validation error" if no_errors == 1 else f"{no_errors} validation errors")
-        + f" found in {config_path}\n"
-        f"See https://bugwarrior.readthedocs.io\n\n{msg}"
-    )
-    sys.exit(1)
-
-
-def get_target_validator(targets):
-    @model_validator(mode='before')
-    @classmethod
-    def compute_target(cls, values):
-        for target in targets:
-            values[target]['target'] = target
-        return values
-
-    return compute_target
-
-
-def validate_config(config: dict, main_section: str, config_path: str) -> dict:
-    # Pre-validate the minimum requirements to build our pydantic models.
-    try:
-        main = config[main_section]
-    except KeyError:
-        raise_validation_error(f"No section: '{main_section}'", config_path)
-    try:
-        targets = TypeAdapter(ConfigList).validate_python(main['targets'])
-    except KeyError:
-        raise_validation_error(
-            f"No option 'targets' in section: '{main_section}'", config_path
-        )
-    try:
-        configmap = {target: config[target] for target in targets}
-    except KeyError as e:
-        raise_validation_error(f"No section: '{e.args[0]}'", config_path)
-    servicemap = {}
-    for target, serviceconfig in configmap.items():
-        try:
-            servicemap[target] = serviceconfig['service']
-        except KeyError:
-            raise_validation_error(
-                f"No option 'service' in section: '{target}'", config_path
-            )
-
-    # Construct Service Models
-    target_schemas = {
-        target: (get_service(service).CONFIG_SCHEMA, ...)
-        for target, service in servicemap.items()
-    }
-
-    # Construct Flavors
-    flavor_schemas = {
-        section: (MainSectionConfig, ...)
-        for section in config.keys()
-        if section.startswith('flavor.')
-    }
-
-    # Construct Validation Model
-    bugwarrior_config_model = pydantic.create_model(
-        'bugwarriorrc',
-        __base__=SchemaBase,
-        __validators__={'compute_target': get_target_validator(targets)},
-        general=(MainSectionConfig, ...),
-        **flavor_schemas,
-        **target_schemas,
-    )
-
-    # Validate
-    try:
-        # Convert top-level model to dict since target names are dynamic and
-        # a bunch of calls to getattr(config, target) inhibits readability.
-        return dict(bugwarrior_config_model.model_validate(config))
-    except pydantic.ValidationError as e:
-        errors = get_validation_error_enhanced_messages(e)
-        raise_validation_error("\n".join(errors), config_path, no_errors=len(errors))
-
-
 # Dynamically add template fields to model.
 _ServiceConfig = pydantic.create_model(
     "_ServiceConfig",
@@ -312,9 +197,11 @@ class ServiceConfig(_ServiceConfig):
     .. _Pydantic: https://docs.pydantic.dev/latest/
     """
 
+    service: str
+    target: str
+
     # Added during validation (computed field)
     templates: dict = {}
-    target: typing.Optional[str] = None
 
     # Optional fields shared by all services.
     only_if_assigned: str = ""

--- a/bugwarrior/config/validation.py
+++ b/bugwarrior/config/validation.py
@@ -16,12 +16,12 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-def _format_section_error(section: str | int, msg: str) -> str:
+def _format_section_error(section: str, msg: str) -> str:
     return f"[{section}]  <- {msg}\n"
 
 
 def _format_field_error(
-    section: str | int, field: str | int, msg: str, error: ErrorDetails | dict
+    section: str, field: str, msg: str, error: ErrorDetails | dict
 ) -> str:
     formatted = f"[{section}]\n{field}"
     if error["type"] != "missing":
@@ -56,6 +56,7 @@ def _format_service_error(
     if len(loc) == 2 or loc[-1] == "__root__":
         return _format_section_error(target, msg)
 
+    assert isinstance(loc[2], str)
     return _format_field_error(target, loc[2], msg, error)
 
 
@@ -70,6 +71,7 @@ def _format_flavor_error(error: ErrorDetails | dict) -> str:
     msg = error["msg"]
 
     flavor_name = loc[0]
+    assert isinstance(flavor_name, str)
 
     if len(loc) == 1:
         raise ValueError(f"Unexpected error loc with single element: {loc}")
@@ -77,6 +79,7 @@ def _format_flavor_error(error: ErrorDetails | dict) -> str:
     if loc[-1] == "__root__":
         return _format_section_error(flavor_name, msg)
 
+    assert isinstance(loc[1], str)
     return _format_field_error(flavor_name, loc[1], msg, error)
 
 
@@ -100,6 +103,7 @@ def _format_extra_section_error(error: ErrorDetails | dict) -> str:
     if loc[-1] == "__root__":
         return _format_section_error(section_name, msg)
 
+    assert isinstance(loc[1], str)
     return _format_field_error(section_name, loc[1], msg, error)
 
 
@@ -147,7 +151,7 @@ def validate_config(config: dict, main_section: str, config_path: str) -> "Confi
         error_messages.extend(_format_flavor_error(err) for err in error.errors())
 
     # Check for misquoted flavor sections (e.g., ["flavor.myflavor"] instead of [flavor.myflavor])
-    services_list = []
+    raw_service_configs = []
     for service in config.pop("services", []):
         target = service["target"]
         if target.startswith("flavor."):
@@ -156,17 +160,17 @@ def validate_config(config: dict, main_section: str, config_path: str) -> "Confi
                 "Use [flavor.name] (not quoted) to define a flavor.\n"
             )
         else:
-            services_list.append(service)
+            raw_service_configs.append(service)
 
     # Validate service configs
-    ServiceConfigType = get_service_config_union_type(services_list)
+    ServiceConfigType = get_service_config_union_type(raw_service_configs)
     try:
         service_configs = TypeAdapter(list[ServiceConfigType]).validate_python(
-            services_list
+            raw_service_configs
         )
     except ValidationError as error:
         error_messages.extend(
-            _format_service_error(err, services_list) for err in error.errors()
+            _format_service_error(err, raw_service_configs) for err in error.errors()
         )
         service_configs = []
 
@@ -175,7 +179,9 @@ def validate_config(config: dict, main_section: str, config_path: str) -> "Confi
         error_messages.append(f"No section: '{main_section}'\n")
 
     # Check targets exist for all flavors
-    available_targets = {service_config["target"] for service_config in services_list}
+    available_targets = {
+        service_config["target"] for service_config in raw_service_configs
+    }
     for flavor_name, flavor in flavors.items():
         missing = sorted(set(flavor.targets) - available_targets)
         for target in missing:

--- a/bugwarrior/config/validation.py
+++ b/bugwarrior/config/validation.py
@@ -31,21 +31,24 @@ def _format_field_error(
     return f"{formatted}  <- {msg}\n"
 
 
-def _format_service_error(error: ErrorDetails | dict) -> str:
+def _format_service_error(
+    error: ErrorDetails | dict, services: list[dict[str, Any]]
+) -> str:
     """Format validation error for service configs (discriminated union).
 
     loc structure:
-    - (target,) - discriminator error (missing 'service')
-    - (target, service_type) - model-level error
-    - (target, service_type, '__root__') - model validator
-    - (target, service_type, field) - field error
+    - (index,) - discriminator error (missing 'service')
+    - (index, service_type) - model-level error
+    - (index, service_type, '__root__') - model validator
+    - (index, service_type, field) - field error
     """
     loc = error["loc"]
     msg = error["msg"]
     if error["type"] == "extra_forbidden":
         msg = "unrecognized option"
 
-    target = loc[0]
+    index = int(loc[0])
+    target = services[index].get("target", f"service[{index}]")
 
     if len(loc) == 1:
         return _format_section_error(
@@ -76,17 +79,24 @@ def _format_flavor_error(error: ErrorDetails | dict) -> str:
     return _format_field_error(flavor_name, loc[1], msg, error)
 
 
-def _format_simple_section_error(error: ErrorDetails | dict, section_name: str) -> str:
-    """Format validation error for simple sections (hooks, notifications)."""
+def _format_extra_section_error(error: ErrorDetails | dict) -> str:
+    """Format validation error for extra options (hooks, notifications).
+
+    loc structure:
+    - (section_name, field) - field error
+    - (section_name, '__root__') - model validator
+    """
     loc = error["loc"]
     msg = error["msg"]
     if error["type"] == "extra_forbidden":
         msg = "unrecognized option"
 
-    if not loc or loc[-1] == "__root__":
+    section_name = str(loc[0])
+
+    if len(loc) == 1 or loc[-1] == "__root__":
         return _format_section_error(section_name, msg)
 
-    return _format_field_error(section_name, loc[0], msg, error)
+    return _format_field_error(section_name, loc[1], msg, error)
 
 
 def raise_validation_error(msg, config_path, error_count=1) -> typing.NoReturn:
@@ -98,10 +108,20 @@ def raise_validation_error(msg, config_path, error_count=1) -> typing.NoReturn:
     sys.exit(1)
 
 
-def get_service_config_union_type(services: dict[str, dict[str, Any]]):
+def get_service_config_union_type(services: list[dict[str, Any]]):
+    """
+    Return a Union type of the ServiceConfig subclasses of the services actually configured.
+
+    We don't want to include all available services because each service must be imported
+    which could have side-effects.
+
+    The returned type takes advantaged of Pydantic's "Discriminated Unions" feature
+    to ensure that each service configuration is validated against
+    the ServiceConfig corresponding to the correct service.
+    """
     service_config_classes = tuple(
         get_service(service["service"]).CONFIG_SCHEMA
-        for service in services.values()
+        for service in services
         if "service" in service
     )
 
@@ -114,62 +134,44 @@ def get_service_config_union_type(services: dict[str, dict[str, Any]]):
 
 def validate_config(config: dict, main_section: str, config_path: str) -> "Config":
     error_messages: list[str] = []
-
+    raw_flavors = config.pop("flavor", {})
     # Validate flavors
-    flavors: dict[str, MainSectionConfig] = {}
     try:
-        flavors = TypeAdapter(dict[str, MainSectionConfig]).validate_python(
-            config.get("flavors", {})
-        )
+        flavors = TypeAdapter(dict[str, MainSectionConfig]).validate_python(raw_flavors)
     except pydantic.ValidationError as error:
+        flavors = {}
         error_messages.extend(_format_flavor_error(err) for err in error.errors())
 
     # Check for misquoted flavor sections (e.g., ["flavor.myflavor"] instead of [flavor.myflavor])
-    services_config = config.get("services", {})
-    misquoted_flavors = [name for name in services_config if name.startswith("flavor.")]
-    for section in misquoted_flavors:
-        error_messages.append(
-            f'["{section}"]  <- Did you mean [{section}]?\n'
-            "Use [flavor.name] (not quoted) to define a flavor.\n"
-        )
-        del services_config[section]
+    services_list = []
+    for service in config.pop("services", []):
+        target = service["target"]
+        if target.startswith("flavor."):
+            error_messages.append(
+                f'["{target}"]  <- Did you mean [{target}]?\n'
+                "Use [flavor.name] (not quoted) to define a flavor.\n"
+            )
+        else:
+            services_list.append(service)
 
     # Validate service configs
-    ServiceConfigType = get_service_config_union_type(services_config)
-    service_configs: dict[str, ServiceConfigType] = {}
+    ServiceConfigType = get_service_config_union_type(services_list)
     try:
-        service_configs = TypeAdapter(dict[str, ServiceConfigType]).validate_python(
-            services_config
-        )
-    except pydantic.ValidationError as error:
-        error_messages.extend(_format_service_error(err) for err in error.errors())
-
-    # Validate hooks
-    hooks = Hooks()
-    try:
-        hooks = TypeAdapter(Hooks).validate_python(config.get("hooks", {}))
-    except pydantic.ValidationError as error:
-        error_messages.extend(
-            _format_simple_section_error(err, "hooks") for err in error.errors()
-        )
-
-    # Validate notifications
-    notifications = Notifications()
-    try:
-        notifications = TypeAdapter(Notifications).validate_python(
-            config.get("notifications", {})
+        service_configs = TypeAdapter(list[ServiceConfigType]).validate_python(
+            services_list
         )
     except pydantic.ValidationError as error:
         error_messages.extend(
-            _format_simple_section_error(err, "notifications") for err in error.errors()
+            _format_service_error(err, services_list) for err in error.errors()
         )
+        service_configs = []
 
     # Check main_section exists in flavors
-    if main_section not in flavors:
+    if main_section not in raw_flavors:
         error_messages.append(f"No section: '{main_section}'\n")
 
     # Check targets exist for all flavors
-    available_targets = set(service_configs.keys())
+    available_targets = {service_config["target"] for service_config in services_list}
     for flavor_name, flavor in flavors.items():
         missing = set(flavor.targets) - available_targets
         if missing:
@@ -177,20 +179,25 @@ def validate_config(config: dict, main_section: str, config_path: str) -> "Confi
                 f"[{flavor_name}] missing targets: {', '.join(sorted(missing))}\n"
             )
 
+    main = flavors.get(main_section, MainSectionConfig(targets=[]))
+    filtered_service_configs = [
+        service_config
+        for service_config in service_configs
+        if service_config.target in main.targets
+    ]
+
+    try:
+        _config = Config(service_configs=filtered_service_configs, main=main, **config)
+    except pydantic.ValidationError as error:
+        error_messages.extend(
+            _format_extra_section_error(err) for err in error.errors()
+        )
+
     if error_messages:
         raise_validation_error(
             "".join(error_messages), config_path, error_count=len(error_messages)
         )
-
-    main = flavors[main_section]
-    filtered_service_configs = [service_configs[target] for target in main.targets]
-
-    return Config(
-        service_configs=filtered_service_configs,
-        main=main,
-        hooks=hooks,
-        notifications=notifications,
-    )
+    return _config
 
 
 class Config(BaseConfig):

--- a/bugwarrior/config/validation.py
+++ b/bugwarrior/config/validation.py
@@ -1,10 +1,8 @@
 import logging
 import sys
-import typing
-from typing import TYPE_CHECKING, Annotated, Any, Union
+from typing import TYPE_CHECKING, Annotated, Any, NoReturn, Union
 
-import pydantic
-from pydantic import Field, TypeAdapter
+from pydantic import Field, TypeAdapter, ValidationError
 from pydantic_core import ErrorDetails
 
 from bugwarrior.collect import get_service
@@ -34,10 +32,10 @@ def _format_field_error(
 def _format_service_error(
     error: ErrorDetails | dict, services: list[dict[str, Any]]
 ) -> str:
-    """Format validation error for service configs (discriminated union).
+    """Format validation error for service configs.
 
     loc structure:
-    - (index,) - discriminator error (missing 'service')
+    - (index,) - 'service' key is missing, can't determine which model to validate against
     - (index, service_type) - model-level error
     - (index, service_type, '__root__') - model validator
     - (index, service_type, field) - field error
@@ -48,7 +46,7 @@ def _format_service_error(
         msg = "unrecognized option"
 
     index = int(loc[0])
-    target = services[index].get("target", f"service[{index}]")
+    target = services[index]["target"]
 
     if len(loc) == 1:
         return _format_section_error(
@@ -73,7 +71,10 @@ def _format_flavor_error(error: ErrorDetails | dict) -> str:
 
     flavor_name = loc[0]
 
-    if len(loc) == 1 or loc[-1] == "__root__":
+    if len(loc) == 1:
+        raise ValueError(f"Unexpected error loc with single element: {loc}")
+
+    if loc[-1] == "__root__":
         return _format_section_error(flavor_name, msg)
 
     return _format_field_error(flavor_name, loc[1], msg, error)
@@ -93,13 +94,16 @@ def _format_extra_section_error(error: ErrorDetails | dict) -> str:
 
     section_name = str(loc[0])
 
-    if len(loc) == 1 or loc[-1] == "__root__":
+    if len(loc) == 1:
+        raise ValueError(f"Unexpected error loc with single element: {loc}")
+
+    if loc[-1] == "__root__":
         return _format_section_error(section_name, msg)
 
     return _format_field_error(section_name, loc[1], msg, error)
 
 
-def raise_validation_error(msg, config_path, error_count=1) -> typing.NoReturn:
+def raise_validation_error(msg, config_path, error_count=1) -> NoReturn:
     log.error(
         ("Validation error" if error_count == 1 else f"{error_count} validation errors")
         + f" found in {config_path}\n"
@@ -138,7 +142,7 @@ def validate_config(config: dict, main_section: str, config_path: str) -> "Confi
     # Validate flavors
     try:
         flavors = TypeAdapter(dict[str, MainSectionConfig]).validate_python(raw_flavors)
-    except pydantic.ValidationError as error:
+    except ValidationError as error:
         flavors = {}
         error_messages.extend(_format_flavor_error(err) for err in error.errors())
 
@@ -160,7 +164,7 @@ def validate_config(config: dict, main_section: str, config_path: str) -> "Confi
         service_configs = TypeAdapter(list[ServiceConfigType]).validate_python(
             services_list
         )
-    except pydantic.ValidationError as error:
+    except ValidationError as error:
         error_messages.extend(
             _format_service_error(err, services_list) for err in error.errors()
         )
@@ -173,10 +177,10 @@ def validate_config(config: dict, main_section: str, config_path: str) -> "Confi
     # Check targets exist for all flavors
     available_targets = {service_config["target"] for service_config in services_list}
     for flavor_name, flavor in flavors.items():
-        missing = set(flavor.targets) - available_targets
-        if missing:
+        missing = sorted(set(flavor.targets) - available_targets)
+        for target in missing:
             error_messages.append(
-                f"[{flavor_name}] missing targets: {', '.join(sorted(missing))}\n"
+                f"[{flavor_name}]\ntargets = {flavor.targets}  <- No [{target}] section found\n"
             )
 
     main = flavors.get(main_section, MainSectionConfig(targets=[]))
@@ -188,7 +192,7 @@ def validate_config(config: dict, main_section: str, config_path: str) -> "Confi
 
     try:
         _config = Config(service_configs=filtered_service_configs, main=main, **config)
-    except pydantic.ValidationError as error:
+    except ValidationError as error:
         error_messages.extend(
             _format_extra_section_error(err) for err in error.errors()
         )

--- a/bugwarrior/config/validation.py
+++ b/bugwarrior/config/validation.py
@@ -1,0 +1,200 @@
+import logging
+import sys
+import typing
+from typing import TYPE_CHECKING, Annotated, Any, Union
+
+import pydantic
+from pydantic import Field, TypeAdapter
+from pydantic_core import ErrorDetails
+
+from bugwarrior.collect import get_service
+
+from .schema import BaseConfig, Hooks, MainSectionConfig, Notifications, ServiceConfig
+
+if TYPE_CHECKING:
+    ServiceConfigType = ServiceConfig
+
+
+log = logging.getLogger(__name__)
+
+
+def _format_section_error(section: str | int, msg: str) -> str:
+    return f"[{section}]  <- {msg}\n"
+
+
+def _format_field_error(
+    section: str | int, field: str | int, msg: str, error: ErrorDetails | dict
+) -> str:
+    formatted = f"[{section}]\n{field}"
+    if error["type"] != "missing":
+        formatted = f"{formatted} = {error['input']}"
+    return f"{formatted}  <- {msg}\n"
+
+
+def _format_service_error(error: ErrorDetails | dict) -> str:
+    """Format validation error for service configs (discriminated union).
+
+    loc structure:
+    - (target,) - discriminator error (missing 'service')
+    - (target, service_type) - model-level error
+    - (target, service_type, '__root__') - model validator
+    - (target, service_type, field) - field error
+    """
+    loc = error["loc"]
+    msg = error["msg"]
+    if error["type"] == "extra_forbidden":
+        msg = "unrecognized option"
+
+    target = loc[0]
+
+    if len(loc) == 1:
+        return _format_section_error(
+            target, f"No option 'service' in section: '{target}'"
+        )
+
+    if len(loc) == 2 or loc[-1] == "__root__":
+        return _format_section_error(target, msg)
+
+    return _format_field_error(target, loc[2], msg, error)
+
+
+def _format_flavor_error(error: ErrorDetails | dict) -> str:
+    """Format validation error for flavors.
+
+    loc structure:
+    - (flavor_name, '__root__') - model validator
+    - (flavor_name, field) - field error
+    """
+    loc = error["loc"]
+    msg = error["msg"]
+
+    flavor_name = loc[0]
+
+    if len(loc) == 1 or loc[-1] == "__root__":
+        return _format_section_error(flavor_name, msg)
+
+    return _format_field_error(flavor_name, loc[1], msg, error)
+
+
+def _format_simple_section_error(error: ErrorDetails | dict, section_name: str) -> str:
+    """Format validation error for simple sections (hooks, notifications)."""
+    loc = error["loc"]
+    msg = error["msg"]
+    if error["type"] == "extra_forbidden":
+        msg = "unrecognized option"
+
+    if not loc or loc[-1] == "__root__":
+        return _format_section_error(section_name, msg)
+
+    return _format_field_error(section_name, loc[0], msg, error)
+
+
+def raise_validation_error(msg, config_path, error_count=1) -> typing.NoReturn:
+    log.error(
+        ("Validation error" if error_count == 1 else f"{error_count} validation errors")
+        + f" found in {config_path}\n"
+        f"See https://bugwarrior.readthedocs.io\n\n{msg}"
+    )
+    sys.exit(1)
+
+
+def get_service_config_union_type(services: dict[str, dict[str, Any]]):
+    service_config_classes = tuple(
+        get_service(service["service"]).CONFIG_SCHEMA
+        for service in services.values()
+        if "service" in service
+    )
+
+    # Default to generic ServiceConfig if no service defined, mostly for tests
+    if not service_config_classes:
+        return ServiceConfig
+
+    return Annotated[Union[service_config_classes], Field(discriminator="service")]
+
+
+def validate_config(config: dict, main_section: str, config_path: str) -> "Config":
+    error_messages: list[str] = []
+
+    # Validate flavors
+    flavors: dict[str, MainSectionConfig] = {}
+    try:
+        flavors = TypeAdapter(dict[str, MainSectionConfig]).validate_python(
+            config.get("flavors", {})
+        )
+    except pydantic.ValidationError as error:
+        error_messages.extend(_format_flavor_error(err) for err in error.errors())
+
+    # Check for misquoted flavor sections (e.g., ["flavor.myflavor"] instead of [flavor.myflavor])
+    services_config = config.get("services", {})
+    misquoted_flavors = [name for name in services_config if name.startswith("flavor.")]
+    for section in misquoted_flavors:
+        error_messages.append(
+            f'["{section}"]  <- Did you mean [{section}]?\n'
+            "Use [flavor.name] (not quoted) to define a flavor.\n"
+        )
+        del services_config[section]
+
+    # Validate service configs
+    ServiceConfigType = get_service_config_union_type(services_config)
+    service_configs: dict[str, ServiceConfigType] = {}
+    try:
+        service_configs = TypeAdapter(dict[str, ServiceConfigType]).validate_python(
+            services_config
+        )
+    except pydantic.ValidationError as error:
+        error_messages.extend(_format_service_error(err) for err in error.errors())
+
+    # Validate hooks
+    hooks = Hooks()
+    try:
+        hooks = TypeAdapter(Hooks).validate_python(config.get("hooks", {}))
+    except pydantic.ValidationError as error:
+        error_messages.extend(
+            _format_simple_section_error(err, "hooks") for err in error.errors()
+        )
+
+    # Validate notifications
+    notifications = Notifications()
+    try:
+        notifications = TypeAdapter(Notifications).validate_python(
+            config.get("notifications", {})
+        )
+    except pydantic.ValidationError as error:
+        error_messages.extend(
+            _format_simple_section_error(err, "notifications") for err in error.errors()
+        )
+
+    # Check main_section exists in flavors
+    if main_section not in flavors:
+        error_messages.append(f"No section: '{main_section}'\n")
+
+    # Check targets exist for all flavors
+    available_targets = set(service_configs.keys())
+    for flavor_name, flavor in flavors.items():
+        missing = set(flavor.targets) - available_targets
+        if missing:
+            error_messages.append(
+                f"[{flavor_name}] missing targets: {', '.join(sorted(missing))}\n"
+            )
+
+    if error_messages:
+        raise_validation_error(
+            "".join(error_messages), config_path, error_count=len(error_messages)
+        )
+
+    main = flavors[main_section]
+    filtered_service_configs = [service_configs[target] for target in main.targets]
+
+    return Config(
+        service_configs=filtered_service_configs,
+        main=main,
+        hooks=hooks,
+        notifications=notifications,
+    )
+
+
+class Config(BaseConfig):
+    service_configs: list[ServiceConfig]
+    main: MainSectionConfig
+    hooks: Hooks = Hooks()
+    notifications: Notifications = Notifications()

--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -13,7 +13,6 @@ from bugwarrior.collect import get_service
 from bugwarrior.notifications import send_notification
 
 if TYPE_CHECKING:
-    from bugwarrior.config.schema import ServiceConfig
     from bugwarrior.config.validation import Config
 
 log = logging.getLogger(__name__)
@@ -247,8 +246,9 @@ def run_hooks(pre_import):
 
 
 def synchronize(issue_generator, conf: "Config", dry_run: bool = False):
-    key_list = build_key_list(conf.service_configs)
-    uda_list = build_uda_config_overrides(conf.service_configs)
+    services = [service_config.service for service_config in conf.service_configs]
+    key_list = build_key_list(services)
+    uda_list = build_uda_config_overrides(services)
 
     if uda_list:
         log.info(
@@ -401,7 +401,10 @@ def synchronize(issue_generator, conf: "Config", dry_run: bool = False):
 
     log.debug(f'Closing tasks for succeeding services: {list(successful_config_map)}.')
     succeeded_service_task_uuids = get_managed_task_uuids(
-        tw, build_key_list(successful_config_map.values())
+        tw,
+        build_key_list(
+            service_config.service for service_config in successful_config_map.values()
+        ),
     )
     issue_updates['closed'] = succeeded_service_task_uuids - seen_uuids
     log.info("Closing %i tasks", len(issue_updates['closed']))
@@ -446,21 +449,20 @@ def synchronize(issue_generator, conf: "Config", dry_run: bool = False):
             )
 
 
-def build_key_list(service_configs: "Iterable[ServiceConfig]"):
+def build_key_list(services: Iterable[str]):
     return {
-        service_config.service: get_service(
-            service_config.service
-        ).ISSUE_CLASS.UNIQUE_KEY
-        for service_config in service_configs
+        service: get_service(service).ISSUE_CLASS.UNIQUE_KEY for service in services
     }
 
 
 def get_defined_udas_as_strings(conf: "Config"):
-    uda_list = build_uda_config_overrides(conf.service_configs)
+    uda_list = build_uda_config_overrides(
+        service_config.service for service_config in conf.service_configs
+    )
     yield from convert_override_args_to_taskrc_settings(uda_list)
 
 
-def build_uda_config_overrides(service_configs: "Iterable[ServiceConfig]"):
+def build_uda_config_overrides(services: Iterable[str]):
     """Returns a list of UDAs defined by given targets
 
     For all targets in `targets`, build a dictionary of configuration overrides
@@ -491,8 +493,8 @@ def build_uda_config_overrides(service_configs: "Iterable[ServiceConfig]"):
 
     """
     targets_udas = {}
-    for service_config in service_configs:
-        targets_udas.update(get_service(service_config.service).ISSUE_CLASS.UDAS)
+    for service in services:
+        targets_udas.update(get_service(service).ISSUE_CLASS.UDAS)
     return {'uda': targets_udas}
 
 

--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -1,14 +1,20 @@
+from collections.abc import Iterable
 import itertools
 import json
 import logging
 import re
 import subprocess
+from typing import TYPE_CHECKING
 
 from taskw import TaskWarriorShellout
 from taskw.exceptions import TaskwarriorError
 
 from bugwarrior.collect import get_service
 from bugwarrior.notifications import send_notification
+
+if TYPE_CHECKING:
+    from bugwarrior.config.schema import ServiceConfig
+    from bugwarrior.config.validation import Config
 
 log = logging.getLogger(__name__)
 
@@ -240,13 +246,9 @@ def run_hooks(pre_import):
             raise RuntimeError(msg)
 
 
-def synchronize(issue_generator, conf, main_section, dry_run=False):
-    main_config = conf[main_section]
-
-    targets = main_config.targets.copy()
-    services = set([conf[target].service for target in targets])
-    key_list = build_key_list(services)
-    uda_list = build_uda_config_overrides(services)
+def synchronize(issue_generator, conf: "Config", dry_run: bool = False):
+    key_list = build_key_list(conf.service_configs)
+    uda_list = build_uda_config_overrides(conf.service_configs)
 
     if uda_list:
         log.info(
@@ -256,20 +258,24 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
         )
 
     # Before running CRUD operations, call the pre_import hook(s).
-    run_hooks(conf['hooks'].pre_import)
+    run_hooks(conf.hooks.pre_import)
 
-    notify = conf['notifications'].notifications and not dry_run
+    notify = conf.notifications.notifications and not dry_run
 
     tw = TaskWarriorShellout(
-        config_filename=main_config.taskrc, config_overrides=uda_list, marshal=True
+        config_filename=conf.main.taskrc, config_overrides=uda_list, marshal=True
     )
 
     issue_updates = {'new': [], 'existing': [], 'changed': [], 'closed': []}
 
     issue_map = {}  # unique identifier -> issue
+    successful_config_map = {
+        service_config.target: service_config for service_config in conf.service_configs
+    }
+
     for issue in issue_generator:
         if isinstance(issue, tuple) and issue[0] == 'SERVICE FAILED':
-            targets.remove(issue[1])
+            successful_config_map.pop(issue[1])
             continue
 
         # De-duplicate issues coming in
@@ -303,7 +309,7 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
             issue['priority'] = None
 
         # Target was only tacked on to pass configuration to this function.
-        service_config = conf[issue.pop('target')]
+        service_config = successful_config_map[issue.pop('target')]
 
         try:
             existing_taskwarrior_uuid = find_taskwarrior_uuid(tw, key_list, issue)
@@ -323,18 +329,18 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
             # Drop static fields from the upstream issue.  We don't want to
             # overwrite local changes to fields we declare static.
             for field in itertools.chain(
-                main_config.static_fields, service_config.static_fields
+                conf.main.static_fields, service_config.static_fields
             ):
                 if field in issue:
                     del issue[field]
 
             # Merge annotations & tags from online into our task object
-            if main_config.merge_annotations:
+            if conf.main.merge_annotations:
                 merge_left('annotations', task, issue, hamming=True)
 
-            if main_config.merge_tags:
-                if main_config.replace_tags:
-                    replace_left('tags', task, issue, list(main_config.static_tags))
+            if conf.main.merge_tags:
+                if conf.main.replace_tags:
+                    replace_left('tags', task, issue, list(conf.main.static_tags))
                 else:
                     merge_left('tags', task, issue)
 
@@ -357,7 +363,7 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
         if dry_run:
             continue
         if notify:
-            send_notification(issue, 'Created', conf['notifications'])
+            send_notification(issue, 'Created', conf.notifications)
 
         try:
             new_task = tw.task_add(**issue)
@@ -393,9 +399,9 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
         except TaskwarriorError as e:
             log.exception("Unable to modify task: %s" % e.stderr)
 
-    log.debug(f'Closing tasks for succeeding services: {targets}.')
+    log.debug(f'Closing tasks for succeeding services: {list(successful_config_map)}.')
     succeeded_service_task_uuids = get_managed_task_uuids(
-        tw, build_key_list(set([conf[target].service for target in targets]))
+        tw, build_key_list(successful_config_map.values())
     )
     issue_updates['closed'] = succeeded_service_task_uuids - seen_uuids
     log.info("Closing %i tasks", len(issue_updates['closed']))
@@ -411,7 +417,7 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
             continue
 
         if notify:
-            send_notification(task_info, 'Completed', conf['notifications'])
+            send_notification(task_info, 'Completed', conf.notifications)
 
         try:
             tw.task_done(uuid=issue)
@@ -425,7 +431,7 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
             + len(issue_updates['changed'])
             + len(issue_updates['closed'])
         )
-        if not conf['notifications'].only_on_new_tasks or updates > 0:
+        if not conf.notifications.only_on_new_tasks or updates > 0:
             send_notification(
                 dict(
                     description="New: %d, Changed: %d, Completed: %d"
@@ -436,26 +442,25 @@ def synchronize(issue_generator, conf, main_section, dry_run=False):
                     )
                 ),
                 'bw_finished',
-                conf['notifications'],
+                conf.notifications,
             )
 
 
-def build_key_list(targets):
-    keys = {}
-    for target in targets:
-        keys[target] = get_service(target).ISSUE_CLASS.UNIQUE_KEY
-    return keys
+def build_key_list(service_configs: "Iterable[ServiceConfig]"):
+    return {
+        service_config.service: get_service(
+            service_config.service
+        ).ISSUE_CLASS.UNIQUE_KEY
+        for service_config in service_configs
+    }
 
 
-def get_defined_udas_as_strings(conf, main_section):
-    targets = conf[main_section].targets
-    services = set([conf[target].service for target in targets])
-    uda_list = build_uda_config_overrides(services)
-
+def get_defined_udas_as_strings(conf: "Config"):
+    uda_list = build_uda_config_overrides(conf.service_configs)
     yield from convert_override_args_to_taskrc_settings(uda_list)
 
 
-def build_uda_config_overrides(targets):
+def build_uda_config_overrides(service_configs: "Iterable[ServiceConfig]"):
     """Returns a list of UDAs defined by given targets
 
     For all targets in `targets`, build a dictionary of configuration overrides
@@ -486,8 +491,8 @@ def build_uda_config_overrides(targets):
 
     """
     targets_udas = {}
-    for target in targets:
-        targets_udas.update(get_service(target).ISSUE_CLASS.UDAS)
+    for service_config in service_configs:
+        targets_udas.update(get_service(service_config.service).ISSUE_CLASS.UDAS)
     return {'uda': targets_udas}
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,13 +2,53 @@ import abc
 import os.path
 import shutil
 import tempfile
+import typing
 import unittest
 
 import pytest
 import responses
 
-from bugwarrior import config
+from bugwarrior import config, services
 from bugwarrior.config import schema
+
+
+class DumbConfig(config.ServiceConfig):
+    service: typing.Literal["test"] = "test"
+
+    import_labels_as_tags: bool = False
+    label_template: str = "{{label}}"
+
+    @property
+    def service_class(cls) -> type["DumbService"]:
+        return DumbService
+
+
+class DumbIssue(services.Issue):
+    UDAS: dict = {}
+    UNIQUE_KEY: tuple[str, ...] = ("id",)
+    PRIORITY_MAP: dict = {}
+
+    def get_default_description(self):
+        raise NotImplementedError
+
+    def to_taskwarrior(self):
+        raise NotImplementedError
+
+
+class DumbService(services.Service):
+    API_VERSION = 1.0
+    ISSUE_CLASS = DumbIssue
+    CONFIG_SCHEMA = DumbConfig
+
+    @staticmethod
+    def get_keyring_service(_):
+        raise NotImplementedError
+
+    def get_owner(self, _):
+        raise NotImplementedError
+
+    def issues(self):
+        raise NotImplementedError
 
 
 class AbstractServiceTest(abc.ABC):

--- a/tests/base.py
+++ b/tests/base.py
@@ -9,7 +9,8 @@ import pytest
 import responses
 
 from bugwarrior import config, services
-from bugwarrior.config import schema
+from bugwarrior.config import schema, validation
+from bugwarrior.config.load import format_config
 
 
 class DumbConfig(config.ServiceConfig):
@@ -17,10 +18,6 @@ class DumbConfig(config.ServiceConfig):
 
     import_labels_as_tags: bool = False
     label_template: str = "{{label}}"
-
-    @property
-    def service_class(cls) -> type["DumbService"]:
-        return DumbService
 
 
 class DumbIssue(services.Issue):
@@ -103,10 +100,12 @@ class ConfigTest(unittest.TestCase):
     def inject_fixtures(self, caplog):
         self.caplog = caplog
 
-    def validate(self):
-        self.config['general'] = self.config.get('general', {})
-        self.config['general']['interactive'] = False
-        return schema.validate_config(self.config, 'general', 'configpath')
+    def validate(self) -> validation.Config:
+        config = self.config.copy()
+        config['general'] = config.get('general', {})
+        config['general']['interactive'] = False
+        formatted_config = format_config(config)
+        return validation.validate_config(formatted_config, 'general', 'configpath')
 
     def assertValidationError(self, expected):
         with self.assertRaises(SystemExit):

--- a/tests/config/example-bugwarrior.toml
+++ b/tests/config/example-bugwarrior.toml
@@ -58,10 +58,11 @@ pre_import = ["/home/someuser/backup.sh", "/home/someuser/sometask.sh"]
 # - applescript        macOS      no external dependencies
 # - gobject            Linux      python gobject must be installed
 # 
-# [notifications]
-# notifications = True
-# backend = gobject
-# only_on_new_tasks = True
+
+[notifications]
+notifications = true
+backend = "gobject"
+only_on_new_tasks = true
 # This is a github example.  It says, "scrape every issue from every repository
 # on http://github.com/ralphbean.  It doesn't matter if ralphbean owns the issue
 # or not."

--- a/tests/config/example-bugwarriorrc
+++ b/tests/config/example-bugwarriorrc
@@ -58,10 +58,10 @@ pre_import = /home/someuser/backup.sh, /home/someuser/sometask.sh
 #  - applescript        macOS      no external dependencies
 #  - gobject            Linux      python gobject must be installed
 #
-#[notifications]
-# notifications = True
-# backend = gobject
-# only_on_new_tasks = True
+[notifications]
+notifications = True
+backend = gobject
+only_on_new_tasks = True
 
 
 # This is a github example.  It says, "scrape every issue from every repository

--- a/tests/config/test_data.py
+++ b/tests/config/test_data.py
@@ -1,7 +1,8 @@
 import json
 import os
 
-from bugwarrior.config import data, schema
+from bugwarrior.config import data, validation
+from bugwarrior.config.load import format_config
 
 from ..base import ConfigTest
 
@@ -49,12 +50,11 @@ class TestGetDataPath(ConfigTest):
                 'username': 'ralphbean',
             },
         }
-        self.config = schema.validate_config(rawconfig, 'general', 'configpath')
+        formatted = format_config(rawconfig)
+        self.config = validation.validate_config(formatted, 'general', 'configpath')
 
     def assertDataPath(self, expected_datapath):
-        self.assertEqual(
-            expected_datapath, data.get_data_path(self.config['general'].taskrc)
-        )
+        self.assertEqual(expected_datapath, data.get_data_path(self.config.main.taskrc))
 
     def test_TASKDATA(self):
         """

--- a/tests/config/test_data.py
+++ b/tests/config/test_data.py
@@ -51,10 +51,14 @@ class TestGetDataPath(ConfigTest):
             },
         }
         formatted = format_config(rawconfig)
-        self.config = validation.validate_config(formatted, 'general', 'configpath')
+        self.validated_config = validation.validate_config(
+            formatted, 'general', 'configpath'
+        )
 
     def assertDataPath(self, expected_datapath):
-        self.assertEqual(expected_datapath, data.get_data_path(self.config.main.taskrc))
+        self.assertEqual(
+            expected_datapath, data.get_data_path(self.validated_config.main.taskrc)
+        )
 
     def test_TASKDATA(self):
         """

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -138,7 +138,7 @@ class TestParseFile(LoadTest):
         config = load.parse_file(config_path)
 
         self.assertEqual(
-            config, {'flavors': {'general': {'foo': 'bar'}}, 'services': {}}
+            config, {'flavor': {'general': {'foo': 'bar'}}, 'services': []}
         )
 
     def test_toml_invalid(self):
@@ -175,8 +175,7 @@ class TestParseFile(LoadTest):
             fout.write(f'{section}\ntargets = ["my_gitlab"]')
         config = load.parse_file(config_path)
         self.assertEqual(
-            config,
-            {'flavors': {'myflavor': {'targets': ['my_gitlab']}}, 'services': {}},
+            config, {'flavor': {'myflavor': {'targets': ['my_gitlab']}}, 'services': []}
         )
 
     def test_ini_flavors(self):
@@ -191,7 +190,7 @@ class TestParseFile(LoadTest):
         config = load.parse_file(config_path)
 
         self.assertEqual(
-            config, {'flavors': {'myflavor': {'targets': 'my_gitlab'}}, 'services': {}}
+            config, {'flavor': {'myflavor': {'targets': 'my_gitlab'}}, 'services': []}
         )
 
     def test_ini_options_renamed(self):
@@ -213,11 +212,12 @@ class TestParseFile(LoadTest):
             )
         config = load.parse_file(config_path)
 
-        self.assertIn('optionname', config['services']['baz'])
-        self.assertNotIn('prefix.optionname', config['services']['baz'])
+        baz_service = next(svc for svc in config['services'] if svc['target'] == 'baz')
+        self.assertIn('optionname', baz_service)
+        self.assertNotIn('prefix.optionname', baz_service)
 
-        self.assertIn('log_level', config['flavors']['general'])
-        self.assertNotIn('log.level', config['flavors']['general'])
+        self.assertIn('log_level', config['flavor']['general'])
+        self.assertNotIn('log.level', config['flavor']['general'])
 
     def test_ini_missing_prefix(self):
         config_path = self.create('.bugwarriorrc')

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -1,6 +1,7 @@
 import configparser
 import itertools
 import os
+from pathlib import Path
 import textwrap
 from unittest import TestCase
 
@@ -24,6 +25,18 @@ class LoadTest(ConfigTest):
             os.makedirs(os.path.dirname(fpath))
         open(fpath, 'a').close()
         return fpath
+
+
+class ExampleTest(ConfigTest):
+    def setUp(self):
+        self.basedir = Path(__file__).parent
+        super().setUp()
+
+    def test_example(self):
+        for rcfile in ('example-bugwarriorrc', 'example-bugwarrior.toml'):
+            with self.subTest(rcfile=rcfile):
+                os.environ['BUGWARRIORRC'] = str(self.basedir / rcfile)
+                load.load_config('general', False, False)
 
 
 class TestGetConfigPath(LoadTest):

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -170,9 +170,8 @@ class TestParseFile(LoadTest):
     def test_toml_flavors(self):
         config_path = self.create('.bugwarrior.toml')
 
-        section = '[flavor.myflavor]'
         with open(config_path, 'w') as fout:
-            fout.write(f'{section}\ntargets = ["my_gitlab"]')
+            fout.write('[flavor.myflavor]\ntargets = ["my_gitlab"]')
         config = load.parse_file(config_path)
         self.assertEqual(
             config, {'flavor': {'myflavor': {'targets': ['my_gitlab']}}, 'services': []}

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -1,7 +1,6 @@
 import configparser
 import itertools
 import os
-import pathlib
 import textwrap
 from unittest import TestCase
 
@@ -13,23 +12,6 @@ except ImportError:
 from bugwarrior.config import load
 
 from ..base import ConfigTest
-
-
-class ExampleTest(ConfigTest):
-    def setUp(self):
-        self.basedir = pathlib.Path(__file__).parent
-        super().setUp()
-
-    def test_example(self):
-        for rcfile in ('example-bugwarriorrc', 'example-bugwarrior.toml'):
-            with self.subTest(rcfile=rcfile):
-                os.environ['BUGWARRIORRC'] = str(self.basedir / rcfile)
-                config = load.load_config('general', False, False)
-
-                self.assertEqual(
-                    config['flavor.myflavor'].targets,
-                    ["gitlab_config", "jira_project", "my_github"],
-                )
 
 
 class LoadTest(ConfigTest):
@@ -155,7 +137,9 @@ class TestParseFile(LoadTest):
             )
         config = load.parse_file(config_path)
 
-        self.assertEqual(config, {'general': {'foo': 'bar'}})
+        self.assertEqual(
+            config, {'flavors': {'general': {'foo': 'bar'}}, 'services': {}}
+        )
 
     def test_toml_invalid(self):
         config_path = self.create('.bugwarrior.toml')
@@ -185,14 +169,15 @@ class TestParseFile(LoadTest):
 
     def test_toml_flavors(self):
         config_path = self.create('.bugwarrior.toml')
-        for section in ('["flavor.myflavor"]', '[flavor.myflavor]'):
-            with self.subTest(section=section):
-                with open(config_path, 'w') as fout:
-                    fout.write(f'{section}\ntargets = ["my_gitlab"]')
-                config = load.parse_file(config_path)
-                self.assertEqual(
-                    config, {'flavor.myflavor': {'targets': ['my_gitlab']}}
-                )
+
+        section = '[flavor.myflavor]'
+        with open(config_path, 'w') as fout:
+            fout.write(f'{section}\ntargets = ["my_gitlab"]')
+        config = load.parse_file(config_path)
+        self.assertEqual(
+            config,
+            {'flavors': {'myflavor': {'targets': ['my_gitlab']}}, 'services': {}},
+        )
 
     def test_ini_flavors(self):
         config_path = self.create('.bugwarriorrc')
@@ -205,7 +190,9 @@ class TestParseFile(LoadTest):
             )
         config = load.parse_file(config_path)
 
-        self.assertEqual(config, {'flavor.myflavor': {'targets': 'my_gitlab'}})
+        self.assertEqual(
+            config, {'flavors': {'myflavor': {'targets': 'my_gitlab'}}, 'services': {}}
+        )
 
     def test_ini_options_renamed(self):
         """
@@ -226,11 +213,11 @@ class TestParseFile(LoadTest):
             )
         config = load.parse_file(config_path)
 
-        self.assertIn('optionname', config['baz'])
-        self.assertNotIn('prefix.optionname', config['baz'])
+        self.assertIn('optionname', config['services']['baz'])
+        self.assertNotIn('prefix.optionname', config['services']['baz'])
 
-        self.assertIn('log_level', config['general'])
-        self.assertNotIn('log.level', config['general'])
+        self.assertIn('log_level', config['flavors']['general'])
+        self.assertNotIn('log.level', config['flavors']['general'])
 
     def test_ini_missing_prefix(self):
         config_path = self.create('.bugwarriorrc')

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -10,7 +10,7 @@ from pydantic import TypeAdapter
 
 from bugwarrior.config import schema
 
-from ..base import ConfigTest
+from ..base import ConfigTest, DumbConfig
 
 
 class TestExpandedPath(unittest.TestCase):
@@ -249,7 +249,7 @@ class TestValidation(ConfigTest):
 class TestComputeTemplates(unittest.TestCase):
     def test_template(self):
         raw_values = {'templates': {}, 'project_template': 'foo'}
-        computed_values = schema.ServiceConfig().compute_templates(raw_values)
+        computed_values = DumbConfig.compute_templates(raw_values)
         self.assertEqual(computed_values['templates'], {'project': 'foo'})
 
     def test_empty_template(self):
@@ -262,7 +262,7 @@ class TestComputeTemplates(unittest.TestCase):
         https://github.com/ralphbean/bugwarrior/issues/970
         """
         raw_values = {'templates': {}, 'project_template': ''}
-        computed_values = schema.ServiceConfig().compute_templates(raw_values)
+        computed_values = DumbConfig.compute_templates(raw_values)
         self.assertEqual(computed_values['templates'], {'project': ''})
 
 

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -60,9 +60,7 @@ class TestTaskrcPath(ConfigTest):
 
     def test_default_factory_default(self):
         config = self.validate()
-        self.assertEqual(
-            str(config['general'].taskrc), os.path.join(self.tempdir, '.taskrc')
-        )
+        self.assertEqual(str(config.main.taskrc), os.path.join(self.tempdir, '.taskrc'))
 
     def test_default_factory_env_override(self):
         override = os.path.join(self.tempdir, 'override_taskrc')
@@ -71,7 +69,7 @@ class TestTaskrcPath(ConfigTest):
         os.environ['TASKRC'] = override
 
         config = self.validate()
-        self.assertEqual(str(config['general'].taskrc), override)
+        self.assertEqual(str(config.main.taskrc), override)
 
     def test_default_factory_xdg_config_home(self):
         os.remove(self.taskrc)
@@ -83,7 +81,7 @@ class TestTaskrcPath(ConfigTest):
             fout.write('data.location=%s\n' % self.lists_path)
 
         config = self.validate()
-        self.assertEqual(str(config['general'].taskrc), taskrc)
+        self.assertEqual(str(config.main.taskrc), taskrc)
 
     def test_default_factory_dot_config_taskrc(self):
         """Taskrc is still found if XDG_CONFIG_HOME is unset."""
@@ -97,7 +95,7 @@ class TestTaskrcPath(ConfigTest):
         del os.environ['XDG_CONFIG_HOME']
 
         config = self.validate()
-        self.assertEqual(str(config['general'].taskrc), taskrc)
+        self.assertEqual(str(config.main.taskrc), taskrc)
 
     def test_no_taskrc_file_found(self):
         os.remove(self.taskrc)
@@ -116,134 +114,6 @@ class TestUnsupportedOption(unittest.TestCase):
     def test_unsupportedoption_truthy(self):
         with self.assertRaises(pydantic.ValidationError):
             self.adapter.validate_python('foo')
-
-
-class TestValidation(ConfigTest):
-    def setUp(self):
-        super().setUp()
-        self.config = {
-            'general': {'targets': ['my_service', 'my_kan', 'my_gitlab']},
-            'my_service': {
-                'service': 'github',
-                'login': 'ralph',
-                'username': 'ralph',
-                'token': 'abc123',
-            },
-            'my_kan': {
-                'service': 'kanboard',
-                'url': 'https://kanboard.example.org',
-                'username': 'ralph',
-                'password': 'abc123',
-            },
-            'my_gitlab': {
-                'service': 'gitlab',
-                'host': 'my-git.org',
-                'login': 'arbitrary_login',
-                'token': 'arbitrary_token',
-                'owned': 'false',
-            },
-        }
-
-    def test_valid(self):
-        self.validate()
-
-    def test_main_section_required(self):
-        del self.config['general']
-
-        with self.assertRaises(SystemExit):
-            schema.validate_config(self.config, 'general', 'configpath')
-
-        self.assertEqual(len(self.caplog.records), 1)
-        self.assertIn("No section: 'general'", self.caplog.records[0].message)
-
-    def test_main_section_missing_targets_option(self):
-        del self.config['general']['targets']
-
-        self.assertValidationError("No option 'targets' in section: 'general'")
-
-    def test_target_section_missing(self):
-        del self.config['my_service']
-
-        self.assertValidationError("No section: 'my_service'")
-
-    def test_service_missing(self):
-        del self.config['my_service']['service']
-
-        self.assertValidationError("No option 'service' in section: 'my_service'")
-
-    def test_extra_field(self):
-        """Undeclared fields are forbidden."""
-        self.config['my_service']['undeclared_field'] = 'extra'
-
-        self.assertValidationError(
-            '[my_service]\nundeclared_field = extra  <- unrecognized option'
-        )
-
-    def test_root_validator(self):
-        del self.config['my_service']['username']
-
-        self.assertValidationError(
-            '[my_service]  <- Value error, section requires one of:\n    username\n    query'
-        )
-
-    def test_no_scheme_url_validator_default(self):
-        conf = self.validate()
-        self.assertEqual(conf['my_service'].host, 'github.com')
-
-    def test_no_scheme_url_validator_set(self):
-        self.config['my_service']['host'] = 'github.com'
-        conf = self.validate()
-        self.assertEqual(conf['my_service'].host, 'github.com')
-
-    def test_no_scheme_url_validator_scheme(self):
-        self.config['my_service']['host'] = 'https://github.com'
-        self.assertValidationError(
-            "host = https://github.com  <- URL should not include scheme ('https')"
-        )
-
-    def test_stripped_trailing_slash_url(self):
-        self.config['my_kan']['url'] = 'https://kanboard.example.org/'
-        conf = self.validate()
-        self.assertEqual(conf['my_kan'].url, 'https://kanboard.example.org')
-
-    def test_deprecated_filter_merge_requests(self):
-        conf = self.validate()
-        self.assertEqual(conf['my_gitlab'].include_merge_requests, True)
-
-        self.config['my_gitlab']['filter_merge_requests'] = 'true'
-        conf = self.validate()
-        self.assertEqual(conf['my_gitlab'].include_merge_requests, False)
-
-    def test_deprecated_filter_merge_requests_and_include_merge_requests(self):
-        self.config['my_gitlab']['filter_merge_requests'] = 'true'
-        self.config['my_gitlab']['include_merge_requests'] = 'true'
-        self.assertValidationError(
-            'filter_merge_requests and include_merge_requests are incompatible.'
-        )
-
-    def test_deprecated_project_name(self):
-        """We're just testing that deprecation doesn't break validation."""
-        self.config['general']['targets'] = [
-            'my_service',
-            'my_kan',
-            'my_gitlab',
-            'my_redmine',
-        ]
-        self.config['my_redmine'] = {
-            'service': 'redmine',
-            'url': 'https://example.com',
-            'key': 'mykey',
-        }
-        self.validate()
-
-        self.config['my_redmine']['project_name'] = 'myproject'
-        self.validate()
-
-    def test_flavors(self):
-        self.config.setdefault('flavor', {})['myflavor'] = {
-            'targets': ['my_service', 'my_gitlab']
-        }
-        self.validate()
 
 
 class TestComputeTemplates(unittest.TestCase):

--- a/tests/config/test_validation.py
+++ b/tests/config/test_validation.py
@@ -183,3 +183,24 @@ class TestValidation(ConfigTest):
                 'TracConfig',
             },
         )
+
+    def test_hooks_invalid_option(self):
+        self.config['hooks'] = {'invalid_option': 'value'}
+        self.assertValidationError(
+            '[hooks]\ninvalid_option = value  <- unrecognized option'
+        )
+
+    def test_notifications_invalid_backend(self):
+        self.config['notifications'] = {'backend': 'invalid_backend'}
+        self.assertValidationError(
+            "[notifications]\nbackend = invalid_backend  <- Input should be "
+            "'gobject', 'growlnotify' or 'applescript'"
+        )
+
+    def test_service_and_hooks_errors_reported_together(self):
+        del self.config['my_service']['service']
+        self.config['hooks'] = {'invalid_option': 'value'}
+        self.assertValidationError("No option 'service' in section: 'my_service'")
+        self.assertValidationError(
+            '[hooks]\ninvalid_option = value  <- unrecognized option'
+        )

--- a/tests/config/test_validation.py
+++ b/tests/config/test_validation.py
@@ -1,0 +1,185 @@
+from pathlib import Path
+
+from bugwarrior.config import validation
+from bugwarrior.config.load import format_config, parse_file
+
+from ..base import ConfigTest
+
+
+class TestValidation(ConfigTest):
+    def setUp(self):
+        super().setUp()
+        self.config = {
+            'general': {'targets': ['my_service', 'my_kan', 'my_gitlab']},
+            'my_service': {
+                'service': 'github',
+                'login': 'ralph',
+                'username': 'ralph',
+                'token': 'abc123',
+            },
+            'my_kan': {
+                'service': 'kanboard',
+                'url': 'https://kanboard.example.org',
+                'username': 'ralph',
+                'password': 'abc123',
+            },
+            'my_gitlab': {
+                'service': 'gitlab',
+                'host': 'my-git.org',
+                'login': 'arbitrary_login',
+                'token': 'arbitrary_token',
+                'owned': 'false',
+            },
+        }
+
+    def test_valid(self):
+        self.validate()
+
+    def test_main_section_required(self):
+        del self.config['general']
+
+        with self.assertRaises(SystemExit):
+            formatted = format_config(self.config)
+            validation.validate_config(formatted, 'general', 'configpath')
+
+        self.assertEqual(len(self.caplog.records), 1)
+        self.assertIn("No section: 'general'", self.caplog.records[0].message)
+
+    def test_main_section_missing_targets_option(self):
+        del self.config['general']['targets']
+
+        self.assertValidationError("[general]\ntargets  <- Field required")
+
+    def test_target_section_missing(self):
+        del self.config['my_service']
+
+        self.assertValidationError("[general] missing targets: my_service")
+
+    def test_service_missing(self):
+        del self.config['my_service']['service']
+
+        self.assertValidationError("No option 'service' in section: 'my_service'")
+
+    def test_extra_field(self):
+        """Undeclared fields are forbidden."""
+        self.config['my_service']['undeclared_field'] = 'extra'
+
+        self.assertValidationError(
+            '[my_service]\nundeclared_field = extra  <- unrecognized option'
+        )
+
+    def test_root_validator(self):
+        del self.config['my_service']['username']
+
+        self.assertValidationError(
+            '[my_service]  <- Value error, section requires one of:\n    username\n    query'
+        )
+
+    def test_no_scheme_url_validator_default(self):
+        conf = self.validate()
+        service_config = next(
+            service_config
+            for service_config in conf.service_configs
+            if service_config.target == "my_service"
+        )
+        self.assertEqual(service_config.host, 'github.com')
+
+    def test_no_scheme_url_validator_set(self):
+        self.config['my_service']['host'] = 'github.com'
+        conf = self.validate()
+        service_config = next(
+            service_config
+            for service_config in conf.service_configs
+            if service_config.target == "my_service"
+        )
+        self.assertEqual(service_config.host, 'github.com')
+
+    def test_no_scheme_url_validator_scheme(self):
+        self.config['my_service']['host'] = 'https://github.com'
+        self.assertValidationError(
+            "host = https://github.com  <- URL should not include scheme ('https')"
+        )
+
+    def test_stripped_trailing_slash_url(self):
+        self.config['my_kan']['url'] = 'https://kanboard.example.org/'
+        conf = self.validate()
+        service_config = next(
+            service_config
+            for service_config in conf.service_configs
+            if service_config.target == "my_kan"
+        )
+        self.assertEqual(service_config.url, 'https://kanboard.example.org')
+
+    def test_deprecated_filter_merge_requests(self):
+        conf = self.validate()
+        service_config = next(
+            service_config
+            for service_config in conf.service_configs
+            if service_config.target == "my_gitlab"
+        )
+        self.assertEqual(service_config.include_merge_requests, True)
+
+        self.config['my_gitlab']['filter_merge_requests'] = 'true'
+        conf = self.validate()
+        service_config = next(
+            service_config
+            for service_config in conf.service_configs
+            if service_config.target == "my_gitlab"
+        )
+        self.assertEqual(service_config.include_merge_requests, False)
+
+    def test_deprecated_filter_merge_requests_and_include_merge_requests(self):
+        self.config['my_gitlab']['filter_merge_requests'] = 'true'
+        self.config['my_gitlab']['include_merge_requests'] = 'true'
+        self.assertValidationError(
+            'filter_merge_requests and include_merge_requests are incompatible.'
+        )
+
+    def test_deprecated_project_name(self):
+        """We're just testing that deprecation doesn't break validation."""
+        self.config['general']['targets'] = [
+            'my_service',
+            'my_kan',
+            'my_gitlab',
+            'my_redmine',
+        ]
+        self.config['my_redmine'] = {
+            'service': 'redmine',
+            'url': 'https://example.com',
+            'key': 'mykey',
+        }
+        self.validate()
+
+        self.config['my_redmine']['project_name'] = 'myproject'
+        self.validate()
+
+    def test_flavors(self):
+        self.config['flavor'] = {'myflavor': {'targets': ['my_service', 'my_gitlab']}}
+        self.validate()
+
+    def test_quoted_flavor_key_error(self):
+        """Using ["flavor.myflavor"] instead of [flavor.myflavor] raises an error."""
+        self.config['flavor.myflavor'] = {'targets': ['my_service']}
+        self.assertValidationError(
+            '["flavor.myflavor"]  <- Did you mean [flavor.myflavor]?'
+        )
+
+    def test_load_and_validate_example_toml(self):
+        config_path = Path(__file__).parent / 'example-bugwarrior.toml'
+        raw_config = parse_file(str(config_path))
+        config = validation.validate_config(raw_config, 'general', str(config_path))
+
+        self.assertEqual(
+            {conf.__class__.__name__ for conf in config.service_configs},
+            {
+                'GithubConfig',
+                'GitlabConfig',
+                'GmailConfig',
+                'JiraConfig',
+                'KanboardConfig',
+                'PhabricatorConfig',
+                'PivotalTrackerConfig',
+                'RedMineConfig',
+                'TracConfig',
+            },
+        )

--- a/tests/config/test_validation.py
+++ b/tests/config/test_validation.py
@@ -32,6 +32,14 @@ class TestValidation(ConfigTest):
             },
         }
 
+    def validate_and_get_service(self, target):
+        conf = self.validate()
+        return next(
+            service_config
+            for service_config in conf.service_configs
+            if service_config.target == target
+        )
+
     def test_valid(self):
         self.validate()
 
@@ -53,7 +61,11 @@ class TestValidation(ConfigTest):
     def test_target_section_missing(self):
         del self.config['my_service']
 
-        self.assertValidationError("[general] missing targets: my_service")
+        self.assertValidationError(
+            "[general]\ntargets = "
+            "['my_service', 'my_kan', 'my_gitlab']"
+            "  <- No [my_service] section found"
+        )
 
     def test_service_missing(self):
         del self.config['my_service']['service']
@@ -76,22 +88,12 @@ class TestValidation(ConfigTest):
         )
 
     def test_no_scheme_url_validator_default(self):
-        conf = self.validate()
-        service_config = next(
-            service_config
-            for service_config in conf.service_configs
-            if service_config.target == "my_service"
-        )
+        service_config = self.validate_and_get_service("my_service")
         self.assertEqual(service_config.host, 'github.com')
 
     def test_no_scheme_url_validator_set(self):
         self.config['my_service']['host'] = 'github.com'
-        conf = self.validate()
-        service_config = next(
-            service_config
-            for service_config in conf.service_configs
-            if service_config.target == "my_service"
-        )
+        service_config = self.validate_and_get_service("my_service")
         self.assertEqual(service_config.host, 'github.com')
 
     def test_no_scheme_url_validator_scheme(self):
@@ -102,30 +104,15 @@ class TestValidation(ConfigTest):
 
     def test_stripped_trailing_slash_url(self):
         self.config['my_kan']['url'] = 'https://kanboard.example.org/'
-        conf = self.validate()
-        service_config = next(
-            service_config
-            for service_config in conf.service_configs
-            if service_config.target == "my_kan"
-        )
+        service_config = self.validate_and_get_service("my_kan")
         self.assertEqual(service_config.url, 'https://kanboard.example.org')
 
     def test_deprecated_filter_merge_requests(self):
-        conf = self.validate()
-        service_config = next(
-            service_config
-            for service_config in conf.service_configs
-            if service_config.target == "my_gitlab"
-        )
+        service_config = self.validate_and_get_service("my_gitlab")
         self.assertEqual(service_config.include_merge_requests, True)
 
         self.config['my_gitlab']['filter_merge_requests'] = 'true'
-        conf = self.validate()
-        service_config = next(
-            service_config
-            for service_config in conf.service_configs
-            if service_config.target == "my_gitlab"
-        )
+        service_config = self.validate_and_get_service("my_gitlab")
         self.assertEqual(service_config.include_merge_requests, False)
 
     def test_deprecated_filter_merge_requests_and_include_merge_requests(self):
@@ -164,14 +151,14 @@ class TestValidation(ConfigTest):
             '["flavor.myflavor"]  <- Did you mean [flavor.myflavor]?'
         )
 
-    def test_load_and_validate_example_toml(self):
-        config_path = Path(__file__).parent / 'example-bugwarrior.toml'
-        raw_config = parse_file(str(config_path))
-        config = validation.validate_config(raw_config, 'general', str(config_path))
-
-        self.assertEqual(
-            {conf.__class__.__name__ for conf in config.service_configs},
-            {
+    def test_load_and_validate_example_files(self):
+        example_dir = Path(__file__).parent
+        config_files = [
+            example_dir / 'example-bugwarrior.toml',
+            example_dir / 'example-bugwarriorrc',
+        ]
+        expected_by_flavor = {
+            'general': {
                 'GithubConfig',
                 'GitlabConfig',
                 'GmailConfig',
@@ -182,7 +169,19 @@ class TestValidation(ConfigTest):
                 'RedMineConfig',
                 'TracConfig',
             },
-        )
+            'myflavor': {'GitlabConfig', 'JiraConfig', 'GithubConfig'},
+        }
+        for config_path in config_files:
+            for main_section, expected_configs in expected_by_flavor.items():
+                with self.subTest(config=config_path.name, main_section=main_section):
+                    formatted_config = parse_file(str(config_path))
+                    config = validation.validate_config(
+                        formatted_config, main_section, str(config_path)
+                    )
+                    self.assertEqual(
+                        {conf.__class__.__name__ for conf in config.service_configs},
+                        expected_configs,
+                    )
 
     def test_hooks_invalid_option(self):
         self.config['hooks'] = {'invalid_option': 'value'}

--- a/tests/test_clickup.py
+++ b/tests/test_clickup.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 
 import responses
 
-from bugwarrior.collect import TaskConstructor
+from bugwarrior.collect import TaskConstructor, get_service_instances
 from bugwarrior.services.clickup import ClickupClient, ClickupService
 
 from .base import AbstractServiceTest, ConfigTest, ServiceTest
@@ -166,11 +166,11 @@ class TestClickupService(ConfigTest):
     @property
     def service(self):
         conf = self.validate()
-        service = ClickupService(conf['myservice'], conf['general'])
+        service = get_service_instances(conf)[0]
         return service
 
     def test_get_keyring_service(self):
-        conf = self.validate()['myservice']
+        conf = self.validate().service_configs[0]
         self.assertEqual(ClickupService.get_keyring_service(conf), 'clickup://')
 
     def test_is_assigned(self):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -121,7 +121,7 @@ class TestSynchronize(ConfigTest):
             # writing out to taskwarrior.
             # https://github.com/ralphbean/bugwarrior/issues/601
             issue_generator = iter((copy.deepcopy(issue), duplicate_issue))
-            db.synchronize(issue_generator, bwconfig, 'general')
+            db.synchronize(issue_generator, bwconfig)
 
             self.assertEqual(
                 get_tasks(tw),
@@ -149,7 +149,7 @@ class TestSynchronize(ConfigTest):
         # Change static field
         issue['project'] = 'other_project'
 
-        db.synchronize(iter((copy.deepcopy(issue),)), bwconfig, 'general')
+        db.synchronize(iter((copy.deepcopy(issue),)), bwconfig)
 
         self.assertEqual(
             get_tasks(tw),
@@ -172,7 +172,7 @@ class TestSynchronize(ConfigTest):
         )
 
         # TEST CLOSED ISSUE.
-        db.synchronize(iter(()), bwconfig, 'general')
+        db.synchronize(iter(()), bwconfig)
 
         completed_tasks = tw.load_tasks()
 
@@ -199,7 +199,7 @@ class TestSynchronize(ConfigTest):
         )
 
         # TEST REOPENED ISSUE
-        db.synchronize(iter((copy.deepcopy(issue),)), bwconfig, 'general')
+        db.synchronize(iter((copy.deepcopy(issue),)), bwconfig)
 
         tasks = tw.load_tasks()
         self.assertEqual(
@@ -241,7 +241,7 @@ class TestUDAs(ConfigTest):
         }
 
         conf = self.validate()
-        udas = sorted(list(db.get_defined_udas_as_strings(conf, 'general')))
+        udas = sorted(list(db.get_defined_udas_as_strings(conf)))
         self.assertEqual(
             udas,
             [

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -2,8 +2,8 @@ import dataclasses
 from datetime import datetime, timezone
 from unittest import mock
 
-from bugwarrior.collect import TaskConstructor
-from bugwarrior.services.deck import NextcloudDeckClient, NextcloudDeckService
+from bugwarrior.collect import TaskConstructor, get_service_instances
+from bugwarrior.services.deck import NextcloudDeckClient
 
 from .base import AbstractServiceTest, ServiceTest
 
@@ -93,7 +93,7 @@ class TestNextcloudDeckIssue(AbstractServiceTest, ServiceTest):
     @property
     def service(self):
         conf = self.validate()
-        service = NextcloudDeckService(conf['deck'], conf['general'])
+        service = get_service_instances(conf)[0]
         service.client = mock.MagicMock(spec=NextcloudDeckClient)
         service.client.get_boards = mock.MagicMock(
             return_value=[{'id': 5, 'title': 'testboard'}]

--- a/tests/test_gitbug.py
+++ b/tests/test_gitbug.py
@@ -86,7 +86,9 @@ class TestGitBugIssue(AbstractServiceTest, ServiceTest):
 class TestGitBugConfig(ConfigTest):
     def setUp(self):
         super().setUp()
-        self.config = GitBugConfig(service="gitbug", path="~/custom-gitbug-repo")
+        self.config = GitBugConfig(
+            service="gitbug", path="~/custom-gitbug-repo", target="mygitbug"
+        )
 
     def test_home_path_expansion(self):
         expected = self.tempdir + "/custom-gitbug-repo"

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -268,14 +268,14 @@ class TestGithubService(ServiceTest):
 
     def test_keyring_service(self):
         """Checks that the keyring service name"""
-        service_config = GithubConfig(**self.SERVICE_CONFIG)
+        service_config = GithubConfig(**self.SERVICE_CONFIG, target="myservice")
         keyring_service = GithubService.get_keyring_service(service_config)
         self.assertEqual("github://tintin@github.com/milou", keyring_service)
 
     def test_keyring_service_host(self):
         """Checks that the keyring key depends on the github host."""
         service_config = GithubConfig(
-            **{'host': 'github.example.com'}, **self.SERVICE_CONFIG
+            **{'host': 'github.example.com'}, **self.SERVICE_CONFIG, target="myservice"
         )
         keyring_service = GithubService.get_keyring_service(service_config)
         self.assertEqual("github://tintin@github.example.com/milou", keyring_service)

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -2,7 +2,7 @@ from datetime import date, datetime, timedelta, timezone
 
 import responses
 
-from bugwarrior.collect import TaskConstructor
+from bugwarrior.collect import TaskConstructor, get_service_instances
 from bugwarrior.services.gitlab import GitlabClient, GitlabService
 
 from .base import AbstractServiceTest, ConfigTest, ServiceTest
@@ -523,23 +523,26 @@ class TestGitlabService(ConfigTest):
         }
 
     @property
+    def conf(self):
+        return self.validate()
+
+    @property
     def service(self):
-        conf = self.validate()
-        service = GitlabService(conf['myservice'], conf['general'])
+        service = get_service_instances(self.conf)[0]
         service.gitlab_client.repo_cache = {
             1: {'id': 1, 'path_with_namespace': 'arbitrary_namespace/arbitrary_project'}
         }
         return service
 
     def test_get_keyring_service_default_host(self):
-        conf = self.validate()['myservice']
+        conf = self.conf.service_configs[0]
         self.assertEqual(
             GitlabService.get_keyring_service(conf), 'gitlab://foobar@gitlab.com'
         )
 
     def test_get_keyring_service_custom_host(self):
         self.config['myservice']['host'] = 'my-git.org'
-        conf = self.validate()['myservice']
+        conf = self.conf.service_configs[0]
         self.assertEqual(
             GitlabService.get_keyring_service(conf), 'gitlab://foobar@my-git.org'
         )

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -523,26 +523,25 @@ class TestGitlabService(ConfigTest):
         }
 
     @property
-    def conf(self):
-        return self.validate()
-
-    @property
     def service(self):
-        service = get_service_instances(self.conf)[0]
+        conf = self.validate()
+        service = get_service_instances(conf)[0]
         service.gitlab_client.repo_cache = {
             1: {'id': 1, 'path_with_namespace': 'arbitrary_namespace/arbitrary_project'}
         }
         return service
 
     def test_get_keyring_service_default_host(self):
-        conf = self.conf.service_configs[0]
+        conf = self.validate()
+        conf = conf.service_configs[0]
         self.assertEqual(
             GitlabService.get_keyring_service(conf), 'gitlab://foobar@gitlab.com'
         )
 
     def test_get_keyring_service_custom_host(self):
         self.config['myservice']['host'] = 'my-git.org'
-        conf = self.conf.service_configs[0]
+        conf = self.validate()
+        conf = conf.service_configs[0]
         self.assertEqual(
             GitlabService.get_keyring_service(conf), 'gitlab://foobar@my-git.org'
         )

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from google.oauth2.credentials import Credentials
 
-from bugwarrior.collect import TaskConstructor
+from bugwarrior.collect import TaskConstructor, get_service_instances
 from bugwarrior.services import gmail
 
 from .base import AbstractServiceTest, ConfigTest, ServiceTest
@@ -37,7 +37,7 @@ class TestGmailService(ConfigTest):
         gmail.GmailService.build_api = mock_api
 
         conf = self.validate()
-        self.service = gmail.GmailService(conf['myservice'], conf['general'])
+        self.service = get_service_instances(conf)[0]
 
     def test_get_credentials_exists_and_valid(self):
         expected = Credentials(**copy(TEST_CREDENTIAL))

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -3,7 +3,8 @@ from datetime import datetime, timezone
 from unittest import mock
 
 from bugwarrior.collect import TaskConstructor
-from bugwarrior.config import schema
+from bugwarrior.config import validation
+from bugwarrior.config.load import format_config
 from bugwarrior.services.jira import JiraExtraFields, JiraService
 
 from .base import AbstractServiceTest, ConfigTest, ServiceTest
@@ -41,16 +42,18 @@ class testJiraService(ConfigTest):
     def test_body_length_no_limit(self):
         description = "A very short issue body.  Fixes #828."
         self.config['myjira']['body_length'] = '5'
-        conf = schema.validate_config(self.config, 'general', 'configpath')
-        service = JiraService(conf['myjira'], conf['general'], _skip_server=True)
+        formatted = format_config(self.config)
+        conf = validation.validate_config(formatted, 'general', 'configpath')
+        service = JiraService(conf.service_configs[0], conf.main, _skip_server=True)
         issue = mock.Mock()
         issue.record = dict(fields=dict(description=description))
         self.assertEqual(description[:5], service.body(issue))
 
     def test_body_length_limit(self):
         description = "A very short issue body.  Fixes #828."
-        conf = schema.validate_config(self.config, 'general', 'configpath')
-        service = JiraService(conf['myjira'], conf['general'], _skip_server=True)
+        formatted = format_config(self.config)
+        conf = validation.validate_config(formatted, 'general', 'configpath')
+        service = JiraService(conf.service_configs[0], conf.main, _skip_server=True)
         issue = mock.Mock()
         issue.record = dict(fields=dict(description=description))
         self.assertEqual(description, service.body(issue))

--- a/tests/test_kanboard.py
+++ b/tests/test_kanboard.py
@@ -38,7 +38,7 @@ class TestKanboardServiceConfig(ConfigTest):
         self.config["kb"].update(
             {"url": "http://example.com/", "username": "myuser", "password": "mypass"}
         )
-        service_config = self.validate()['kb']
+        service_config = self.validate().service_configs[0]
         self.assertEqual(
             KanboardService.get_keyring_service(service_config),
             "kanboard://myuser@example.com",

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -106,20 +106,20 @@ class TestLinearServiceConfig(ConfigTest):
         self.config["linear"].update({"api_token": "abc123"})
         conf = self.validate()
         self.assertEqual(
-            conf["linear"].status_types, ["backlog", "unstarted", "started"]
+            conf.service_configs[0].status_types, ["backlog", "unstarted", "started"]
         )
 
     def test_statuses_only(self):
         self.config["linear"].update({"api_token": "abc123", "statuses": "Done, Todo"})
         conf = self.validate()
-        self.assertEqual(conf["linear"].statuses, ["Done", "Todo"])
-        self.assertIsNone(conf["linear"].status_types)
+        self.assertEqual(conf.service_configs[0].statuses, ["Done", "Todo"])
+        self.assertIsNone(conf.service_configs[0].status_types)
 
     def test_status_types_only(self):
         self.config["linear"].update({"api_token": "abc123", "status_types": "started"})
         conf = self.validate()
-        self.assertEqual(conf["linear"].status_types, ["started"])
-        self.assertEqual(conf["linear"].statuses, [])
+        self.assertEqual(conf.service_configs[0].status_types, ["started"])
+        self.assertEqual(conf.service_configs[0].statuses, [])
 
 
 class TestLinearIssue(AbstractServiceTest, ServiceTest):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3,7 +3,8 @@ import re
 import unittest.mock
 
 from bugwarrior import services
-from bugwarrior.config import schema
+from bugwarrior.config import validation
+from bugwarrior.config.load import format_config
 
 from .base import ConfigTest, DumbService
 
@@ -23,10 +24,11 @@ class ServiceBase(ConfigTest):
 
     def makeService(self):
         with unittest.mock.patch(
-            'bugwarrior.config.schema.get_service', lambda x: DumbService
+            'bugwarrior.config.validation.get_service', lambda x: DumbService
         ):
-            conf = schema.validate_config(self.config, 'general', 'configpath')
-        return DumbService(conf['test'], conf['general'])
+            formatted = format_config(self.config)
+            conf = validation.validate_config(formatted, 'general', 'configpath')
+        return DumbService(conf.service_configs[0], conf.main)
 
     def makeIssue(self):
         service = self.makeService()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,56 +1,16 @@
 import pathlib
 import re
-import typing
 import unittest.mock
 
-from bugwarrior import config, services
+from bugwarrior import services
 from bugwarrior.config import schema
 
-from .base import ConfigTest
+from .base import ConfigTest, DumbService
 
 LONG_MESSAGE = """\
 Some message that is over 100 characters. This message is so long it's
 going to fill up your floppy disk taskwarrior backup. Actually it's not
 that long.""".replace('\n', ' ')
-
-
-class DumbConfig(config.ServiceConfig):
-    service: typing.Literal['test']
-
-    import_labels_as_tags: bool = False
-    label_template: str = '{{label}}'
-
-
-class DumbIssue(services.Issue):
-    """
-    Implement the required methods but they shouldn't be called.
-    """
-
-    def get_default_description(self):
-        raise NotImplementedError
-
-    def to_taskwarrior(self):
-        raise NotImplementedError
-
-
-class DumbService(services.Service):
-    """
-    Implement the required methods but they shouldn't be called.
-    """
-
-    API_VERSION = 1.0
-    ISSUE_CLASS = DumbIssue
-    CONFIG_SCHEMA = DumbConfig
-
-    @staticmethod
-    def get_keyring_service(_):
-        raise NotImplementedError
-
-    def get_owner(self, _):
-        raise NotImplementedError
-
-    def issues(self):
-        raise NotImplementedError
 
 
 class ServiceBase(ConfigTest):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,8 +1,7 @@
 from bugwarrior.collect import TaskConstructor
-from bugwarrior.config.schema import MainSectionConfig, ServiceConfig
+from bugwarrior.config.schema import MainSectionConfig
 
-from .base import ServiceTest
-from .test_service import DumbIssue
+from .base import DumbConfig, DumbIssue, ServiceTest
 
 
 class TestTemplates(ServiceTest):
@@ -14,7 +13,7 @@ class TestTemplates(ServiceTest):
     def get_issue(self, templates=None, issue=None, description=None, add_tags=None):
         templates = {} if templates is None else templates
         template_kwargs = {f'{key}_template': value for key, value in templates.items()}
-        config = ServiceConfig(
+        config = DumbConfig(
             target='dummy', add_tags=add_tags if add_tags else [], **template_kwargs
         )
         main_config = MainSectionConfig(interactive=False, targets=[])

--- a/tests/test_trello.py
+++ b/tests/test_trello.py
@@ -1,7 +1,7 @@
 from dateutil.parser import parse as parse_date
 import responses
 
-from bugwarrior.collect import TaskConstructor
+from bugwarrior.collect import TaskConstructor, get_service_instances
 from bugwarrior.config.schema import MainSectionConfig
 from bugwarrior.services.trello import TrelloConfig, TrelloIssue, TrelloService
 
@@ -30,6 +30,7 @@ class TestTrelloIssue(ServiceTest):
             import_labels_as_tags=True,
             default_priority='M',
             label_template='trello_{{label}}',
+            target="mytrello",
         )
         main_config = MainSectionConfig(
             interactive=False, targets=[], inline_links=True, description_length=31
@@ -122,7 +123,7 @@ class TestTrelloService(ConfigTest):
     def test_get_boards_config(self):
         self.config['mytrello']['include_boards'] = 'F00, B4R'
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'])
+        service = get_service_instances(conf)[0]
         boards = service.get_boards()
         self.assertEqual(
             list(boards),
@@ -132,14 +133,14 @@ class TestTrelloService(ConfigTest):
     @responses.activate
     def test_get_boards_api(self):
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'])
+        service = get_service_instances(conf)[0]
         boards = service.get_boards()
         self.assertEqual(list(boards), [self.BOARD])
 
     @responses.activate
     def test_get_lists(self):
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'])
+        service = get_service_instances(conf)[0]
         lists = service.get_lists('B04RD')
         self.assertEqual(list(lists), [self.LIST1, self.LIST2])
 
@@ -147,7 +148,7 @@ class TestTrelloService(ConfigTest):
     def test_get_lists_include(self):
         self.config['mytrello']['include_lists'] = 'List 1'
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'])
+        service = get_service_instances(conf)[0]
         lists = service.get_lists('B04RD')
         self.assertEqual(list(lists), [self.LIST1])
 
@@ -155,14 +156,14 @@ class TestTrelloService(ConfigTest):
     def test_get_lists_exclude(self):
         self.config['mytrello']['exclude_lists'] = 'List 1'
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'])
+        service = get_service_instances(conf)[0]
         lists = service.get_lists('B04RD')
         self.assertEqual(list(lists), [self.LIST2])
 
     @responses.activate
     def test_get_cards(self):
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'])
+        service = get_service_instances(conf)[0]
         cards = service.get_cards('L15T')
         self.assertEqual(list(cards), [self.CARD1, self.CARD2, self.CARD3])
 
@@ -170,7 +171,7 @@ class TestTrelloService(ConfigTest):
     def test_get_cards_assigned(self):
         self.config['mytrello']['only_if_assigned'] = 'tintin'
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'])
+        service = get_service_instances(conf)[0]
         cards = service.get_cards('L15T')
         self.assertEqual(list(cards), [self.CARD1])
 
@@ -180,21 +181,21 @@ class TestTrelloService(ConfigTest):
             {'only_if_assigned': 'tintin', 'also_unassigned': 'true'}
         )
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'])
+        service = get_service_instances(conf)[0]
         cards = service.get_cards('L15T')
         self.assertEqual(list(cards), [self.CARD1, self.CARD3])
 
     @responses.activate
     def test_get_comments(self):
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'])
+        service = get_service_instances(conf)[0]
         comments = service.get_comments('C4RD')
         self.assertEqual(list(comments), [self.COMMENT1, self.COMMENT2])
 
     @responses.activate
     def test_annotations(self):
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'])
+        service = get_service_instances(conf)[0]
         annotations = service.annotations(self.CARD1)
         self.assertEqual(list(annotations), ["@luidgi - Preums", "@mario - Deuz"])
 
@@ -202,7 +203,7 @@ class TestTrelloService(ConfigTest):
     def test_annotations_with_link(self):
         self.config['general']['annotation_links'] = 'true'
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'])
+        service = get_service_instances(conf)[0]
         annotations = service.annotations(self.CARD1)
         self.assertEqual(
             list(annotations),
@@ -215,7 +216,7 @@ class TestTrelloService(ConfigTest):
             {'include_lists': 'List 1', 'only_if_assigned': 'tintin'}
         )
         conf = self.validate()
-        service = TrelloService(conf['mytrello'], conf['general'])
+        service = get_service_instances(conf)[0]
         issues = service.issues()
         expected = {
             'due': parse_date('2018-12-02T12:59:00.000Z'),
@@ -255,5 +256,5 @@ class TestTrelloService(ConfigTest):
     def test_keyring_service(self):
         """Checks that the keyring service name"""
         conf = self.validate()
-        keyring_service = TrelloService.get_keyring_service(conf['mytrello'])
+        keyring_service = TrelloService.get_keyring_service(conf.service_configs[0])
         self.assertEqual("trello://XXXX@trello.com", keyring_service)

--- a/tests/test_youtrak.py
+++ b/tests/test_youtrak.py
@@ -16,7 +16,7 @@ class TestYoutrackService(ConfigTest):
 
     def test_get_keyring_service(self):
         self.config['myservice']['host'] = 'youtrack.example.com'
-        service_config = self.validate()['myservice']
+        service_config = self.validate().service_configs[0]
         self.assertEqual(
             YoutrackService.get_keyring_service(service_config),
             'youtrack://foobar@youtrack.example.com',


### PR DESCRIPTION
Before changing the actual config validation implementation, I think it's easier to use another `Config` model once everything has been validated, and use this model downstream. 
I plan to change the validate_config implementation once we agree on these changes, and this `Config` model.

What do you think @ryneeverett  ? 

There is a failing test related to flavors in test_load.py, It will be fixed once I modify the validation step