### PR TITLE
Gitlab worker fails because index out of range

### DIFF
--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -150,14 +150,14 @@ class GitlabClient(Client):
             users = self._fetch(f'users?username={only_if_assigned}')
 
             if len(users) != 1:
-                log.warning(
+                log.critical(
                     "Expected exactly one user for '%s', got %d. "
-                    "Assignee filter will be ignored.",
+                    "Is only_if_assigned configured to a valid username?",
                     only_if_assigned,
                     len(users),
                 )
-            else:
-                assignee_id = users[0]["id"]
+                sys.exit(1)
+            assignee_id = users[0]["id"]
 
         self.assignee_query = f'assignee_id={assignee_id}' if assignee_id else ''
 

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -141,13 +141,17 @@ class GitlabClient(Client):
 
         self.repo_cache = {}
 
-        # If we're only fetching assigned issues we can reduce requests by
-        # filtering in the query.
-        assignee_id = (
-            self._fetch(f'users?username={only_if_assigned}')[-1]['id']
-            if only_if_assigned and not also_unassigned
-            else None
-        )
+        assignee_id = None
+        if only_if_assigned and not also_unassigned:
+            users = self._fetch(f'users?username={only_if_assigned}')
+            if not users:
+                log.warning(f"User '{only_if_assigned}' not found on GitLab instance")
+            elif len(users) > 1:
+                log.warning(f"Multiple users found for '{only_if_assigned}', using first match")
+                assignee_id = users[0]['id']
+            else:
+                assignee_id = users[0]['id']
+
         self.assignee_query = f'assignee_id={assignee_id}' if assignee_id else ''
 
     def _base_url(self):

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -142,15 +142,22 @@ class GitlabClient(Client):
         self.repo_cache = {}
 
         assignee_id = None
+
         if only_if_assigned and not also_unassigned:
+            # GitLab API returns:
+            #   - a single-element list if the username exists
+            #   - an empty list if it does not
             users = self._fetch(f'users?username={only_if_assigned}')
-            if not users:
-                log.warning(f"User '{only_if_assigned}' not found on GitLab instance")
-            elif len(users) > 1:
-                log.warning(f"Multiple users found for '{only_if_assigned}', using first match")
-                assignee_id = users[0]['id']
+
+            if len(users) != 1:
+                log.warning(
+                    "Expected exactly one user for '%s', got %d. "
+                    "Assignee filter will be ignored.",
+                    only_if_assigned,
+                    len(users),
+                )
             else:
-                assignee_id = users[0]['id']
+                assignee_id = users[0]["id"]
 
         self.assignee_query = f'assignee_id={assignee_id}' if assignee_id else ''
 

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -1167,16 +1167,3 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
             self.get_mock_service(GitlabService, config_overrides=overrides)
         self.assertEqual(cm.exception.code, 1)
 
-    @responses.activate
-    def test_only_if_assigned_with_also_unassigned(self):
-        """Test that assignee_id is None when also_unassigned is True"""
-        overrides = {'only_if_assigned': 'jack_smith', 'also_unassigned': 'true'}
-
-        # User lookup should NOT be called when also_unassigned is True
-        # So we don't add any mock response
-
-        # Should not raise an error and not call the API
-        service = self.get_mock_service(GitlabService, config_overrides=overrides)
-
-        # Verify service was created successfully
-        self.assertIsNotNone(service)

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -1166,4 +1166,3 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
         with self.assertRaises(SystemExit) as cm:
             self.get_mock_service(GitlabService, config_overrides=overrides)
         self.assertEqual(cm.exception.code, 1)
-

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -1098,3 +1098,107 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
         }
 
         self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+
+    @responses.activate
+    def test_only_if_assigned_user_lookup(self):
+        """Test that only_if_assigned correctly looks up the user and uses first match"""
+        # Mock the user lookup API call - WITH username in query string
+        self.add_response(
+            'https://my-git.org/api/v4/users?username=jack_smith',
+            json=[
+                {
+                    'id': 2,
+                    'username': 'jack_smith',
+                    'name': 'Jack Smith',
+                    'state': 'active'
+                }
+            ],
+        )
+
+        overrides = {
+            'only_if_assigned': 'jack_smith',
+        }
+
+        # Should not raise an error
+        service = self.get_mock_service(GitlabService, config_overrides=overrides)
+
+        # Verify service was created successfully
+        self.assertIsNotNone(service)
+
+    @responses.activate
+    def test_only_if_assigned_user_not_found(self):
+        """Test that empty user list logs warning and continues gracefully"""
+        # Mock empty user lookup response
+        self.add_response(
+            'https://my-git.org/api/v4/users?username=nonexistent_user',
+            json=[],
+        )
+
+        overrides = {
+            'only_if_assigned': 'nonexistent_user',
+        }
+
+        # Should not crash - logs warning and continues with None assignee_id
+        with self.assertLogs('bugwarrior.services.gitlab', level='WARNING') as cm:
+            service = self.get_mock_service(GitlabService, config_overrides=overrides)
+            self.assertIsNotNone(service)
+
+            # Verify warning was logged
+            self.assertTrue(
+                any("not found on GitLab instance" in msg for msg in cm.output),
+                "Expected warning about user not found"
+            )
+
+    @responses.activate
+    def test_only_if_assigned_multiple_users(self):
+        """Test that first user is selected when multiple matches exist"""
+        # Mock multiple users with similar names
+        self.add_response(
+            'https://my-git.org/api/v4/users?username=smith',
+            json=[
+                {
+                    'id': 10,
+                    'username': 'smith',
+                    'name': 'John Smith',
+                    'state': 'active'
+                },
+                {
+                    'id': 20,
+                    'username': 'smithy',
+                    'name': 'Jane Smith',
+                    'state': 'active'
+                }
+            ],
+        )
+
+        overrides = {
+            'only_if_assigned': 'smith',
+        }
+
+        # Should log warning and use first user (id: 10)
+        with self.assertLogs('bugwarrior.services.gitlab', level='WARNING') as cm:
+            service = self.get_mock_service(GitlabService, config_overrides=overrides)
+            self.assertIsNotNone(service)
+
+            # Verify warning about multiple users was logged
+            self.assertTrue(
+                any("Multiple users found" in msg for msg in cm.output),
+                "Expected warning about multiple users"
+            )
+
+    @responses.activate
+    def test_only_if_assigned_with_also_unassigned(self):
+        """Test that assignee_id is None when also_unassigned is True"""
+        overrides = {
+            'only_if_assigned': 'jack_smith',
+            'also_unassigned': 'true',
+        }
+
+        # User lookup should NOT be called when also_unassigned is True
+        # So we don't add any mock response
+
+        # Should not raise an error and not call the API
+        service = self.get_mock_service(GitlabService, config_overrides=overrides)
+
+        # Verify service was created successfully
+        self.assertIsNotNone(service)

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -1110,14 +1110,12 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
                     'id': 2,
                     'username': 'jack_smith',
                     'name': 'Jack Smith',
-                    'state': 'active'
+                    'state': 'active',
                 }
             ],
         )
 
-        overrides = {
-            'only_if_assigned': 'jack_smith',
-        }
+        overrides = {'only_if_assigned': 'jack_smith'}
 
         # Should not raise an error
         service = self.get_mock_service(GitlabService, config_overrides=overrides)
@@ -1127,31 +1125,22 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
 
     @responses.activate
     def test_only_if_assigned_user_not_found(self):
-        """Test that empty user list logs warning and continues gracefully"""
+        """Test that empty user list causes SystemExit"""
         # Mock empty user lookup response
         self.add_response(
-            'https://my-git.org/api/v4/users?username=nonexistent_user',
-            json=[],
+            'https://my-git.org/api/v4/users?username=nonexistent_user', json=[]
         )
 
-        overrides = {
-            'only_if_assigned': 'nonexistent_user',
-        }
+        overrides = {'only_if_assigned': 'nonexistent_user'}
 
-        # Should not crash - logs warning and continues with None assignee_id
-        with self.assertLogs('bugwarrior.services.gitlab', level='WARNING') as cm:
-            service = self.get_mock_service(GitlabService, config_overrides=overrides)
-            self.assertIsNotNone(service)
-
-            # Verify warning was logged
-            self.assertTrue(
-                any("not found on GitLab instance" in msg for msg in cm.output),
-                "Expected warning about user not found"
-            )
+        # Should exit with 1
+        with self.assertRaises(SystemExit) as cm:
+            self.get_mock_service(GitlabService, config_overrides=overrides)
+        self.assertEqual(cm.exception.code, 1)
 
     @responses.activate
     def test_only_if_assigned_multiple_users(self):
-        """Test that first user is selected when multiple matches exist"""
+        """Test that multiple users found causes SystemExit"""
         # Mock multiple users with similar names
         self.add_response(
             'https://my-git.org/api/v4/users?username=smith',
@@ -1160,39 +1149,28 @@ class TestGitlabIssue(AbstractServiceTest, ServiceTest):
                     'id': 10,
                     'username': 'smith',
                     'name': 'John Smith',
-                    'state': 'active'
+                    'state': 'active',
                 },
                 {
                     'id': 20,
                     'username': 'smithy',
                     'name': 'Jane Smith',
-                    'state': 'active'
-                }
+                    'state': 'active',
+                },
             ],
         )
 
-        overrides = {
-            'only_if_assigned': 'smith',
-        }
+        overrides = {'only_if_assigned': 'smith'}
 
-        # Should log warning and use first user (id: 10)
-        with self.assertLogs('bugwarrior.services.gitlab', level='WARNING') as cm:
-            service = self.get_mock_service(GitlabService, config_overrides=overrides)
-            self.assertIsNotNone(service)
-
-            # Verify warning about multiple users was logged
-            self.assertTrue(
-                any("Multiple users found" in msg for msg in cm.output),
-                "Expected warning about multiple users"
-            )
+        # Should exit with 1
+        with self.assertRaises(SystemExit) as cm:
+            self.get_mock_service(GitlabService, config_overrides=overrides)
+        self.assertEqual(cm.exception.code, 1)
 
     @responses.activate
     def test_only_if_assigned_with_also_unassigned(self):
         """Test that assignee_id is None when also_unassigned is True"""
-        overrides = {
-            'only_if_assigned': 'jack_smith',
-            'also_unassigned': 'true',
-        }
+        overrides = {'only_if_assigned': 'jack_smith', 'also_unassigned': 'true'}
 
         # User lookup should NOT be called when also_unassigned is True
         # So we don't add any mock response


### PR DESCRIPTION
In my case I tried to fetch issues which are assigned to my user and I used 

```
[gitlab_instance]
service = gitlab
gitlab.only_if_assigned = USER
gitlab.owned = True
gitlab.login = USER
gitlab.token = TOKEN
gitlab.host = HOST
gitlab.import_labels_as_tags = True
gitlab.label_template = GL {{label}}
gitlab.description_template = Issue {{gitlabnumber}}: {{gitlabtitle}}
```

At the moment there aren't any assigned issues and the response contains an empty list. I added some code and updated the tests the for `only_if_assigned` behavior in GitLab service. They handle some additional edge cases for user lookup, including missing, multiple matches, and `also_unassigned`.

With theses changes I got no error anymore and if I created some issues in the production system, it runs just fine. 

If you have any further questions, feel free to contact me. 

Bests 
Daniel