### PR TITLE
notifications: allow None project. Fix #945

### DIFF
--- a/bugwarrior/notifications.py
+++ b/bugwarrior/notifications.py
@@ -27,7 +27,7 @@ def _get_metadata(issue):
     priority = ''
     metadata = ''
     project = ''
-    if 'project' in issue:
+    if 'project' in issue and issue['project']:
         project = "Project: " + issue['project']
     # if 'due' in issue:
     #     due = "Due: " + datetime.datetime.fromtimestamp(


### PR DESCRIPTION
The project field can be None which causes a TypeError when concatenating with a string. Similarly to with priority, we can simply guard against this possibility.