### PR TITLE
fix: now use proper ty comments

### DIFF
--- a/bugwarrior/config/load.py
+++ b/bugwarrior/config/load.py
@@ -8,7 +8,7 @@ from typing import Any
 if sys.version_info >= (3, 11):
     import tomllib
 else:
-    import tomli as tomllib  # type: ignore[unresolved-import]
+    import tomli as tomllib
 
 from .validation import Config, validate_config
 

--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -180,7 +180,7 @@ class Notifications(BaseConfig):
 
 
 # Dynamically add template fields to model.
-_ServiceConfig = pydantic.create_model(  # type: ignore[no-matching-overload]
+_ServiceConfig = pydantic.create_model(  # type: ignore[ty:no-matching-overload]
     "_ServiceConfig",
     __base__=BaseConfig,
     **{

--- a/bugwarrior/docs/_ext/config.py
+++ b/bugwarrior/docs/_ext/config.py
@@ -11,8 +11,8 @@ class Config(SphinxDirective):
 
     def _make_tab(self, lang: str):
         self.arguments = [lang]
-        tab = TabDirective.run(self)[0]  # type: ignore[arg-type]
-        tab[1][0] = CodeBlock.run(self)[0]  # type: ignore[arg-type]
+        tab = TabDirective.run(self)[0]  # type: ignore[ty:arg-type]
+        tab[1][0] = CodeBlock.run(self)[0]  # type: ignore[ty:arg-type]
         # While line breaks were previously separate elements, they're now
         # within the single CodeBlock element.
         del tab[1][1:]

--- a/bugwarrior/docs/_ext/extras.py
+++ b/bugwarrior/docs/_ext/extras.py
@@ -7,7 +7,7 @@ from sphinx.util.docutils import SphinxDirective
 if sys.version_info >= (3, 11):
     import tomllib
 else:
-    import tomli as tomllib  # type: ignore[unresolved-import]
+    import tomli as tomllib
 
 
 class Extras(SphinxDirective):

--- a/bugwarrior/notifications.py
+++ b/bugwarrior/notifications.py
@@ -68,7 +68,7 @@ def send_notification(issue, op, conf):
             'Deprecation Warning: The growlnotify project is deprecated upstream. We recommend '
             'using the applescript backend instead.'
         )
-        import gntp.notifier  # type: ignore[unresolved-import]  # optional dependency
+        import gntp.notifier  # type: ignore[ty:unresolved-import]  # optional dependency
 
         growl = gntp.notifier.GrowlNotifier(
             applicationName="Bugwarrior",
@@ -113,10 +113,10 @@ def send_notification(issue, op, conf):
     elif notify_backend == 'gobject':
         _cache_logo()
 
-        import gi  # type: ignore[unresolved-import]  # optional dependency
+        import gi  # type: ignore[ty:unresolved-import]  # optional dependency
 
         gi.require_version('Notify', '0.7')
-        from gi.repository import Notify  # type: ignore[unresolved-import]
+        from gi.repository import Notify  # type: ignore[ty:unresolved-import]
 
         Notify.init("bugwarrior")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ max-line-length = 100
 include = ["bugwarrior*"]
 
 [tool.ty.environment]
-python-version = "3.10"
+python-version = "3.13"
 
 [tool.ty.src]
 exclude = ["tests/", "bugwarrior/docs/"]
@@ -129,5 +129,5 @@ test = [
     "responses",
     # ruff and ty are required by tests/test_general.py
     "ruff",
-    "ty>=0.0.23",
+    "ty>=0.0.29",
 ]

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -9,7 +9,7 @@ from unittest import TestCase
 if sys.version_info >= (3, 11):
     import tomllib
 else:
-    import tomli as tomllib  # type: ignore[unresolved-import]
+    import tomli as tomllib
 
 from bugwarrior.config import load
 


### PR DESCRIPTION
`ty` use `ty:` comments, and not `type:` comments, so the ignore comments were not used. That's now fixed.

https://github.com/GothenburgBitFactory/bugwarrior/issues/1194