### PR TITLE
linear: cursor pagination + set entry from createdAt

### DIFF
--- a/bugwarrior/services/linear.py
+++ b/bugwarrior/services/linear.py
@@ -149,8 +149,8 @@ class LinearService(Service, Client):
             )
 
         self.query = """
-            query Issues($filter: IssueFilter!) {
-              issues(filter: $filter) {
+            query Issues($filter: IssueFilter!, $after: String) {
+              issues(filter: $filter, first: 250, after: $after) {
                 nodes {
                   url
                   title
@@ -181,6 +181,10 @@ class LinearService(Service, Client):
                     name
                   }
                 }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
               }
             }
             """
@@ -195,19 +199,35 @@ class LinearService(Service, Client):
 
     def get_issues(self):
         """
-        Make a Linear API request, using the query defined in the constructor.
+        Make Linear API requests, paginating with cursors until exhausted.
+
+        Linear's GraphQL API uses Relay-style cursor pagination on the
+        ``issues`` connection. Without an explicit ``first`` argument, the
+        server returns its default page size (50) and we silently lose any
+        remaining issues. We request the maximum page size (250) and follow
+        ``pageInfo.endCursor`` until ``hasNextPage`` is false.
         """
-        data = {
-            "query": self.query,
-            "variables": {"filter": {"and": self.filter} if self.filter else {}},
-        }
-        response = self.session.post(self.config.host, data=json.dumps(data))
-        res = self.json_response(response)
+        cursor = None
+        filter_arg = {"and": self.filter} if self.filter else {}
+        while True:
+            data = {
+                "query": self.query,
+                "variables": {"filter": filter_arg, "after": cursor},
+            }
+            response = self.session.post(self.config.host, data=json.dumps(data))
+            res = self.json_response(response)
 
-        if "errors" in res:
-            messages = [
-                error.get("message", "Unknown error") for error in res['errors']
-            ]
-            raise ValueError("; ".join(messages))
+            if "errors" in res:
+                messages = [
+                    error.get("message", "Unknown error") for error in res['errors']
+                ]
+                raise ValueError("; ".join(messages))
 
-        return res.get("data", {}).get("issues", {}).get("nodes", [])
+            issues = res.get("data", {}).get("issues", {})
+            for node in issues.get("nodes", []):
+                yield node
+
+            page_info = issues.get("pageInfo", {})
+            if not page_info.get("hasNextPage"):
+                return
+            cursor = page_info.get("endCursor")

--- a/bugwarrior/services/linear.py
+++ b/bugwarrior/services/linear.py
@@ -90,6 +90,7 @@ class LinearIssue(Issue):
                 or None
             ),
             "priority": self.config.default_priority,
+            "entry": created,
             "annotations": get(self.extra, "annotations", []),
             "tags": self.get_tags(),
             self.URL: self.record["url"],

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -214,3 +214,39 @@ class TestLinearIssue(AbstractServiceTest, ServiceTest):
             "tags": [],
         }
         self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+
+    @responses.activate
+    def test_issues_paginates(self):
+        """Drains every page when Linear signals ``hasNextPage``."""
+        # Reset the default mock registered in setUp so we can control page order.
+        responses.reset()
+
+        page_one = {
+            "data": {
+                "issues": {
+                    "nodes": [RESPONSE["data"]["issues"]["nodes"][0]],
+                    "pageInfo": {"hasNextPage": True, "endCursor": "cursor-page-2"},
+                }
+            }
+        }
+        page_two = {
+            "data": {
+                "issues": {
+                    "nodes": [RESPONSE["data"]["issues"]["nodes"][1]],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+        responses.add(responses.POST, "https://api.linear.app/graphql", json=page_one)
+        responses.add(responses.POST, "https://api.linear.app/graphql", json=page_two)
+
+        identifiers = [issue.record["identifier"] for issue in self.service.issues()]
+        self.assertEqual(identifiers, ["DUS-5", "DUS-1"])
+
+        # Two HTTP calls were made, and the second one carried the cursor
+        # returned by the first.
+        self.assertEqual(len(responses.calls), 2)
+        first_body = json.loads(responses.calls[0].request.body)
+        second_body = json.loads(responses.calls[1].request.body)
+        self.assertIsNone(first_body["variables"]["after"])
+        self.assertEqual(second_body["variables"]["after"], "cursor-page-2")

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -144,6 +144,7 @@ class TestLinearIssue(AbstractServiceTest, ServiceTest):
         expected_output = {
             "project": "prj",
             "priority": "M",
+            "entry": created_timestamp,
             "annotations": [],
             "tags": [],
             "linearurl": "https://linear.app/dustins-doings/issue/DUS-5/do-stuff",
@@ -170,6 +171,7 @@ class TestLinearIssue(AbstractServiceTest, ServiceTest):
         expected_output = {
             "project": None,
             "priority": "M",
+            "entry": created_timestamp,
             "annotations": [],
             "tags": ["Improvement", "Feature"],
             "linearurl": "https://linear.app/dustins-doings/issue/DUS-1/bugwarrior",
@@ -198,6 +200,7 @@ class TestLinearIssue(AbstractServiceTest, ServiceTest):
             "annotations": [],
             "description": "(bw)#DUS-5 - DO STUFF .. "
             "https://linear.app/dustins-doings/issue/DUS-5/do-stuff",
+            "entry": created_timestamp,
             "linearassignee": "djmitche@gmail.com",
             "linearclosed": closed_timestamp,
             "linearcreated": created_timestamp,


### PR DESCRIPTION
Two related fixes for the Linear service.

## 1. Pagination

The Linear GraphQL service issues a single query without `first:` or cursor pagination, so Linear's Relay-style `issues` connection returns only its default page size (50 issues) and any remaining matches are silently dropped. Workspaces with more than 50 matching issues miss the overflow on every pull.

The fix requests `first: 250` (Linear's documented maximum) and follows `pageInfo.endCursor` until `hasNextPage` is false. `get_issues` becomes a generator that streams pages, so memory stays flat regardless of total issue count. The `issues()` caller already iterated lazily, so no caller updates are needed.

A new test (`test_issues_paginates`) registers two paginated mock responses and asserts both pages' issues are returned and that the second request carries the cursor returned by the first.

## 2. Set `entry` from Linear `createdAt`

Without this, freshly imported Linear issues have `entry` set to the local pull time, so `entry.age` and the urgency age coefficient see every imported issue as brand-new regardless of its real upstream age. Mirrors the pattern already used by several other services.

The existing `test_to_taskwarrior` and `test_issues` dict-equality assertions are updated to expect the new key.