### PR TITLE
Fix parent item title retrieval in Azure DevOps service

### DIFF
--- a/bugwarrior/services/azuredevops.py
+++ b/bugwarrior/services/azuredevops.py
@@ -97,7 +97,7 @@ class AzureDevopsClient(Client):
 
         if parent_id:
             parent_item = self.get_work_item(parent_id)
-            return parent_item["fields"]["System.Title"]
+            return parent_item.get("fields", {}).get("System.Title", None)
         else:
             return None
 

--- a/bugwarrior/services/azuredevops.py
+++ b/bugwarrior/services/azuredevops.py
@@ -93,11 +93,11 @@ class AzureDevopsClient(Client):
         return resp.json().get("comments", None)
 
     def get_parent_name(self, workitem: dict[str, Any]) -> str | None:
-        parent_id = workitem.get("fields", {}).get("System.Parent", None)
+        parent_id = workitem.get("fields", {}).get("System.Parent")
 
         if parent_id:
             parent_item = self.get_work_item(parent_id)
-            return parent_item.get("fields", {}).get("System.Title", None)
+            return parent_item.get("fields", {}).get("System.Title")
         else:
             return None
 


### PR DESCRIPTION
I was facing this issue recently:

```
INFO:bugwarrior.db:Service-defined UDAs exist: you can optionally use the `bugwarrior-uda` command to export a list of UDAs you can add to your taskrc file.
INFO:bugwarrior.collect:Starting to aggregate remote issues.
INFO:bugwarrior.collect:Spawning 5 workers.
Worker for [ado_issues] failed: 'fields'
Traceback (most recent call last):
  File "~/.local/share/uv/tools/bugwarrior/lib/python3.12/site-packages/bugwarrior/collect.py", line 47, in _aggregate_issues
    for issue in service.issues():
                 ^^^^^^^^^^^^^^^^
  File "~/.local/share/uv/tools/bugwarrior/lib/python3.12/site-packages/bugwarrior/services/azuredevops.py", line 245, in issues
    parent_title = self.client.get_parent_name(issue)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.local/share/uv/tools/bugwarrior/lib/python3.12/site-packages/bugwarrior/services/azuredevops.py", line 97, in get_parent_name
    return parent_item["fields"]["System.Title"]
           ~~~~~~~~~~~^^^^^^^^^^
KeyError: 'fields'
ERROR:bugwarrior.collect:Aborted [ado_issues] due to critical error.
Worker for [ado_issues_other] failed: 'fields'
Traceback (most recent call last):
  File "~/.local/share/uv/tools/bugwarrior/lib/python3.12/site-packages/bugwarrior/collect.py", line 47, in _aggregate_issues
    for issue in service.issues():
                 ^^^^^^^^^^^^^^^^
  File "~/.local/share/uv/tools/bugwarrior/lib/python3.12/site-packages/bugwarrior/services/azuredevops.py", line 245, in issues
    parent_title = self.client.get_parent_name(issue)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.local/share/uv/tools/bugwarrior/lib/python3.12/site-packages/bugwarrior/services/azuredevops.py", line 97, in get_parent_name
    return parent_item["fields"]["System.Title"]
           ~~~~~~~~~~~^^^^^^^^^^
KeyError: 'fields'
ERROR:bugwarrior.collect:Aborted [ado_issues_other] due to critical error.
INFO:bugwarrior.collect:Done aggregating remote issues.
INFO:bugwarrior.db:Adding 0 tasks
INFO:bugwarrior.db:Updating 0 tasks
INFO:bugwarrior.db:Closing 0 tasks
```

The reason is, that I have a assigned work item in Azure DevOps, which an assigned parent, but I do not have access to this parent.

This fix will fallback to `None`, if it can not read the parent title.
