### PR TITLE
Remove interactive flag

### DIFF
--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 from typing import TYPE_CHECKING, Any
+import warnings
 
 import click
 from lockfile import LockTimeout
@@ -110,8 +111,6 @@ def pull(
     Relies on configuration file.
     """
     if interactive:
-        import warnings
-
         warnings.warn(
             "The --interactive flag is deprecated and has no effect. "
             "Interactive mode is now detected automatically via sys.stdin.isatty().",

--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -29,11 +29,9 @@ def _get_section_name(flavor: str | None) -> str:
     return 'general'
 
 
-def _try_load_config(
-    main_section: str, interactive: bool = False, quiet: bool = False
-) -> "Config":
+def _try_load_config(main_section: str, quiet: bool = False) -> "Config":
     try:
-        return load_config(main_section, interactive, quiet)
+        return load_config(main_section, quiet)
     except OSError:
         # Our standard logging configuration depends on the bugwarrior
         # configuration file which just failed to load.
@@ -94,7 +92,11 @@ def cli() -> None:
 @cli.command()
 @click.option('--dry-run', is_flag=True)
 @click.option('--flavor', default=None, help='The flavor to use')
-@click.option('--interactive', is_flag=True)
+@click.option(
+    '--interactive',
+    is_flag=True,
+    help='Deprecated. Interactive mode is now detected automatically via isatty().',
+)
 @click.option(
     '--debug', is_flag=True, help='Do not use multiprocessing (which breaks pdb).'
 )
@@ -107,10 +109,19 @@ def pull(
 
     Relies on configuration file.
     """
+    if interactive:
+        import warnings
+
+        warnings.warn(
+            "The --interactive flag is deprecated and has no effect. "
+            "Interactive mode is now detected automatically via sys.stdin.isatty().",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     try:
         main_section = _get_section_name(flavor)
-        config = _try_load_config(main_section, interactive, quiet)
+        config = _try_load_config(main_section, quiet)
 
         lockfile_path = os.path.join(config.main.data.path, 'bugwarrior.lockfile')
         lockfile = PIDLockFile(lockfile_path)

--- a/bugwarrior/config/load.py
+++ b/bugwarrior/config/load.py
@@ -117,11 +117,9 @@ def parse_file(configpath: str) -> dict[str, Any]:
     return format_config(config)
 
 
-def load_config(main_section: str, interactive: bool, quiet: bool) -> Config:
+def load_config(main_section: str, quiet: bool) -> Config:
     configpath = get_config_path()
     rawconfig = parse_file(configpath)
-    for flavor in rawconfig['flavor'].values():
-        flavor['interactive'] = interactive
     config = validate_config(rawconfig, main_section, configpath)
     configure_logging(
         config.main.log_file, 'WARNING' if quiet else config.main.log_level

--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -138,10 +138,6 @@ class MainSectionConfig(BaseConfig):
     # required
     targets: ConfigList
 
-    # added during configuration loading
-    #: Interactive status.
-    interactive: bool
-
     @computed_field
     @property
     def data(self) -> BugwarriorData:

--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -138,6 +138,9 @@ class MainSectionConfig(BaseConfig):
     # required
     targets: ConfigList
 
+    #: *DEPRECATED*
+    interactive: bool = True
+
     @computed_field
     @property
     def data(self) -> BugwarriorData:

--- a/bugwarrior/config/secrets.py
+++ b/bugwarrior/config/secrets.py
@@ -18,6 +18,19 @@ def get_keyring() -> ModuleType:
     return keyring
 
 
+def _ask_password(service: str) -> str:
+    import getpass
+
+    if not sys.stdin.isatty():
+        log.error(
+            f"Unable to retrieve password for service {service}. "
+            "Not running in an interactive terminal; cannot prompt for password."
+        )
+        sys.exit(1)
+
+    return getpass.getpass(f"{service} password: ")
+
+
 def get_service_password(service: str, username: str, oracle: str | None = None) -> str:
     """
     Retrieve the sensitive password for a service by:
@@ -31,46 +44,46 @@ def get_service_password(service: str, username: str, oracle: str | None = None)
     which requires that the user provides a password (interactive mode).
     Interactive mode is detected automatically via sys.stdin.isatty().
 
-    :param service:     Service name, may be key into secure store (as string).
-    :param username:    Username for the service (as string).
-    :param oracle:      Hint which password oracle strategy to use.
-    :return: Retrieved password (as string)
-
     .. seealso::
         https://bitbucket.org/kang/python-keyring-lib
     """
-    import getpass
 
-    interactive = sys.stdin.isatty()
-    password = None
-    if not oracle or oracle == "@oracle:use_keyring":
-        keyring = get_keyring()
-        password = keyring.get_password(service, username)
-        if interactive and password is None:
-            # -- LEARNING MODE: Password is not stored in keyring yet.
-            oracle = "@oracle:ask_password"
-            password = get_service_password(service, username, oracle)
-            if password:
-                keyring.set_password(service, username, password)
-        elif not interactive and password is None:
-            log.error(
-                'Unable to retrieve password from keyring. '
-                'Not running in an interactive terminal; cannot prompt for password.'
+    oracle = oracle.removeprefix("@oracle:") if oracle else "use_keyring"
+
+    match oracle:
+        case "ask_password":
+            return _ask_password(service)
+
+        case "use_keyring":
+            keyring = get_keyring()
+            try:
+                password = keyring.get_password(service, username)
+            except keyring.errors.KeyringLocked:
+                # keyring unlocking failed.
+                # TODO we should probably have a timeout, otherwise the dialog could block
+                log.error(
+                    f"Keyring is locked for service {service}. "
+                    "Unlock your keyring and try again."
+                )
+                sys.exit(1)
+
+            if password is not None:
+                return password
+
+            # LEARNING MODE: password not in keyring yet, prompt and store it.
+            log.info(
+                f"password for {service} is not in keyring, trying to ask for new password"
             )
-    elif interactive and oracle == "@oracle:ask_password":
-        prompt = "%s password: " % service
-        password = getpass.getpass(prompt)
-    elif oracle.startswith('@oracle:eval:'):
-        command = oracle[13:]
-        return oracle_eval(command)
+            password = _ask_password(service)
+            keyring.set_password(service, username, password)
+            return password
 
-    if password is None:
-        log.critical(
-            "MISSING PASSWORD: oracle='%s', interactive=%s for service=%s"
-            % (oracle, sys.stdin.isatty(), service)
-        )
-        sys.exit(1)
-    return password
+        case _:
+            if not oracle.startswith("eval:"):
+                log.error(f"Unknown oracle for service {service}: {oracle}")
+                sys.exit(1)
+
+            return oracle_eval(oracle.removeprefix("eval:"))
 
 
 def oracle_eval(command: str) -> str:

--- a/bugwarrior/config/secrets.py
+++ b/bugwarrior/config/secrets.py
@@ -1,3 +1,4 @@
+import getpass
 import logging
 import subprocess
 import sys
@@ -19,8 +20,6 @@ def get_keyring() -> ModuleType:
 
 
 def _ask_password(service: str) -> str:
-    import getpass
-
     if not sys.stdin.isatty():
         log.error(
             f"Unable to retrieve password for service {service}. "

--- a/bugwarrior/config/secrets.py
+++ b/bugwarrior/config/secrets.py
@@ -18,9 +18,7 @@ def get_keyring() -> ModuleType:
     return keyring
 
 
-def get_service_password(
-    service: str, username: str, oracle: str | None = None, interactive: bool = False
-) -> str:
+def get_service_password(service: str, username: str, oracle: str | None = None) -> str:
     """
     Retrieve the sensitive password for a service by:
 
@@ -31,6 +29,7 @@ def get_service_password(
 
     Note that the keyring may or may not be locked
     which requires that the user provides a password (interactive mode).
+    Interactive mode is detected automatically via sys.stdin.isatty().
 
     :param service:     Service name, may be key into secure store (as string).
     :param username:    Username for the service (as string).
@@ -42,6 +41,7 @@ def get_service_password(
     """
     import getpass
 
+    interactive = sys.stdin.isatty()
     password = None
     if not oracle or oracle == "@oracle:use_keyring":
         keyring = get_keyring()
@@ -49,13 +49,13 @@ def get_service_password(
         if interactive and password is None:
             # -- LEARNING MODE: Password is not stored in keyring yet.
             oracle = "@oracle:ask_password"
-            password = get_service_password(service, username, oracle, interactive=True)
+            password = get_service_password(service, username, oracle)
             if password:
                 keyring.set_password(service, username, password)
         elif not interactive and password is None:
             log.error(
                 'Unable to retrieve password from keyring. '
-                'Re-run in interactive mode to set a password'
+                'Not running in an interactive terminal; cannot prompt for password.'
             )
     elif interactive and oracle == "@oracle:ask_password":
         prompt = "%s password: " % service
@@ -67,7 +67,7 @@ def get_service_password(
     if password is None:
         log.critical(
             "MISSING PASSWORD: oracle='%s', interactive=%s for service=%s"
-            % (oracle, interactive, service)
+            % (oracle, sys.stdin.isatty(), service)
         )
         sys.exit(1)
     return password

--- a/bugwarrior/config/validation.py
+++ b/bugwarrior/config/validation.py
@@ -191,7 +191,7 @@ def validate_config(config: dict, main_section: str, config_path: str) -> "Confi
                 f"[{flavor_name}]\ntargets = {flavor.targets}  <- No [{target}] section found\n"
             )
 
-    main = flavors.get(main_section, MainSectionConfig(targets=[], interactive=False))
+    main = flavors.get(main_section, MainSectionConfig(targets=[]))
     filtered_service_configs = [
         service_config
         for service_config in service_configs

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -286,10 +286,7 @@ class Service(abc.ABC, Generic[T_Issue]):
         keyring_service = self.get_keyring_service(self.config)
         if not password or password.startswith("@oracle:"):
             password = secrets.get_service_password(
-                keyring_service,
-                login,
-                oracle=password,
-                interactive=self.main_config.interactive,
+                keyring_service, login, oracle=password
             )
         return password
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -103,7 +103,6 @@ class ConfigTest(unittest.TestCase):
     def validate(self) -> validation.Config:
         config = self.config.copy()
         config['general'] = config.get('general', {})
-        config['general']['interactive'] = False
         formatted_config = format_config(config)
         return validation.validate_config(formatted_config, 'general', 'configpath')
 
@@ -121,11 +120,7 @@ class ConfigTest(unittest.TestCase):
 
 
 class ServiceTest(ConfigTest):
-    GENERAL_CONFIG = {
-        'interactive': False,
-        'annotation_length': 100,
-        'description_length': 100,
-    }
+    GENERAL_CONFIG = {'annotation_length': 100, 'description_length': 100}
     SERVICE_CONFIG = {}
 
     @classmethod

--- a/tests/config/test_data.py
+++ b/tests/config/test_data.py
@@ -42,7 +42,7 @@ class TestGetDataPath(ConfigTest):
     def setUp(self):
         super().setUp()
         rawconfig = {
-            'general': {'targets': ['my_service'], 'interactive': False},
+            'general': {'targets': ['my_service']},
             'my_service': {
                 'service': 'github',
                 'login': 'ralphbean',

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -37,7 +37,7 @@ class ExampleTest(ConfigTest):
         for rcfile in ('example-bugwarriorrc', 'example-bugwarrior.toml'):
             with self.subTest(rcfile=rcfile):
                 os.environ['BUGWARRIORRC'] = str(self.basedir / rcfile)
-                load.load_config('general', False, False)
+                load.load_config('general', False)
 
 
 class TestGetConfigPath(LoadTest):
@@ -282,12 +282,7 @@ class TestLoadConfig(LoadTest):
             )
 
         with self.assertRaises(SystemExit):
-            load.load_config("general", False, False)
+            load.load_config("general", False)
 
         self.assertEqual(len(self.caplog.records), 1)
         self.assertIn("No section: 'general'", self.caplog.records[0].message)
-
-    def test_interactive_flag_propagated(self):
-        os.environ['BUGWARRIORRC'] = str(self.basedir / 'example-bugwarriorrc')
-        config = load.load_config('general', interactive=True, quiet=False)
-        self.assertTrue(config.main.interactive)

--- a/tests/config/test_secrets.py
+++ b/tests/config/test_secrets.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import MagicMock, patch
 
 from bugwarrior.config import secrets
 
@@ -6,3 +7,107 @@ from bugwarrior.config import secrets
 class TestOracleEval(unittest.TestCase):
     def test_echo(self):
         self.assertEqual(secrets.oracle_eval("echo fööbår"), "fööbår")
+
+
+class TestGetServicePassword(unittest.TestCase):
+    """Tests for get_service_password, covering every oracle code path."""
+
+    SERVICE = "myservice"
+    USERNAME = "username"
+
+    def _call(self, oracle):
+        return secrets.get_service_password(self.SERVICE, self.USERNAME, oracle=oracle)
+
+    def _mock_keyring(self, password=None, locked=False):
+        """Return a mock keyring module.
+
+        If "locked" is True, get_password raises KeyringLocked.
+        Otherwise it returns the given password.
+        """
+        import keyring.errors
+
+        mock = MagicMock()
+        if locked:
+            mock.get_password.side_effect = keyring.errors.KeyringLocked()
+        else:
+            mock.get_password.return_value = password
+        mock.errors = keyring.errors
+        return mock
+
+    def test_eval_oracle_returns_command_output(self):
+        with patch.object(secrets, "oracle_eval", return_value="s3cr3t") as mock_eval:
+            result = self._call(oracle="@oracle:eval:echo s3cr3t")
+        mock_eval.assert_called_once_with("echo s3cr3t")
+        self.assertEqual(result, "s3cr3t")
+
+    def test_ask_password_interactive_prompts_user(self):
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("getpass.getpass", return_value="typed") as mock_getpass,
+        ):
+            mock_stdin.isatty.return_value = True
+            result = self._call(oracle="@oracle:ask_password")
+        mock_getpass.assert_called_once()
+        self.assertEqual(result, "typed")
+
+    def test_ask_password_non_interactive_exits(self):
+        with patch("sys.stdin") as mock_stdin, patch("getpass.getpass") as mock_getpass:
+            mock_stdin.isatty.return_value = False
+            with self.assertRaises(SystemExit):
+                self._call(oracle="@oracle:ask_password")
+        mock_getpass.assert_not_called()
+
+    def test_keyring_has_password_returns_it(self):
+        mock = self._mock_keyring(password="stored")
+        with patch.object(secrets, "get_keyring", return_value=mock):
+            result = self._call(oracle="@oracle:use_keyring")
+        mock.get_password.assert_called_once_with(self.SERVICE, self.USERNAME)
+        self.assertEqual(result, "stored")
+
+    def test_default_oracle_also_uses_keyring(self):
+        """Passing oracle=None should behave identically to @oracle:use_keyring."""
+        mock = self._mock_keyring(password="stored")
+        with patch.object(secrets, "get_keyring", return_value=mock):
+            result = self._call(oracle=None)
+        self.assertEqual(result, "stored")
+
+    def test_keyring_locked_exits(self):
+        """When the keyring is locked and the unlock dialog is dismissed,
+        keyring raises KeyringLocked. bugwarrior should exit fatally."""
+        mock = self._mock_keyring(locked=True)
+        with patch.object(secrets, "get_keyring", return_value=mock):
+            with self.assertRaises(SystemExit):
+                self._call(oracle="@oracle:use_keyring")
+
+    def test_keyring_empty_interactive_prompts_and_stores(self):
+        """When keyring has no password and stdin is a tty, the user is prompted
+        and the password is saved back to the keyring."""
+        mock = self._mock_keyring(password=None)
+        with (
+            patch.object(secrets, "get_keyring", return_value=mock),
+            patch("sys.stdin") as mock_stdin,
+            patch("getpass.getpass", return_value="newpass"),
+        ):
+            mock_stdin.isatty.return_value = True
+            result = self._call(oracle="@oracle:use_keyring")
+        self.assertEqual(result, "newpass")
+        mock.set_password.assert_called_once_with(
+            self.SERVICE, self.USERNAME, "newpass"
+        )
+
+    def test_keyring_empty_non_interactive_exits(self):
+        """When keyring has no password and stdin is not a tty, exit fatally."""
+        mock = self._mock_keyring(password=None)
+        with (
+            patch.object(secrets, "get_keyring", return_value=mock),
+            patch("sys.stdin") as mock_stdin,
+            patch("getpass.getpass") as mock_getpass,
+        ):
+            mock_stdin.isatty.return_value = False
+            with self.assertRaises(SystemExit):
+                self._call(oracle="@oracle:use_keyring")
+        mock_getpass.assert_not_called()
+
+    def test_unknown_oracle_exits(self):
+        with self.assertRaises(SystemExit):
+            self._call(oracle="@oracle:unknown_strategy")

--- a/tests/config/test_secrets.py
+++ b/tests/config/test_secrets.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+import keyring.errors
+
 from bugwarrior.config import secrets
 
 
@@ -24,8 +26,6 @@ class TestGetServicePassword(unittest.TestCase):
         If "locked" is True, get_password raises KeyringLocked.
         Otherwise it returns the given password.
         """
-        import keyring.errors
-
         mock = MagicMock()
         if locked:
             mock.get_password.side_effect = keyring.errors.KeyringLocked()

--- a/tests/config/test_validation.py
+++ b/tests/config/test_validation.py
@@ -141,9 +141,7 @@ class TestValidation(ConfigTest):
         self.validate()
 
     def test_flavors(self):
-        self.config['flavor'] = {
-            'myflavor': {'targets': ['my_service', 'my_gitlab'], 'interactive': False}
-        }
+        self.config['flavor'] = {'myflavor': {'targets': ['my_service', 'my_gitlab']}}
         self.validate()
 
     def test_quoted_flavor_key_error(self):
@@ -177,9 +175,6 @@ class TestValidation(ConfigTest):
             for main_section, expected_configs in expected_by_flavor.items():
                 with self.subTest(config=config_path.name, main_section=main_section):
                     formatted_config = parse_file(str(config_path))
-
-                    for flavor in formatted_config['flavor'].values():
-                        flavor['interactive'] = False
 
                     config = validation.validate_config(
                         formatted_config, main_section, str(config_path)

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -26,7 +26,7 @@ class testJiraService(ConfigTest):
     def setUp(self):
         super().setUp()
         self.config = {
-            'general': {'targets': ['myjira'], 'interactive': 'false'},
+            'general': {'targets': ['myjira']},
             'myjira': {
                 'service': 'jira',
                 'base_uri': 'https://example.com',

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -17,10 +17,7 @@ that long.""".replace('\n', ' ')
 class ServiceBase(ConfigTest):
     def setUp(self):
         super().setUp()
-        self.config = {
-            'general': {'targets': ['test'], 'interactive': 'false'},
-            'test': {'service': 'test'},
-        }
+        self.config = {'general': {'targets': ['test']}, 'test': {'service': 'test'}}
 
     def makeService(self):
         with unittest.mock.patch(

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -16,7 +16,7 @@ class TestTemplates(ServiceTest):
         config = DumbConfig(
             target='dummy', add_tags=add_tags if add_tags else [], **template_kwargs
         )
-        main_config = MainSectionConfig(interactive=False, targets=[])
+        main_config = MainSectionConfig(targets=[])
 
         issue = DumbIssue({}, config, main_config, {})
         issue.to_taskwarrior = lambda: (

--- a/tests/test_trello.py
+++ b/tests/test_trello.py
@@ -33,7 +33,7 @@ class TestTrelloIssue(ServiceTest):
             target="mytrello",
         )
         main_config = MainSectionConfig(
-            interactive=False, targets=[], inline_links=True, description_length=31
+            targets=[], inline_links=True, description_length=31
         )
         extra = {'boardname': 'Hyperspatial express route', 'listname': 'Something'}
         self.issue = TrelloIssue(self.JSON, config, main_config, extra)


### PR DESCRIPTION
Fixes #1199

* `--interactive` is still accepted, but do nothing except raising a deprecation warning
* refactor `get_service_password` to simplify the logic
* add several tests for `get_service_password`