### PR TITLE
fix os.environ restoration in ConfigTest.tearDown

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -94,7 +94,9 @@ class ConfigTest(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.tempdir, ignore_errors=True)
-        os.environ = self.old_environ
+
+        os.environ.clear()
+        os.environ.update(self.old_environ)
 
     @pytest.fixture(autouse=True)
     def inject_fixtures(self, caplog):


### PR DESCRIPTION
Replace `os.environ = self.old_environ` (which swaps the live _Environ proxy for a plain dict) with in-place clear+update, preserving the proxy.

Add tests/test_base.py to demonstrate the two failure modes:
- os.environ no longer an os._Environ instance after tearDown
- subprocess cannot see env changes because putenv() is never called

The tests may be removed from the MR, I used them to ensure there was an issue.

According to my AI agent, it may be related to CI failures we noticed recently.

I already mentioned it, but I still think the tests would be cleaner and simpler if we stop using `unittest.TestCase` and rely only on pytest fixtures instead. In this specific case, pytest already handle modifying the env through [`setenv`](https://docs.pytest.org/en/stable/reference/reference.html#pytest.MonkeyPatch.setenv). 
[tempfiles](https://docs.pytest.org/en/stable/how-to/tmp_path.html) handling would also be more robust, as for now the temp directory is not removed in case of an error (pytest has [retention settings](https://docs.pytest.org/en/stable/how-to/tmp_path.html#temporary-directory-location-and-retention)