### PR TITLE
explictly state in documentation that toml is the prefered config format

### DIFF
--- a/bugwarrior/docs/_ext/config.py
+++ b/bugwarrior/docs/_ext/config.py
@@ -45,7 +45,7 @@ class Config(SphinxDirective):
 
         toml = self._make_tab('toml')
 
-        return [ini, toml]
+        return [toml, ini]
 
 
 def setup(app):

--- a/bugwarrior/docs/common_configuration.rst
+++ b/bugwarrior/docs/common_configuration.rst
@@ -1,7 +1,7 @@
 How to Configure
 ================
 
-Bugwarrior's configuration file can be written either in `ini <https://en.wikipedia.org/wiki/INI_file#Format>`_ or `toml <https://toml.io>`_ format. See :ref:`the man page <configuration-files>` to determine the name and location of this file.
+Bugwarrior's configuration file can be written in `toml <https://toml.io>`_ (recommended) or `ini <https://en.wikipedia.org/wiki/INI_file#Format>`_ format. See :ref:`the man page <configuration-files>` to determine the name and location of this file.
 
 A basic configuration might look like this:
 

--- a/bugwarrior/docs/conf.py
+++ b/bugwarrior/docs/conf.py
@@ -117,8 +117,6 @@ exclude_patterns = []
 # output. They are ignored by default.
 # show_authors = False
 
-# The default language to highlight source code in.
-highlight_language = 'ini'
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'


### PR DESCRIPTION
#1176 

toml is now the first format in the docs, and we clearly indicate it's the preferred one.