### PR TITLE
Add prek pre-commit hooks for ruff and ty

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,2 +1,22 @@
 ci: {}
-repos: []
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-format
+        name: ruff format
+        entry: scripts/run.sh ruff format --force-exclude --check
+        language: system
+        types_or: [python, pyi]
+
+      - id: ruff-lint
+        name: ruff lint
+        entry: scripts/run.sh ruff check --force-exclude
+        language: system
+        types_or: [python, pyi]
+
+      - id: ty
+        name: ty check
+        entry: scripts/run.sh ty check
+        language: system
+        types_or: [python, pyi]
+        pass_filenames: false

--- a/bugwarrior/docs/contributing.rst
+++ b/bugwarrior/docs/contributing.rst
@@ -71,6 +71,28 @@ separately, but you may find it convenient to run ``ruff check``, ``ruff
 format``, and ``ty check``, or integrate `ruff <https://docs.astral.sh/ruff/editors/setup/>`_
 and `ty <https://docs.astral.sh/ty/editors/>`_ with your editor.
 
+Optionally, you can install the provided hooks to have ruff and ty run
+automatically before each commit. The hooks use `prek <https://github.com/j178/prek>`_
+(or `pre-commit <https://pre-commit.com/>`_ as an alternative):
+
+.. tab:: pip
+
+   .. code-block:: bash
+
+    $ pip install prek
+    $ prek install
+
+.. tab:: uv
+
+   .. code-block:: bash
+
+    $ uv tool install prek
+    $ prek install
+
+The hooks use ``scripts/run.sh`` to invoke ruff and ty from the project's
+virtualenv (via ``uv run`` for uv users, or ``.venv`` for pip users), so they
+always run the same versions as the test suite.
+
 Making a pull request
 ---------------------
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Run a command via `uv run` if uv is available, otherwise run it directly.
+# If a .venv directory exists, prepend it to PATH so the venv's tools are
+# used without requiring the user to have manually activated it.
+if command -v uv >/dev/null 2>&1 && [ -f "uv.lock" ]; then
+    exec uv run "$@"
+else
+    if [ -d ".venv" ]; then
+        export PATH=".venv/bin:$PATH"
+    fi
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "error: '$1' not found."
+        echo "Make sure your virtualenv is set up (see CONTRIBUTING for instructions)."
+        echo "To skip this hook: git commit --no-verify  (or -n)"
+        echo "To skip only this hook: SKIP=$1 git commit"
+        exit 1
+    fi
+    exec "$@"
+fi


### PR DESCRIPTION
Final step for #1151 

So there are multiple ways to define the pre-commits, we can either:

* use the python env from the project. it uses a small script in `run.sh` to determine what env to use (either using `uv` or from `pip`), but I'm not sure how robust this is.
* let `prek` define its own environment, so it does not depend on how the python env is installed, the major downside is having to keep the versions from `pyproject.toml` and `.pre-commit-config.yaml` in sync.

the `run.sh` alternative also allows us to add some help messages to disable the pre commits.
As discussed, neither `ruff-format` nor `ruff-lint` modify the code, it simply fails even something is wrong.