### PR TITLE
Replace get_keyring_service by KEYRING_SERVICE class variable

### DIFF
--- a/bugwarrior/command.py
+++ b/bugwarrior/command.py
@@ -12,7 +12,7 @@ from lockfile import LockTimeout
 from lockfile.pidlockfile import PIDLockFile
 
 from bugwarrior.collect import aggregate_issues
-from bugwarrior.config import get_config_path, get_keyring, get_service, load_config
+from bugwarrior.config import get_config_path, get_keyring, load_config
 from bugwarrior.db import get_defined_udas_as_strings, synchronize
 
 if TYPE_CHECKING:
@@ -162,9 +162,7 @@ def targets() -> Iterator[str]:
     for service_config in config.service_configs:
         for value in dict(service_config).values():
             if isinstance(value, str) and '@oracle:use_keyring' in value:
-                yield get_service(service_config.service).get_keyring_service(
-                    service_config
-                )
+                yield service_config.keyring_service
 
 
 @vault.command()

--- a/bugwarrior/config/__init__.py
+++ b/bugwarrior/config/__init__.py
@@ -15,9 +15,9 @@ from .schema import (
     StrippedTrailingSlashUrl,  # noqa: F401
     TaskrcPath,  # noqa: F401
     UnsupportedOption,  # noqa: F401
+    get_service,  # noqa:F401
 )
 from .secrets import get_keyring  # noqa: F401
-from .validation import get_service  # noqa:F401
 
 # NOTE: __all__ determines the stable, public API.
 __all__ = [BugwarriorData.__name__, MainSectionConfig.__name__, ServiceConfig.__name__]

--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -1,9 +1,11 @@
+from functools import cache
+from importlib.metadata import entry_points
 import logging
 import os
 from pathlib import Path
 import re
 import typing
-from typing import Annotated, Any, Literal
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 import pydantic
 from pydantic import (
@@ -22,6 +24,9 @@ import taskw
 import taskw.task
 
 from .data import BugwarriorData, get_data_path
+
+if TYPE_CHECKING:
+    from bugwarrior.services import Service
 
 log = logging.getLogger(__name__)
 
@@ -215,8 +220,6 @@ class ServiceConfig(_ServiceConfig):
 
     @property
     def keyring_service(self) -> str:
-        # FIXME change this import and move it outside method after rebase
-        from bugwarrior.collect import get_service
 
         service = get_service(self.service)
         if service.API_VERSION < 2:
@@ -291,3 +294,23 @@ class ServiceConfig(_ServiceConfig):
             if value != '':
                 log.warning('project_name is deprecated in favor of project_template')
         return value
+
+
+@cache
+def get_service(service_name: str) -> type["Service"]:
+    try:
+        (service,) = entry_points(group='bugwarrior.service', name=service_name)
+    except ValueError as e:
+        if service_name in [
+            'activecollab',
+            'activecollab2',
+            'megaplan',
+            'teamlab',
+            'versionone',
+        ]:
+            log.warning(f"The {service_name} service has been removed.")
+        raise ValueError(
+            f"Configured service '{service_name}' not found. "
+            "Is it installed? Or misspelled?"
+        ) from e
+    return service.load()

--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -197,9 +197,15 @@ class ServiceConfig(_ServiceConfig):
     .. _Pydantic: https://docs.pydantic.dev/latest/
     """
 
+    KEYRING_SERVICE: typing.ClassVar[str]
+
     # Added before validation (computed field)
     service: str
     target: str
+
+    @property
+    def keyring_service(self) -> str:
+        return self.KEYRING_SERVICE.format(**self.model_dump())
 
     # Added during validation (computed field)
     templates: dict[str, str] = {}

--- a/bugwarrior/config/schema.py
+++ b/bugwarrior/config/schema.py
@@ -203,10 +203,6 @@ class ServiceConfig(_ServiceConfig):
     service: str
     target: str
 
-    @property
-    def keyring_service(self) -> str:
-        return self.KEYRING_SERVICE.format(**self.model_dump())
-
     # Added during validation (computed field)
     templates: dict[str, str] = {}
 
@@ -216,6 +212,18 @@ class ServiceConfig(_ServiceConfig):
     default_priority: Priority = "M"
     add_tags: ConfigList = []
     static_fields: ConfigList = []
+
+    @property
+    def keyring_service(self) -> str:
+        # FIXME change this import and move it outside method after rebase
+        from bugwarrior.collect import get_service
+
+        service = get_service(self.service)
+        if service.API_VERSION < 2:
+            assert hasattr(service, "get_keyring_service")
+            return service.get_keyring_service(self)  # ty: ignore
+
+        return self.KEYRING_SERVICE.format(**self.model_dump())
 
     @model_validator(mode="before")
     @classmethod

--- a/bugwarrior/config/validation.py
+++ b/bugwarrior/config/validation.py
@@ -1,5 +1,3 @@
-from functools import cache
-from importlib.metadata import entry_points
 import logging
 import sys
 from typing import TYPE_CHECKING, Annotated, Any, NoReturn, Union
@@ -7,31 +5,17 @@ from typing import TYPE_CHECKING, Annotated, Any, NoReturn, Union
 from pydantic import Field, TypeAdapter, ValidationError
 from pydantic_core import ErrorDetails
 
-from .schema import BaseConfig, Hooks, MainSectionConfig, Notifications, ServiceConfig
+from .schema import (
+    BaseConfig,
+    Hooks,
+    MainSectionConfig,
+    Notifications,
+    ServiceConfig,
+    get_service,
+)
 
 if TYPE_CHECKING:
     ServiceConfigType = ServiceConfig
-    from bugwarrior.services import Service
-
-
-@cache
-def get_service(service_name: str) -> type["Service"]:
-    try:
-        (service,) = entry_points(group='bugwarrior.service', name=service_name)
-    except ValueError as e:
-        if service_name in [
-            'activecollab',
-            'activecollab2',
-            'megaplan',
-            'teamlab',
-            'versionone',
-        ]:
-            log.warning(f"The {service_name} service has been removed.")
-        raise ValueError(
-            f"Configured service '{service_name}' not found. "
-            "Is it installed? Or misspelled?"
-        ) from e
-    return service.load()
 
 
 log = logging.getLogger(__name__)

--- a/bugwarrior/docs/other-services/api.rst
+++ b/bugwarrior/docs/other-services/api.rst
@@ -1,4 +1,4 @@
-Python API v1.0
+Python API v2.0
 ===============
 
 The interfaces documented here are considered stable. All other interfaces

--- a/bugwarrior/docs/other-services/api.rst
+++ b/bugwarrior/docs/other-services/api.rst
@@ -15,3 +15,14 @@ warning, release notes, or semantic version bumping.
    :exclude-members: __init__,compute_templates,model_config
    :imported-members:
    :member-order: bysource
+
+Changelog
+---------
+
+v2.0
+~~~~
+
+- Removed ``Service.get_keyring_service(config)``. Service configurations should
+  define ``KEYRING_SERVICE`` instead.
+- Added ``ServiceConfig.KEYRING_SERVICE`` as a format string for generating the
+  keyring service identifier from service configuration fields.

--- a/bugwarrior/docs/other-services/tutorial.rst
+++ b/bugwarrior/docs/other-services/tutorial.rst
@@ -190,7 +190,7 @@ Now for the main service class which bugwarrior will invoke to fetch issues.
 .. code:: python
 
   class GitBugService(Service):
-      API_VERSION = 1.0
+      API_VERSION = 2.0
       ISSUE_CLASS = GitBugIssue
       CONFIG_SCHEMA = GitBugConfig
 

--- a/bugwarrior/docs/other-services/tutorial.rst
+++ b/bugwarrior/docs/other-services/tutorial.rst
@@ -75,6 +75,7 @@ Now define an initial configuration schema as follows. Don't worry, we're about 
 
   class GitbugConfig(config.ServiceConfig):
       service: typing.Literal['gitbug']
+      KEYRING_SERVICE = 'gitbug://{path}'
 
       path: pathlib.Path
 
@@ -92,6 +93,8 @@ The ``service`` attribute is how bugwarrior will know to assign a given section 
   service = gitbug
 
 The ``path`` is the only particular detail required to access our local git-bug instance. You'll likely need additional details such as a username and token to authenticate to the service. Look at how you accessed the API in step 1 and ask yourself which components need to be configurable.
+
+The ``KEYRING_SERVICE`` attribute is a format string that returns a string identifier for secrets in the keyring. Ideally, this string uniquely identifies a given instance of the service when it is possible to have multiple instances of the service configured. Service configuration values may be referenced by field name, such as ``{path}``.
 
 The ``import_labels_as_tags`` and ``port`` attributes create optional configuration fields to allow customization of bugwarrior behavior.
 
@@ -199,10 +202,6 @@ Now for the main service class which bugwarrior will invoke to fetch issues.
               port=self.config.port,
               annotation_comments=self.main_config.annotation_comments)
 
-      @staticmethod
-      def get_keyring_service(config):
-          return f'gitbug://{config.path}'
-
       def issues(self):
           for issue in self.client.get_issues():
               comments = issue.pop('comments')
@@ -217,11 +216,9 @@ Now for the main service class which bugwarrior will invoke to fetch issues.
 
               yield self.get_issue_for_record(issue)
 
-Here we see three required class attributes and two required methods.
+Here we see three required class attributes and one required method.
 
-The ``API_VERSION`` is set to the latest, while the other two attributes point to our previously defined classes.
-
-The ``get_keyring_service`` method returns a string identifier for secrets in the keyring. Ideally, this string uniquely identifies a given instance of the service when it is possible to have multiple instances of the service configured.
+The ``API_VERSION`` is set to the latest, while ``ISSUE_CLASS`` and ``CONFIG_SCHEMA`` point to our previously defined classes.
 
 The ``issues`` method is a generator which yields individual issue dictionaries.
 

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -37,7 +37,7 @@ CACHE_REGION = dogpile.cache.make_region().configure(
 # spec will cause breakages with older bugwarrior releases.
 # MINOR versions signal extensions of the spec which enhance future releases of
 # bugwarrior without breaking past releases.
-LATEST_API_VERSION = 1.0
+LATEST_API_VERSION = 2.0
 
 
 class URLShortener:

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -283,10 +283,9 @@ class Service(abc.ABC, Generic[T_Issue]):
             applicable.
         """
         password = getattr(self.config, key)
-        keyring_service = self.get_keyring_service(self.config)
         if not password or password.startswith("@oracle:"):
             password = secrets.get_service_password(
-                keyring_service, login, oracle=password
+                self.config.keyring_service, login, oracle=password
             )
         return password
 
@@ -298,7 +297,7 @@ class Service(abc.ABC, Generic[T_Issue]):
         :param `record`: Foreign record.
         :param `extra`: Computed data which is not directly from the service.
         """
-        extra = extra if extra is not None else {}
+        extra = extra or {}
         return self.ISSUE_CLASS(record, self.config, self.main_config, extra=extra)
 
     def build_annotations(
@@ -358,12 +357,6 @@ class Service(abc.ABC, Generic[T_Issue]):
         The priority should be one of "H", "M", or "L".
         """
         raise NotImplementedError()
-
-    @staticmethod
-    @abc.abstractmethod
-    def get_keyring_service(config: schema.ServiceConfig) -> str:
-        """Return the keyring name for this service."""
-        raise NotImplementedError
 
 
 class Client:

--- a/bugwarrior/services/azuredevops.py
+++ b/bugwarrior/services/azuredevops.py
@@ -184,7 +184,7 @@ class AzureDevopsIssue(Issue):
 
 
 class AzureDevopsService(Service[AzureDevopsIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = AzureDevopsIssue
     CONFIG_SCHEMA = AzureDevopsConfig
 

--- a/bugwarrior/services/azuredevops.py
+++ b/bugwarrior/services/azuredevops.py
@@ -18,6 +18,7 @@ EscapedStr = Annotated[str, BeforeValidator(quote)]
 
 class AzureDevopsConfig(config.ServiceConfig):
     service: Literal['azuredevops']
+    KEYRING_SERVICE = "azuredevops://{organization}@{host}"
     PAT: str
     project: EscapedStr
     organization: EscapedStr
@@ -259,7 +260,3 @@ class AzureDevopsService(Service[AzureDevopsIssue]):
             }
             issue_obj.extra.update(extra)
             yield issue_obj
-
-    @staticmethod
-    def get_keyring_service(config: AzureDevopsConfig) -> str:
-        return f"azuredevops://{config.organization}@{config.host}"

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -15,6 +15,7 @@ class BitbucketConfig(config.ServiceConfig):
     filter_merge_requests: Union[bool, Literal['Undefined']] = 'Undefined'
 
     service: Literal['bitbucket']
+    KEYRING_SERVICE = "bitbucket://{key}/{username}"
 
     username: str
 
@@ -115,10 +116,6 @@ class BitbucketService(Service[BitbucketIssue]):
         self.requests_kwargs = {
             'headers': {'Authorization': f"Bearer {response['access_token']}"}
         }
-
-    @staticmethod
-    def get_keyring_service(config: BitbucketConfig) -> str:
-        return f"bitbucket://{config.key}/{config.username}"
 
     def filter_repos(self, repo_tag: str) -> bool:
         repo = repo_tag.split('/').pop()

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -81,7 +81,7 @@ class BitbucketIssue(Issue):
 
 
 class BitbucketService(Service[BitbucketIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = BitbucketIssue
     CONFIG_SCHEMA = BitbucketConfig
 

--- a/bugwarrior/services/bts.py
+++ b/bugwarrior/services/bts.py
@@ -19,6 +19,7 @@ UDD_BUGS_SEARCH = "https://udd.debian.org/bugs/"
 
 class BTSConfig(config.ServiceConfig):
     service: typing.Literal['bts']
+    KEYRING_SERVICE = 'bts://'
 
     email: pydantic.EmailStr = ''
     packages: config.ConfigList = []
@@ -106,10 +107,6 @@ class BTSService(Service[BTSIssue]):
     API_VERSION = 1.0
     ISSUE_CLASS = BTSIssue
     CONFIG_SCHEMA = BTSConfig
-
-    @staticmethod
-    def get_keyring_service(config: BTSConfig) -> str:
-        return 'bts://'
 
     def _record_for_bug(self, bug: debianbts.Bugreport) -> dict[str, Any]:
         return {

--- a/bugwarrior/services/bts.py
+++ b/bugwarrior/services/bts.py
@@ -104,7 +104,7 @@ class BTSIssue(Issue):
 
 
 class BTSService(Service[BTSIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = BTSIssue
     CONFIG_SCHEMA = BTSConfig
 

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -119,7 +119,7 @@ class BugzillaIssue(Issue):
 
 
 class BugzillaService(Service[BugzillaIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = BugzillaIssue
     CONFIG_SCHEMA = BugzillaConfig
 

--- a/bugwarrior/services/bz.py
+++ b/bugwarrior/services/bz.py
@@ -34,6 +34,7 @@ OptionalSchemeUrl = Annotated[StrippedTrailingSlashUrl, BeforeValidator(validate
 
 class BugzillaConfig(config.ServiceConfig):
     service: typing.Literal['bugzilla']
+    KEYRING_SERVICE = "bugzilla://{username}@{base_uri}"
     username: str
     base_uri: OptionalSchemeUrl
 
@@ -157,10 +158,6 @@ class BugzillaService(Service[BugzillaIssue]):
             if self.config.password:
                 password = self.get_secret('password', self.config.username)
                 self.bz.login(self.config.username, password)
-
-    @staticmethod
-    def get_keyring_service(config: BugzillaConfig) -> str:
-        return f"bugzilla://{config.username}@{config.base_uri}"
 
     def get_owner(self, issue: dict[str, Any]) -> str:
         return issue['assigned_to']

--- a/bugwarrior/services/clickup.py
+++ b/bugwarrior/services/clickup.py
@@ -14,6 +14,7 @@ log = logging.getLogger(__name__)
 
 class ClickupConfig(config.ServiceConfig):
     service: typing.Literal["clickup"]
+    KEYRING_SERVICE = "clickup://"
     token: str
     team_id: int
 
@@ -129,10 +130,6 @@ class ClickupService(Service[ClickupIssue]):
     ) -> None:
         super().__init__(config, main_config)
         self.client = ClickupClient(token=self.get_secret('token'))
-
-    @staticmethod
-    def get_keyring_service(config: ClickupConfig) -> str:
-        return "clickup://"
 
     def is_assigned(self, issue: dict) -> bool:
         if not self.config.only_if_assigned:

--- a/bugwarrior/services/clickup.py
+++ b/bugwarrior/services/clickup.py
@@ -121,7 +121,7 @@ class ClickupIssue(Issue):
 
 
 class ClickupService(Service[ClickupIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = ClickupIssue
     CONFIG_SCHEMA = ClickupConfig
 

--- a/bugwarrior/services/deck.py
+++ b/bugwarrior/services/deck.py
@@ -14,6 +14,7 @@ log = logging.getLogger(__name__)
 
 class NextcloudDeckConfig(config.ServiceConfig):
     service: typing.Literal['deck']
+    KEYRING_SERVICE = 'deck://{username}@{base_uri}'
     base_uri: config.StrippedTrailingSlashUrl
     username: str
 
@@ -140,10 +141,6 @@ class NextcloudDeckService(Service[NextcloudDeckIssue]):
             username=self.config.username,
             password=self.config.password,
         )
-
-    @staticmethod
-    def get_keyring_service(config: NextcloudDeckConfig) -> str:
-        return f'deck://{config.username}@{config.base_uri}'
 
     def get_owner(self, issue: NextcloudDeckIssue) -> str | None:
         rec = issue.record

--- a/bugwarrior/services/deck.py
+++ b/bugwarrior/services/deck.py
@@ -127,7 +127,7 @@ class NextcloudDeckIssue(Issue):
 
 
 class NextcloudDeckService(Service[NextcloudDeckIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = NextcloudDeckIssue
     CONFIG_SCHEMA = NextcloudDeckConfig
 

--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -15,6 +15,7 @@ log = logging.getLogger(__name__)
 
 class GerritConfig(config.ServiceConfig):
     service: typing.Literal['gerrit']
+    KEYRING_SERVICE = "gerrit://{base_uri}"
     base_uri: config.StrippedTrailingSlashUrl
     username: str
     password: str
@@ -101,10 +102,6 @@ class GerritService(Service[GerritIssue]):
             self.session.auth = requests.auth.HTTPBasicAuth(
                 self.config.username, self.password
             )
-
-    @staticmethod
-    def get_keyring_service(config: GerritConfig) -> str:
-        return f"gerrit://{config.base_uri}"
 
     def issues(self) -> Iterator[GerritIssue]:
         # Construct the whole url by hand here, because otherwise requests will

--- a/bugwarrior/services/gerrit.py
+++ b/bugwarrior/services/gerrit.py
@@ -73,7 +73,7 @@ class GerritIssue(Issue):
 
 
 class GerritService(Service[GerritIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = GerritIssue
     CONFIG_SCHEMA = GerritConfig
 

--- a/bugwarrior/services/gitbug.py
+++ b/bugwarrior/services/gitbug.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 
 class GitBugConfig(config.ServiceConfig):
     service: Literal['gitbug']
+    KEYRING_SERVICE = 'gitbug://{path}'
 
     path: config.ExpandedPath
 
@@ -152,10 +153,6 @@ class GitBugService(Service[GitBugIssue]):
             port=self.config.port,
             annotation_comments=self.main_config.annotation_comments,
         )
-
-    @staticmethod
-    def get_keyring_service(config: GitBugConfig) -> str:
-        return f'gitbug://{config.path}'
 
     def issues(self) -> Iterator[GitBugIssue]:
         for issue in self.client.get_issues():

--- a/bugwarrior/services/gitbug.py
+++ b/bugwarrior/services/gitbug.py
@@ -139,7 +139,7 @@ class GitBugIssue(Issue):
 
 
 class GitBugService(Service[GitBugIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = GitBugIssue
     CONFIG_SCHEMA = GitBugConfig
 

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -294,7 +294,7 @@ class GithubIssue(Issue):
 
 
 class GithubService(Service[GithubIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = GithubIssue
     CONFIG_SCHEMA = GithubConfig
 

--- a/bugwarrior/services/github.py
+++ b/bugwarrior/services/github.py
@@ -25,6 +25,7 @@ class GithubConfig(config.ServiceConfig):
 
     # strictly required
     service: typing.Literal['github']
+    KEYRING_SERVICE = "github://{login}@{host}/{username}"
     login: str
     token: str
 
@@ -304,10 +305,6 @@ class GithubService(Service[GithubIssue]):
 
         auth = {'token': self.get_secret('token', self.config.login)}
         self.client = GithubClient(self.config.host, auth)
-
-    @staticmethod
-    def get_keyring_service(config: GithubConfig) -> str:
-        return f"github://{config.login}@{config.host}/{config.username}"
 
     def get_owned_repo_issues(self, tag: str) -> GithubIssueMap:
         """Grab all the issues"""

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -518,7 +518,7 @@ class GitlabIssue(Issue):
 
 
 class GitlabService(Service[GitlabIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = GitlabIssue
     CONFIG_SCHEMA = GitlabConfig
 

--- a/bugwarrior/services/gitlab.py
+++ b/bugwarrior/services/gitlab.py
@@ -29,6 +29,7 @@ class GitlabConfig(config.ServiceConfig):
     filter_merge_requests: typing.Union[bool, typing.Literal['Undefined']] = 'Undefined'
 
     service: typing.Literal['gitlab']
+    KEYRING_SERVICE = "gitlab://{login}@{host}"
     login: str
     token: str
     host: config.NoSchemeUrl
@@ -536,10 +537,6 @@ class GitlabService(Service[GitlabIssue]):
             verify_ssl=self.config.verify_ssl,
         )
         self.repo_map: dict[int, dict[str, Any]] = {}
-
-    @staticmethod
-    def get_keyring_service(config: GitlabConfig) -> str:
-        return f"gitlab://{config.login}@{config.host}"
 
     def get_owner(self, issue: GitlabIssueEntry) -> list[str]:
         return [assignee['username'] for assignee in issue[1]['assignees']]

--- a/bugwarrior/services/gmail.py
+++ b/bugwarrior/services/gmail.py
@@ -106,7 +106,7 @@ class GmailService(Service[GmailIssue]):
     APPLICATION_NAME = 'Bugwarrior Gmail Service'
     SCOPES = ['https://www.googleapis.com/auth/gmail.readonly']
 
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = GmailIssue
     CONFIG_SCHEMA = GmailConfig
     AUTHENTICATION_LOCK = multiprocessing.Lock()

--- a/bugwarrior/services/gmail.py
+++ b/bugwarrior/services/gmail.py
@@ -24,6 +24,7 @@ log = logging.getLogger(__name__)
 
 class GmailConfig(config.ServiceConfig):
     service: typing.Literal['gmail']
+    KEYRING_SERVICE = 'gmail://{login_name}'
 
     client_secret_path: config.ExpandedPath = Path('~/.gmail_client_secret.json')
     query: str = 'label:Starred'
@@ -125,10 +126,6 @@ class GmailService(Service[GmailIssue]):
             'gmail_credentials_%s.pickle' % (credentials_name,),
         )
         self.gmail_api = self.build_api()
-
-    @staticmethod
-    def get_keyring_service(config: GmailConfig) -> str:
-        return f'gmail://{config.login_name}'
 
     def build_api(self) -> googleapiclient.discovery.Resource:
         credentials = self.get_credentials()

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -337,7 +337,7 @@ class JiraIssue(Issue):
 
 
 class JiraService(Service[JiraIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = JiraIssue
     CONFIG_SCHEMA = JiraConfig
 

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -78,6 +78,7 @@ JiraExtraFields = typing.Annotated[
 
 class JiraConfig(config.ServiceConfig):
     service: typing.Literal['jira']
+    KEYRING_SERVICE = "jira://{username}@{base_uri}"
     base_uri: config.StrippedTrailingSlashUrl
     username: str
 
@@ -387,10 +388,6 @@ class JiraService(Service[JiraIssue]):
         if self.config.use_cookies:
             return JIRA(options=jira_options, auth=(self.config.username, password))
         return JIRA(options=jira_options, basic_auth=(self.config.username, password))
-
-    @staticmethod
-    def get_keyring_service(config: JiraConfig) -> str:
-        return f"jira://{config.username}@{config.base_uri}"
 
     def body(self, issue: JiraIssue) -> str | None:
         body = issue.record.get('fields', {}).get('description')

--- a/bugwarrior/services/kanboard.py
+++ b/bugwarrior/services/kanboard.py
@@ -7,6 +7,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from kanboard import Client
+from pydantic import computed_field
 
 from bugwarrior import config
 from bugwarrior.services import Issue, Service
@@ -16,6 +17,7 @@ log = logging.getLogger(__name__)
 
 class KanboardConfig(config.ServiceConfig):
     service: typing.Literal['kanboard']
+    KEYRING_SERVICE = "kanboard://{username}@{url_netloc}"
     url: config.StrippedTrailingSlashUrl
     username: str
     password: str
@@ -24,6 +26,11 @@ class KanboardConfig(config.ServiceConfig):
 
     only_if_assigned: config.UnsupportedOption[str] = ''
     also_unassigned: config.UnsupportedOption[bool] = False
+
+    @computed_field
+    @property
+    def url_netloc(self) -> str:
+        return urlparse(self.url).netloc
 
 
 class KanboardIssue(Issue):
@@ -169,8 +176,3 @@ class KanboardService(Service[KanboardIssue]):
             extra["annotations"] = self.annotations(task, extra["url"])
 
             yield self.get_issue_for_record(task, extra)
-
-    @staticmethod
-    def get_keyring_service(config: KanboardConfig) -> str:
-        parsed = urlparse(config.url)
-        return f"kanboard://{config.username}@{parsed.netloc}"

--- a/bugwarrior/services/kanboard.py
+++ b/bugwarrior/services/kanboard.py
@@ -121,7 +121,7 @@ class KanboardIssue(Issue):
 
 
 class KanboardService(Service[KanboardIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = KanboardIssue
     CONFIG_SCHEMA = KanboardConfig
 

--- a/bugwarrior/services/linear.py
+++ b/bugwarrior/services/linear.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 
 class LinearConfig(config.ServiceConfig):
     service: typing.Literal["linear"]
+    KEYRING_SERVICE = "linear://{host}"
     api_token: str
 
     host: config.StrippedTrailingSlashUrl = "https://api.linear.app/graphql"
@@ -198,10 +199,6 @@ class LinearService(Service[LinearIssue]):
               }
             }
             """
-
-    @staticmethod
-    def get_keyring_service(config: LinearConfig) -> str:
-        return f"linear://{config.host}"
 
     def issues(self) -> Iterator[LinearIssue]:
         for issue in self.get_issues():

--- a/bugwarrior/services/linear.py
+++ b/bugwarrior/services/linear.py
@@ -128,7 +128,7 @@ class LinearIssue(Issue):
 
 
 class LinearService(Service[LinearIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = LinearIssue
     CONFIG_SCHEMA = LinearConfig
 

--- a/bugwarrior/services/logseq.py
+++ b/bugwarrior/services/logseq.py
@@ -324,7 +324,7 @@ class LogseqIssue(Issue):
 
 
 class LogseqService(Service[LogseqIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = LogseqIssue
     CONFIG_SCHEMA = LogseqConfig
 

--- a/bugwarrior/services/logseq.py
+++ b/bugwarrior/services/logseq.py
@@ -15,6 +15,7 @@ log = logging.getLogger(__name__)
 
 class LogseqConfig(config.ServiceConfig):
     service: typing.Literal["logseq"]
+    KEYRING_SERVICE = "http://{host}:{port}"
     host: str = "localhost"
     port: int = 12315
     token: str
@@ -339,10 +340,6 @@ class LogseqService(Service[LogseqIssue]):
             token=self.token,
             filter=filter,
         )
-
-    @staticmethod
-    def get_keyring_service(config: LogseqConfig) -> str:
-        return f"http://{config.host}:{config.port}"
 
     def issues(self) -> Iterator[LogseqIssue]:
         graph_name = self.client.get_graph_name()

--- a/bugwarrior/services/pagure.py
+++ b/bugwarrior/services/pagure.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 class PagureConfig(config.ServiceConfig):
     # strictly required
     service: typing.Literal['pagure']
+    KEYRING_SERVICE = "pagure://{base_url}"
     base_url: config.StrippedTrailingSlashUrl
 
     # conditionally required

--- a/bugwarrior/services/pagure.py
+++ b/bugwarrior/services/pagure.py
@@ -14,7 +14,6 @@ log = logging.getLogger(__name__)
 
 
 class PagureConfig(config.ServiceConfig):
-    # strictly required
     service: typing.Literal['pagure']
     KEYRING_SERVICE = "pagure://{base_url}"
     base_url: config.StrippedTrailingSlashUrl
@@ -92,7 +91,7 @@ class PagureIssue(Issue):
 
 
 class PagureService(Service[PagureIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = PagureIssue
     CONFIG_SCHEMA = PagureConfig
 

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -86,7 +86,7 @@ class PhabricatorIssue(Issue):
 
 
 class PhabricatorService(Service[PhabricatorIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = PhabricatorIssue
     CONFIG_SCHEMA = PhabricatorConfig
 

--- a/bugwarrior/services/phab.py
+++ b/bugwarrior/services/phab.py
@@ -14,6 +14,7 @@ log = logging.getLogger(__name__)
 
 class PhabricatorConfig(config.ServiceConfig):
     service: typing.Literal['phabricator']
+    KEYRING_SERVICE = 'phabricator://{keyring_host}'
 
     user_phids: config.ConfigList = []
     project_phids: config.ConfigList = []
@@ -27,6 +28,11 @@ class PhabricatorConfig(config.ServiceConfig):
     only_if_assigned: bool = False
 
     also_unassigned: config.UnsupportedOption[bool] = False
+
+    @pydantic.computed_field
+    @property
+    def keyring_host(self) -> str:
+        return str(self.host) if self.host else ''
 
 
 class PhabricatorIssue(Issue):
@@ -105,10 +111,6 @@ class PhabricatorService(Service[PhabricatorIssue]):
             if self.config.ignore_author is not None
             else self.config.only_if_assigned
         )
-
-    @staticmethod
-    def get_keyring_service(config: PhabricatorConfig) -> str:
-        return f'phabricator://{config.host if config.host else ""}'
 
     def tasks(self) -> Iterator[PhabricatorIssue]:
         # If self.config.user_phids or self.config.project_phids is set,

--- a/bugwarrior/services/pivotaltracker.py
+++ b/bugwarrior/services/pivotaltracker.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 
 class PivotalTrackerConfig(config.ServiceConfig):
     service: typing.Literal['pivotaltracker']
+    KEYRING_SERVICE = 'pivotaltracker://{user_id}@{host}'
     user_id: int
     account_ids: config.ConfigList
     token: str
@@ -141,10 +142,6 @@ class PivotalTrackerService(Service[PivotalTrackerIssue]):
                 )
             if self.config.only_if_author:
                 self.query += f" requester:{self.config.user_id}"
-
-    @staticmethod
-    def get_keyring_service(config: PivotalTrackerConfig) -> str:
-        return f'pivotaltracker://{config.user_id}@{config.host}'
 
     def annotations(
         self, annotations: list[dict[str, Any]], story: dict[str, Any]

--- a/bugwarrior/services/pivotaltracker.py
+++ b/bugwarrior/services/pivotaltracker.py
@@ -111,7 +111,7 @@ class PivotalTrackerIssue(Issue):
 
 
 class PivotalTrackerService(Service[PivotalTrackerIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = PivotalTrackerIssue
     CONFIG_SCHEMA = PivotalTrackerConfig
 

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -206,7 +206,7 @@ class RedMineIssue(Issue):
 
 
 class RedMineService(Service[RedMineIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = RedMineIssue
     CONFIG_SCHEMA = RedMineConfig
 

--- a/bugwarrior/services/redmine.py
+++ b/bugwarrior/services/redmine.py
@@ -18,6 +18,7 @@ class RedMineConfig(config.ServiceConfig):
     project_name: str = ''
 
     service: typing.Literal['redmine']
+    KEYRING_SERVICE = "redmine://{login}@{url}/"
     url: config.StrippedTrailingSlashUrl
     key: str
 
@@ -231,10 +232,6 @@ class RedMineService(Service[RedMineIssue]):
             self.config.issue_limit,
             self.config.verify_ssl,
         )
-
-    @staticmethod
-    def get_keyring_service(config: RedMineConfig) -> str:
-        return f"redmine://{config.login}@{config.url}/"
 
     def issues(self) -> Iterator[RedMineIssue]:
         issues = self.client.find_issues(

--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -13,6 +13,7 @@ log = logging.getLogger(__name__)
 
 class TaigaConfig(config.ServiceConfig):
     service: typing.Literal['taiga']
+    KEYRING_SERVICE = "taiga://{base_uri}"
     base_uri: config.StrippedTrailingSlashUrl
     auth_token: str
 
@@ -76,10 +77,6 @@ class TaigaService(Service[TaigaIssue]):
                 'Authorization': 'Bearer %s' % self.auth_token,
             }
         )
-
-    @staticmethod
-    def get_keyring_service(config: TaigaConfig) -> str:
-        return f"taiga://{config.base_uri}"
 
     def _issues(
         self, userid: int, task_type: str, task_type_plural: str, task_type_short: str

--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -61,7 +61,7 @@ class TaigaIssue(Issue):
 
 
 class TaigaService(Service[TaigaIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = TaigaIssue
     CONFIG_SCHEMA = TaigaConfig
 

--- a/bugwarrior/services/teamwork_projects.py
+++ b/bugwarrior/services/teamwork_projects.py
@@ -13,6 +13,7 @@ log = logging.getLogger(__name__)
 
 class TeamworkConfig(config.ServiceConfig):
     service: typing.Literal['teamwork_projects']
+    KEYRING_SERVICE = 'teamwork_projects://{host}'
     host: config.StrippedTrailingSlashUrl
     token: str
 
@@ -105,10 +106,6 @@ class TeamworkService(Service[TeamworkIssue]):
         user = self.client.get("authenticate.json")
         self.user_id = user["account"]["userId"]
         self.name = user["account"]["firstname"] + " " + user["account"]["lastname"]
-
-    @staticmethod
-    def get_keyring_service(config: TeamworkConfig) -> str:
-        return f'teamwork_projects://{config.host}'
 
     def get_comments(self, issue: dict[str, Any]) -> list[str]:
         if self.main_config.annotation_comments:

--- a/bugwarrior/services/teamwork_projects.py
+++ b/bugwarrior/services/teamwork_projects.py
@@ -94,7 +94,7 @@ class TeamworkIssue(Issue):
 
 
 class TeamworkService(Service[TeamworkIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = TeamworkIssue
     CONFIG_SCHEMA = TeamworkConfig
 

--- a/bugwarrior/services/todoist.py
+++ b/bugwarrior/services/todoist.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 
 class TodoistConfig(config.ServiceConfig):
     service: typing.Literal["todoist"]
+    KEYRING_SERVICE = "todoist://"
     token: str
     filter: str = "(view all)"
     import_labels_as_tags: bool = False
@@ -206,10 +207,6 @@ class TodoistService(Service[TodoistIssue]):
         log.info(f"Using Todoist filter: {filter}")
 
         self.client = TodoistClient(token=self.token, filter=filter)
-
-    @staticmethod
-    def get_keyring_service(config: TodoistConfig) -> str:
-        return "todoist://"
 
     def annotations(
         self, user_index: dict[Any, str], issue: dict[str, Any]

--- a/bugwarrior/services/todoist.py
+++ b/bugwarrior/services/todoist.py
@@ -183,7 +183,7 @@ class TodoistIssue(Issue):
 
 
 class TodoistService(Service[TodoistIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = TodoistIssue
     CONFIG_SCHEMA = TodoistConfig
 

--- a/bugwarrior/services/trac.py
+++ b/bugwarrior/services/trac.py
@@ -17,6 +17,7 @@ log = logging.getLogger(__name__)
 
 class TracConfig(config.ServiceConfig):
     service: typing.Literal['trac']
+    KEYRING_SERVICE = "https://{username}@{base_uri}/"
     base_uri: config.NoSchemeUrl
 
     scheme: str = 'https'
@@ -100,10 +101,6 @@ class TracService(Service[TracIssue]):
             self.trac = None
         else:
             self.trac = offtrac.TracServer(uri + 'login/xmlrpc')
-
-    @staticmethod
-    def get_keyring_service(config: TracConfig) -> str:
-        return f"https://{config.username}@{config.base_uri}/"
 
     def annotations(self, issue: dict[str, Any]) -> list[str]:
         annotations = []

--- a/bugwarrior/services/trac.py
+++ b/bugwarrior/services/trac.py
@@ -79,7 +79,7 @@ class TracIssue(Issue):
 
 
 class TracService(Service[TracIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = TracIssue
     CONFIG_SCHEMA = TracConfig
     trac: offtrac.TracServer | None

--- a/bugwarrior/services/trello.py
+++ b/bugwarrior/services/trello.py
@@ -87,7 +87,7 @@ class TrelloIssue(Issue):
 
 
 class TrelloService(Service[TrelloIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = TrelloIssue
     CONFIG_SCHEMA = TrelloConfig
 

--- a/bugwarrior/services/trello.py
+++ b/bugwarrior/services/trello.py
@@ -18,6 +18,7 @@ from bugwarrior.services import Client, Issue, Service
 
 class TrelloConfig(config.ServiceConfig):
     service: typing.Literal['trello']
+    KEYRING_SERVICE = "trello://{api_key}@trello.com"
     api_key: str
     token: str
 
@@ -89,10 +90,6 @@ class TrelloService(Service[TrelloIssue]):
     API_VERSION = 1.0
     ISSUE_CLASS = TrelloIssue
     CONFIG_SCHEMA = TrelloConfig
-
-    @staticmethod
-    def get_keyring_service(config: TrelloConfig) -> str:
-        return f"trello://{config.api_key}@trello.com"
 
     def issues(self) -> Iterator[TrelloIssue]:
         """

--- a/bugwarrior/services/youtrack.py
+++ b/bugwarrior/services/youtrack.py
@@ -111,7 +111,7 @@ class YoutrackIssue(Issue):
 
 
 class YoutrackService(Service[YoutrackIssue]):
-    API_VERSION = 1.0
+    API_VERSION = 2.0
     ISSUE_CLASS = YoutrackIssue
     CONFIG_SCHEMA = YoutrackConfig
 

--- a/bugwarrior/services/youtrack.py
+++ b/bugwarrior/services/youtrack.py
@@ -15,6 +15,7 @@ log = logging.getLogger(__name__)
 
 class YoutrackConfig(config.ServiceConfig):
     service: typing.Literal['youtrack']
+    KEYRING_SERVICE = "youtrack://{login}@{host}"
     host: config.NoSchemeUrl
     login: str
     token: str
@@ -129,10 +130,6 @@ class YoutrackService(Service[YoutrackIssue]):
 
         token = self.get_secret('token', self.config.login)
         self.session.headers['Authorization'] = f'Bearer {token}'
-
-    @staticmethod
-    def get_keyring_service(config: YoutrackConfig) -> str:
-        return f"youtrack://{config.login}@{config.host}"
 
     def issues(self) -> Iterator[YoutrackIssue]:
         params = {

--- a/tests/base.py
+++ b/tests/base.py
@@ -34,7 +34,7 @@ class DumbIssue(services.Issue):
 
 
 class DumbService(services.Service):
-    API_VERSION = 1.0
+    API_VERSION = services.LATEST_API_VERSION
     ISSUE_CLASS = DumbIssue
     CONFIG_SCHEMA = DumbConfig
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -15,6 +15,7 @@ from bugwarrior.config.load import format_config
 
 class DumbConfig(config.ServiceConfig):
     service: typing.Literal["test"] = "test"
+    KEYRING_SERVICE = 'test://'
 
     import_labels_as_tags: bool = False
     label_template: str = "{{label}}"
@@ -36,10 +37,6 @@ class DumbService(services.Service):
     API_VERSION = 1.0
     ISSUE_CLASS = DumbIssue
     CONFIG_SCHEMA = DumbConfig
-
-    @staticmethod
-    def get_keyring_service(_):
-        raise NotImplementedError
 
     def get_owner(self, _):
         raise NotImplementedError

--- a/tests/test_clickup.py
+++ b/tests/test_clickup.py
@@ -169,9 +169,9 @@ class TestClickupService(ConfigTest):
         service = get_service_instances(conf)[0]
         return service
 
-    def test_get_keyring_service(self):
+    def test_keyring_service(self):
         conf = self.validate().service_configs[0]
-        self.assertEqual(ClickupService.get_keyring_service(conf), 'clickup://')
+        self.assertEqual(conf.keyring_service, 'clickup://')
 
     def test_is_assigned(self):
         task = self.data.get_task()

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -269,7 +269,7 @@ class TestGithubService(ServiceTest):
     def test_keyring_service(self):
         """Checks that the keyring service name"""
         service_config = GithubConfig(**self.SERVICE_CONFIG, target="myservice")
-        keyring_service = GithubService.get_keyring_service(service_config)
+        keyring_service = service_config.keyring_service
         self.assertEqual("github://tintin@github.com/milou", keyring_service)
 
     def test_keyring_service_host(self):
@@ -277,7 +277,7 @@ class TestGithubService(ServiceTest):
         service_config = GithubConfig(
             **{'host': 'github.example.com'}, **self.SERVICE_CONFIG, target="myservice"
         )
-        keyring_service = GithubService.get_keyring_service(service_config)
+        keyring_service = service_config.keyring_service
         self.assertEqual("github://tintin@github.example.com/milou", keyring_service)
 
     def test_get_repository_from_issue_url__issue(self):

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -531,20 +531,16 @@ class TestGitlabService(ConfigTest):
         }
         return service
 
-    def test_get_keyring_service_default_host(self):
+    def test_keyring_service_default_host(self):
         conf = self.validate()
         conf = conf.service_configs[0]
-        self.assertEqual(
-            GitlabService.get_keyring_service(conf), 'gitlab://foobar@gitlab.com'
-        )
+        self.assertEqual(conf.keyring_service, 'gitlab://foobar@gitlab.com')
 
-    def test_get_keyring_service_custom_host(self):
+    def test_keyring_service_custom_host(self):
         self.config['myservice']['host'] = 'my-git.org'
         conf = self.validate()
         conf = conf.service_configs[0]
-        self.assertEqual(
-            GitlabService.get_keyring_service(conf), 'gitlab://foobar@my-git.org'
-        )
+        self.assertEqual(conf.keyring_service, 'gitlab://foobar@my-git.org')
 
     def test_filter_gitlab_dot_com(self):
         self.config['myservice'].update({'host': 'gitlab.com', 'owned': 'false'})

--- a/tests/test_kanboard.py
+++ b/tests/test_kanboard.py
@@ -34,14 +34,13 @@ class TestKanboardServiceConfig(ConfigTest):
 
         self.assertValidationError('[kb]\npassword  <- Field required')
 
-    def test_get_keyring_service(self):
+    def test_keyring_service(self):
         self.config["kb"].update(
             {"url": "http://example.com/", "username": "myuser", "password": "mypass"}
         )
         service_config = self.validate().service_configs[0]
         self.assertEqual(
-            KanboardService.get_keyring_service(service_config),
-            "kanboard://myuser@example.com",
+            service_config.keyring_service, "kanboard://myuser@example.com"
         )
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -33,9 +33,7 @@ class ServiceBase(ConfigTest):
         service = self.makeService()
         return service.get_issue_for_record({})
 
-    def checkArchitecture(
-        self, klass: abc.ABCMeta, method_allowlist: set[str] | None = None
-    ):
+    def checkArchitecture(self, klass: abc.ABCMeta):
         """
         Bidirectional communication between the base classes and their children
         has been a source of complication as changes to any part of the
@@ -49,14 +47,14 @@ class ServiceBase(ConfigTest):
         """
         base = Path(services.__file__).read_text()
 
-        for method in klass.__abstractmethods__ - (method_allowlist or set()):
+        for method in klass.__abstractmethods__:
             references = re.findall(rf'{method}\(', base)
             self.assertEqual(len(references), 1, references)
 
 
 class TestService(ServiceBase):
     def test_architecture(self):
-        self.checkArchitecture(services.Service, {"get_keyring_service"})
+        self.checkArchitecture(services.Service)
 
     def test_build_annotations_default(self):
         service = self.makeService()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -111,7 +111,7 @@ class TestService(ServiceBase):
 
         service_config = ServiceConfig(service='legacy', target='legacy-target')
         with unittest.mock.patch(
-            'bugwarrior.collect.get_service', lambda _: LegacyService
+            'bugwarrior.config.schema.get_service', lambda _: LegacyService
         ):
             self.assertEqual(service_config.keyring_service, 'legacy://legacy-target')
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -5,7 +5,7 @@ import re
 import unittest.mock
 
 from bugwarrior import services
-from bugwarrior.config import validation
+from bugwarrior.config import ServiceConfig, validation
 from bugwarrior.config.load import format_config
 
 from .base import ConfigTest, DumbService
@@ -100,6 +100,20 @@ class TestService(ServiceBase):
             latest_documented = float(match.groupdict()['version'])
 
         self.assertEqual(latest_documented, services.LATEST_API_VERSION)
+
+    def test_api_v1_keyring_service_backwards_compatibility(self):
+        class LegacyService:
+            API_VERSION = 1.0
+
+            @staticmethod
+            def get_keyring_service(config):
+                return f'legacy://{config.target}'
+
+        service_config = ServiceConfig(service='legacy', target='legacy-target')
+        with unittest.mock.patch(
+            'bugwarrior.collect.get_service', lambda _: LegacyService
+        ):
+            self.assertEqual(service_config.keyring_service, 'legacy://legacy-target')
 
 
 class TestIssue(ServiceBase):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,4 +1,6 @@
+import abc
 import pathlib
+from pathlib import Path
 import re
 import unittest.mock
 
@@ -31,7 +33,9 @@ class ServiceBase(ConfigTest):
         service = self.makeService()
         return service.get_issue_for_record({})
 
-    def checkArchitecture(self, klass):
+    def checkArchitecture(
+        self, klass: abc.ABCMeta, method_allowlist: set[str] | None = None
+    ):
         """
         Bidirectional communication between the base classes and their children
         has been a source of complication as changes to any part of the
@@ -43,17 +47,16 @@ class ServiceBase(ConfigTest):
         appear once. This should ensure that these methods are declared here
         but not called.
         """
-        with open(services.__file__, 'r') as f:
-            base = f.read()
+        base = Path(services.__file__).read_text()
 
-        for method in klass.__abstractmethods__:
-            references = re.findall(rf'def {method}\(', base)
+        for method in klass.__abstractmethods__ - (method_allowlist or set()):
+            references = re.findall(rf'{method}\(', base)
             self.assertEqual(len(references), 1, references)
 
 
 class TestService(ServiceBase):
     def test_architecture(self):
-        self.checkArchitecture(services.Service)
+        self.checkArchitecture(services.Service, {"get_keyring_service"})
 
     def test_build_annotations_default(self):
         service = self.makeService()

--- a/tests/test_trello.py
+++ b/tests/test_trello.py
@@ -3,7 +3,7 @@ import responses
 
 from bugwarrior.collect import TaskConstructor, get_service_instances
 from bugwarrior.config.schema import MainSectionConfig
-from bugwarrior.services.trello import TrelloConfig, TrelloIssue, TrelloService
+from bugwarrior.services.trello import TrelloConfig, TrelloIssue
 
 from .base import ConfigTest, ServiceTest
 
@@ -256,5 +256,5 @@ class TestTrelloService(ConfigTest):
     def test_keyring_service(self):
         """Checks that the keyring service name"""
         conf = self.validate()
-        keyring_service = TrelloService.get_keyring_service(conf.service_configs[0])
+        keyring_service = conf.service_configs[0].keyring_service
         self.assertEqual("trello://XXXX@trello.com", keyring_service)

--- a/tests/test_youtrak.py
+++ b/tests/test_youtrak.py
@@ -14,12 +14,11 @@ class TestYoutrackService(ConfigTest):
             'myservice': {'service': 'youtrack', 'login': 'foobar', 'token': 'XXXXXX'},
         }
 
-    def test_get_keyring_service(self):
+    def test_keyring_service(self):
         self.config['myservice']['host'] = 'youtrack.example.com'
         service_config = self.validate().service_configs[0]
         self.assertEqual(
-            YoutrackService.get_keyring_service(service_config),
-            'youtrack://foobar@youtrack.example.com',
+            service_config.keyring_service, 'youtrack://foobar@youtrack.example.com'
         )
 
 


### PR DESCRIPTION
## First commit
Fix a test in `test_service.py` : since [this commit](https://github.com/GothenburgBitFactory/bugwarrior/commit/a226abd6591093ded6b5cbf2dcf60d5f0deb84bb#diff-d7fb70d71c01e6c6a932249a22ad45e9e8e5dd800f8d9260922b7726ada72402) the test check each abstract method is _defined_ only once, which does not really make sense. I changed it back to check the number of calls, while adding an allowlist for some abstract methods we do want to call from concrete methods. 

An alternative could be to simply remove this test, since we already have an exception


## Second commit
Replace `Service.get_keyring_service` by a `ServiceConfig.KEYRING_SERVICE` string