### PR TITLE
improvements in db.py

### DIFF
--- a/bugwarrior/collect.py
+++ b/bugwarrior/collect.py
@@ -1,7 +1,8 @@
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 import copy
 from functools import cache
 from importlib.metadata import entry_points
+import json
 import logging
 import multiprocessing
 import time
@@ -9,6 +10,8 @@ from typing import TYPE_CHECKING, Any
 
 from jinja2 import Template
 from taskw.task import Task
+
+from bugwarrior.types import CollectedIssue, CollectionErrorData, TaskwarriorData
 
 if TYPE_CHECKING:
     from bugwarrior.config.validation import Config
@@ -81,7 +84,9 @@ def _aggregate_issues(service: "Service", queue: multiprocessing.Queue) -> None:
         log.info(f"Done with [{target}] in {duration}.")
 
 
-def aggregate_issues(conf: "Config", debug: bool) -> Iterator[dict | tuple[str, str]]:
+def aggregate_issues(
+    conf: "Config", debug: bool
+) -> Iterator[CollectedIssue | CollectionErrorData]:
     """Return all issues from every target."""
     log.info("Starting to aggregate remote issues.")
 
@@ -111,8 +116,7 @@ def aggregate_issues(conf: "Config", debug: bool) -> Iterator[dict | tuple[str, 
     while currently_running > 0:
         issue = queue.get(True)
         try:
-            record = TaskConstructor(issue).get_taskwarrior_record()
-            record['target'] = issue.config.target
+            record = TaskConstructor(issue).get_data_to_sync()
             yield record
         except AttributeError:
             if isinstance(issue, tuple):
@@ -120,11 +124,24 @@ def aggregate_issues(conf: "Config", debug: bool) -> Iterator[dict | tuple[str, 
                 completion_type, target = issue
                 if completion_type == SERVICE_FINISHED_ERROR:
                     log.error(f"Aborted [{target}] due to critical error.")
-                    yield ('SERVICE FAILED', target)
+                    yield CollectionErrorData('SERVICE FAILED', target)
                 continue
             raise
 
     log.info("Done aggregating remote issues.")
+
+
+# NOTE: should this be a method of Issue instead ?
+def make_unique_identifier(
+    key_list: Iterable[str], taskwarrior_data: TaskwarriorData
+) -> str:
+    """For a given issue, make an identifier from its unique keys.
+
+    This is not the same as the taskwarrior uuid, which is assigned
+    only once the task is created.
+    """
+    subset = {key: taskwarrior_data[key] for key in key_list}
+    return json.dumps(subset, sort_keys=True)
 
 
 class TaskConstructor:
@@ -152,6 +169,10 @@ class TaskConstructor:
             record['tags'] = []
         if refined:
             record['tags'].extend(self.get_added_tags())
+
+        # Blank priority should mean *no* priority
+        if record['priority'] == '':
+            record['priority'] = None
         return record
 
     def get_template_context(self) -> dict[str, Any]:
@@ -168,3 +189,11 @@ class TaskConstructor:
             elif field == 'description':
                 record['description'] = self.issue.get_default_description()
         return record
+
+    def get_data_to_sync(self) -> CollectedIssue:
+        taskwarrior_data = self.get_taskwarrior_record()
+        return CollectedIssue(
+            taskwarrior_data=taskwarrior_data,
+            identifier=make_unique_identifier(self.issue.UNIQUE_KEY, taskwarrior_data),
+            target=self.issue.config.target,
+        )

--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -1,6 +1,5 @@
 from collections.abc import Iterable, Iterator
 import itertools
-import json
 import logging
 import re
 import subprocess
@@ -11,6 +10,7 @@ from taskw.exceptions import TaskwarriorError
 
 from bugwarrior.collect import get_service
 from bugwarrior.notifications import send_notification
+from bugwarrior.types import CollectedIssue, CollectionErrorData
 
 if TYPE_CHECKING:
     from bugwarrior.config.validation import Config
@@ -44,21 +44,6 @@ def get_managed_task_uuids(
         expected_task_ids = expected_task_ids | set([task['uuid'] for task in tasks])
 
     return expected_task_ids
-
-
-def make_unique_identifier(
-    key_lists: Iterable[list[str]], issue: dict[str, Any]
-) -> str:
-    """For a given issue, make an identifier from its unique keys.
-
-    This is not the same as the taskwarrior uuid, which is assigned
-    only once the task is created.
-    """
-    for key_list in key_lists:
-        if all(key in issue for key in key_list):
-            subset = {key: issue[key] for key in key_list}
-            return json.dumps(subset, sort_keys=True)
-    raise RuntimeError("Could not determine unique identifier for %s" % issue)
 
 
 def find_taskwarrior_uuid(
@@ -247,7 +232,7 @@ def run_hooks(pre_import: list[str]) -> None:
 
 
 def synchronize(
-    issue_generator: Iterable[dict | tuple[str, str]],
+    issue_generator: Iterator[CollectedIssue | CollectionErrorData],
     conf: "Config",
     dry_run: bool = False,
 ) -> None:
@@ -279,27 +264,26 @@ def synchronize(
     }
 
     for issue in issue_generator:
-        if isinstance(issue, tuple):
-            assert issue[0] == 'SERVICE FAILED', (
-                "'issue' should only be a tuple in case of a failure"
-            )
-            successful_config_map.pop(issue[1])
+        if isinstance(issue, CollectionErrorData):
+            successful_config_map.pop(issue.target)
             continue
 
         # De-duplicate issues coming in
-        unique_identifier = make_unique_identifier(key_lists, issue)
-        if unique_identifier in issue_map:
-            log.debug(f"Merging tags and skipping. Seen {unique_identifier} of {issue}")
+        if issue.identifier in issue_map:
+            log.debug(f"Merging tags and skipping. Seen {issue.identifier} of {issue}")
             # Merge and deduplicate tags.
-            issue_map[unique_identifier]['tags'] += issue['tags']
-            issue_map[unique_identifier]['tags'] = list(
-                set(issue_map[unique_identifier]['tags'])
+            # NOTE: as taskwarrior handle them as a set (ordered), we could do the same
+            new_tags = sorted(
+                set(issue_map[issue.identifier].taskwarrior_data['tags'])
+                | set(issue.taskwarrior_data['tags'])
             )
+            issue_map[issue.identifier].taskwarrior_data['tags'] = new_tags
+
         else:
-            issue_map[unique_identifier] = issue
+            issue_map[issue.identifier] = issue
 
     seen_uuids = set()
-    for issue in issue_map.values():
+    for issue, target, _ in issue_map.values():
         # We received this issue from The Internet, but we're not sure what
         # kind of encoding the service providers may have handed us. Let's try
         # and decode all byte strings from UTF8 off the bat.  If we encounter
@@ -312,12 +296,8 @@ def synchronize(
                 except UnicodeDecodeError:
                     log.warning("Failed to interpret %r as utf-8" % key)
 
-        # Blank priority should mean *no* priority
-        if issue['priority'] == '':
-            issue['priority'] = None
-
         # Target was only tacked on to pass configuration to this function.
-        service_config = successful_config_map[issue.pop('target')]
+        service_config = successful_config_map[target]
 
         try:
             existing_taskwarrior_uuid = find_taskwarrior_uuid(tw, key_lists, issue)

--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -30,25 +30,6 @@ def get_normalized_annotation(annotation: str) -> str:
     return re.sub(r'[\W_]', '', str(annotation))
 
 
-def get_annotation_hamming_distance(left: str, right: str) -> int:
-    left = get_normalized_annotation(left)
-    right = get_normalized_annotation(right)
-    if len(left) > len(right):
-        left = left[0 : len(right)]
-    elif len(right) > len(left):
-        right = right[0 : len(left)]
-    return hamdist(left, right)
-
-
-def hamdist(str1: str, str2: str) -> int:
-    """Count the # of differences between equal length strings str1 and str2"""
-    diffs = 0
-    for ch1, ch2 in zip(str1, str2):
-        if ch1 != ch2:
-            diffs += 1
-    return diffs
-
-
 def get_managed_task_uuids(
     tw: TaskWarriorShellout, key_list: dict[str, list[str]]
 ) -> set[str]:
@@ -234,7 +215,11 @@ def merge_left(
         for local in local_field:
             if (
                 # For annotations, they don't have to match *exactly*.
-                (hamming and get_annotation_hamming_distance(remote, local) == 0)
+                (
+                    hamming
+                    and get_normalized_annotation(remote)
+                    == get_normalized_annotation(local)
+                )
                 # But for everything else, they should.
                 or (remote == local)
             ):

--- a/bugwarrior/db.py
+++ b/bugwarrior/db.py
@@ -4,7 +4,7 @@ import json
 import logging
 import re
 import subprocess
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Sequence
 
 from taskw import TaskWarriorShellout
 from taskw.exceptions import TaskwarriorError
@@ -31,13 +31,13 @@ def get_normalized_annotation(annotation: str) -> str:
 
 
 def get_managed_task_uuids(
-    tw: TaskWarriorShellout, key_list: dict[str, list[str]]
+    tw: TaskWarriorShellout, key_lists: Iterable[Iterable[str]]
 ) -> set[str]:
     expected_task_ids = set()
-    for keys in key_list.values():
+    for key_list in key_lists:
         tasks = tw.filter_tasks(
             {
-                'and': [('%s.any' % key, None) for key in keys],
+                'and': [('%s.any' % key, None) for key in key_list],
                 'or': [('status', 'pending'), ('status', 'waiting')],
             }
         )
@@ -46,21 +46,23 @@ def get_managed_task_uuids(
     return expected_task_ids
 
 
-def make_unique_identifier(keys: dict[str, list[str]], issue: dict[str, Any]) -> str:
+def make_unique_identifier(
+    key_lists: Iterable[list[str]], issue: dict[str, Any]
+) -> str:
     """For a given issue, make an identifier from its unique keys.
 
     This is not the same as the taskwarrior uuid, which is assigned
     only once the task is created.
     """
-    for service, key_list in keys.items():
-        if all([key in issue for key in key_list]):
+    for key_list in key_lists:
+        if all(key in issue for key in key_list):
             subset = {key: issue[key] for key in key_list}
             return json.dumps(subset, sort_keys=True)
     raise RuntimeError("Could not determine unique identifier for %s" % issue)
 
 
 def find_taskwarrior_uuid(
-    tw: TaskWarriorShellout, keys: dict[str, list[str]], issue: dict[str, Any]
+    tw: TaskWarriorShellout, key_lists: Iterable[Sequence[str]], issue: dict[str, Any]
 ) -> str:
     """For a given issue issue, find its local taskwarrior UUID.
 
@@ -97,8 +99,8 @@ def find_taskwarrior_uuid(
 
     possibilities = set()
 
-    for service, key_list in keys.items():
-        if any([key in issue for key in key_list]):
+    for key_list in key_lists:
+        if any(key in issue for key in key_list):
             results = tw.filter_tasks(
                 {
                     'and': [("%s.is" % key, issue[key]) for key in key_list],
@@ -250,7 +252,7 @@ def synchronize(
     dry_run: bool = False,
 ) -> None:
     services = [service_config.service for service_config in conf.service_configs]
-    key_list = build_key_list(services)
+    key_lists = build_key_lists(services)
     uda_list = build_uda_config_overrides(services)
 
     if uda_list:
@@ -285,7 +287,7 @@ def synchronize(
             continue
 
         # De-duplicate issues coming in
-        unique_identifier = make_unique_identifier(key_list, issue)
+        unique_identifier = make_unique_identifier(key_lists, issue)
         if unique_identifier in issue_map:
             log.debug(f"Merging tags and skipping. Seen {unique_identifier} of {issue}")
             # Merge and deduplicate tags.
@@ -318,7 +320,7 @@ def synchronize(
         service_config = successful_config_map[issue.pop('target')]
 
         try:
-            existing_taskwarrior_uuid = find_taskwarrior_uuid(tw, key_list, issue)
+            existing_taskwarrior_uuid = find_taskwarrior_uuid(tw, key_lists, issue)
         except MultipleMatches as e:
             log.exception("Multiple matches: %s", str(e))
         except NotFound:  # Create new task
@@ -408,7 +410,7 @@ def synchronize(
     log.debug(f'Closing tasks for succeeding services: {list(successful_config_map)}.')
     succeeded_service_task_uuids = get_managed_task_uuids(
         tw,
-        build_key_list(
+        build_key_lists(
             service_config.service for service_config in successful_config_map.values()
         ),
     )
@@ -455,10 +457,8 @@ def synchronize(
             )
 
 
-def build_key_list(services: Iterable[str]) -> dict[str, list[str]]:
-    return {
-        service: get_service(service).ISSUE_CLASS.UNIQUE_KEY for service in services
-    }
+def build_key_lists(services: Iterable[str]) -> set[tuple[str, ...]]:
+    return {get_service(service).ISSUE_CLASS.UNIQUE_KEY for service in services}
 
 
 def get_defined_udas_as_strings(conf: "Config") -> Iterator[str]:

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -19,6 +19,7 @@ from jinja2 import Template
 import requests
 
 from bugwarrior.config import schema, secrets
+from bugwarrior.types import TaskwarriorData
 
 log = logging.getLogger(__name__)
 
@@ -121,7 +122,7 @@ class Issue(abc.ABC):
         self.extra = extra
 
     @abc.abstractmethod
-    def to_taskwarrior(self) -> dict[str, Any]:
+    def to_taskwarrior(self) -> TaskwarriorData:
         """Transform a foreign record into a taskwarrior dictionary."""
         raise NotImplementedError()
 

--- a/bugwarrior/types.py
+++ b/bugwarrior/types.py
@@ -1,0 +1,14 @@
+from typing import Any, NamedTuple
+
+TaskwarriorData = dict[str, Any]
+
+
+class CollectedIssue(NamedTuple):
+    taskwarrior_data: TaskwarriorData
+    target: str
+    identifier: str
+
+
+class CollectionErrorData(NamedTuple):
+    error_message: str
+    target: str

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -4,6 +4,7 @@ import unittest
 import taskw.task
 
 from bugwarrior import db
+from bugwarrior.types import CollectedIssue
 
 from .base import ConfigTest
 
@@ -71,19 +72,8 @@ class TestReplaceLeft(unittest.TestCase):
 
 
 class TestSynchronize(ConfigTest):
-    def test_synchronize(self):
-        def remove_non_deterministic_keys(tasks):
-            for status in ['pending', 'completed']:
-                for task in tasks[status]:
-                    del task['modified']
-                    del task['entry']
-                    del task['uuid']
-                    task['tags'] = sorted(task['tags'])
-            return tasks
-
-        def get_tasks(tw):
-            return remove_non_deterministic_keys(tw.load_tasks())
-
+    def setUp(self):
+        super().setUp()
         self.config = {
             'general': {
                 'targets': ['my_service'],
@@ -97,10 +87,38 @@ class TestSynchronize(ConfigTest):
                 'token': 'abc123',
             },
         }
-        bwconfig = self.validate()
+        self.bwconfig = self.validate()
+        self.tw = taskw.TaskWarrior(self.taskrc)
 
-        tw = taskw.TaskWarrior(self.taskrc)
-        self.assertEqual(tw.load_tasks(), {'completed': [], 'pending': []})
+    def synchronize(self, issues_data):
+
+        issue_generator = [
+            CollectedIssue(
+                taskwarrior_data=copy.deepcopy(issue_data),
+                target="my_service",
+                identifier="abcd",
+            )
+            for issue_data in issues_data
+        ]
+        db.synchronize(iter(issue_generator), self.bwconfig)
+
+    def remove_non_deterministic_keys(self, tasks):
+        for status in ['pending', 'completed']:
+            for task in tasks[status]:
+                del task['modified']
+                del task['entry']
+                del task['uuid']
+                task['tags'] = sorted(task['tags'])
+
+        return tasks
+
+    def get_tasks(self):
+
+        return self.remove_non_deterministic_keys(self.tw.load_tasks())
+
+    def test_synchronize(self):
+
+        self.assertEqual(self.tw.load_tasks(), {'completed': [], 'pending': []})
 
         issue = {
             'description': 'Blah blah blah. ☃',
@@ -109,7 +127,6 @@ class TestSynchronize(ConfigTest):
             'githuburl': 'https://example.com',
             'priority': 'M',
             'tags': ['foo'],
-            'target': 'my_service',
         }
         duplicate_issue = copy.deepcopy(issue)
         duplicate_issue['tags'] = ['bar']
@@ -120,11 +137,10 @@ class TestSynchronize(ConfigTest):
             # These should be de-duplicated in db.synchronize before
             # writing out to taskwarrior.
             # https://github.com/ralphbean/bugwarrior/issues/601
-            issue_generator = iter((copy.deepcopy(issue), duplicate_issue))
-            db.synchronize(issue_generator, bwconfig)
+            self.synchronize([issue, duplicate_issue])
 
             self.assertEqual(
-                get_tasks(tw),
+                self.get_tasks(),
                 {
                     'completed': [],
                     'pending': [
@@ -148,11 +164,10 @@ class TestSynchronize(ConfigTest):
 
         # Change static field
         issue['project'] = 'other_project'
-
-        db.synchronize(iter((copy.deepcopy(issue),)), bwconfig)
+        self.synchronize([issue])
 
         self.assertEqual(
-            get_tasks(tw),
+            self.get_tasks(),
             {
                 'completed': [],
                 'pending': [
@@ -172,11 +187,11 @@ class TestSynchronize(ConfigTest):
         )
 
         # TEST CLOSED ISSUE.
-        db.synchronize(iter(()), bwconfig)
+        self.synchronize([])
 
-        completed_tasks = tw.load_tasks()
+        completed_tasks = self.tw.load_tasks()
 
-        tasks = remove_non_deterministic_keys(copy.deepcopy(completed_tasks))
+        tasks = self.remove_non_deterministic_keys(copy.deepcopy(completed_tasks))
         del tasks['completed'][0]['end']
         self.assertEqual(
             tasks,
@@ -199,14 +214,14 @@ class TestSynchronize(ConfigTest):
         )
 
         # TEST REOPENED ISSUE
-        db.synchronize(iter((copy.deepcopy(issue),)), bwconfig)
+        self.synchronize([issue])
 
-        tasks = tw.load_tasks()
+        tasks = self.tw.load_tasks()
         self.assertEqual(
             completed_tasks['completed'][0]['uuid'], tasks['pending'][0]['uuid']
         )
 
-        tasks = remove_non_deterministic_keys(tasks)
+        tasks = self.remove_non_deterministic_keys(tasks)
         self.assertEqual(
             tasks,
             {

--- a/tests/test_synchronize_ordering.py
+++ b/tests/test_synchronize_ordering.py
@@ -1,0 +1,107 @@
+import copy
+
+import taskw
+
+from bugwarrior import db
+from bugwarrior.types import CollectedIssue
+
+from .base import ConfigTest
+
+
+class TestSynchronizeOrdering(ConfigTest):
+    def setUp(self):
+        super().setUp()
+        self.config = {
+            'general': {'targets': ['my_service'], 'taskrc': self.taskrc},
+            'my_service': {
+                'service': 'github',
+                'login': 'ralphbean',
+                'username': 'ralphbean',
+                'token': 'abc123',
+            },
+        }
+        self.bwconfig = self.validate()
+        self.tw = taskw.TaskWarrior(self.taskrc)
+
+    @staticmethod
+    def make_github_issue(tags=None, annotations=None):
+        return {
+            'description': 'Synchronized issue',
+            'githubtype': 'issue',
+            'githuburl': 'https://example.com/issue/1',
+            'priority': 'M',
+            'tags': tags or [],
+            'annotations': annotations or [],
+        }
+
+    @staticmethod
+    def annotation_descriptions(task):
+        return [annotation['description'] for annotation in task.get('annotations', [])]
+
+    def synchronize(self, issue):
+        issue_generator = [
+            CollectedIssue(
+                taskwarrior_data=copy.deepcopy(issue),
+                target="my_service",
+                identifier="abcd",
+            )
+        ]
+        db.synchronize(issue_generator, self.bwconfig)
+
+    def get_task(self):
+        return self.tw.load_tasks()['pending'][0]
+
+    def test_create_preserves_annotation_order_and_duplicates(self):
+        """Creating a task preserves remote annotation order and duplicates."""
+        issue = self.make_github_issue(annotations=['first', 'second', 'first'])
+
+        self.synchronize(issue)
+
+        task = self.get_task()
+        assert self.annotation_descriptions(task) == ['first', 'second', 'first']
+
+    def test_update_preserves_existing_annotation_order(self):
+        """Updating a task keeps existing annotations in their stored order."""
+        issue = self.make_github_issue(annotations=['first', 'second', 'first'])
+        self.synchronize(issue)
+
+        issue['annotations'] = ['first', 'third', 'third', 'fourth']
+        self.synchronize(issue)
+
+        task = self.get_task()
+        descriptions = self.annotation_descriptions(task)
+        assert descriptions[:3] == ['first', 'second', 'first']
+        # taskw.task_update uses a set for annotations it creates, so do not
+        # rely on ordering among newly-added annotations.
+        assert sorted(descriptions[3:]) == ['fourth', 'third']
+
+    def test_update_deduplicates_new_annotations_when_none_exist(self):
+        """Updating a task deduplicates new annotations via taskw.task_update."""
+        issue = self.make_github_issue(annotations=[])
+        self.synchronize(issue)
+
+        issue['annotations'] = ['same', 'same', 'other']
+        self.synchronize(issue)
+
+        task = self.get_task()
+        assert sorted(self.annotation_descriptions(task)) == ['other', 'same']
+
+    def test_create_sorts_and_deduplicates_tags(self):
+        """Creating a task stores tags as a sorted unique collection."""
+        issue = self.make_github_issue(tags=['beta', 'alpha', 'beta'])
+
+        self.synchronize(issue)
+
+        task = self.get_task()
+        assert task['tags'] == ['alpha', 'beta']
+
+    def test_update_sorts_and_deduplicates_tags(self):
+        """Updating a task keeps tags sorted and deduplicated."""
+        issue = self.make_github_issue(tags=['beta', 'alpha', 'beta'])
+        self.synchronize(issue)
+
+        issue['tags'] = ['delta', 'alpha', 'delta', 'gamma']
+        self.synchronize(issue)
+
+        task = self.get_task()
+        assert task['tags'] == ['alpha', 'beta', 'delta', 'gamma']


### PR DESCRIPTION
I've started looking at db.py to prepare for #1077 and #1078 
I've removed some unused code and simplified some logic. 

There are two improvements I have not implemented yet, because I think it's worth discussing it @ryneeverett 
* the smaller one: `merge_left` / `replace_left`, and duplication / ordering
    *  on `tags`, but taskwarrior treats them as a simple (ordered) set, so I don't really understand why we can simply do `local["tags"] |= remote["tags"]` (merge) / `local["tags"] = remote["tags"]` (replace), and order them if needed. 
    *  on `annotations` the tests I added in `tests/test_synchronize_ordering.py` also show that deduplication and ordering are inconsistent, because `taskwarrior` consider them as a normal list, but `taskw` uses a set. Depending on task creation / update, we could end up with duplicates or not, ordered or not. My suggestion would be to always treat them as set (as `taskw` does), I don't see a good use case for annotation duplication, but maybe I'm wrong. 
  
* bigger one: all functions involving `key_lists` rely on finding issues in DB based on the UDAs that identify them (defined by `UNIQUE_KEY`. I see multiple issues with that

   * the queries to retrieve a single issue from taskwarrior (`find_taskwarrior_uuid`), or all of them (`get_managed_task_uuids`) are complex (especially the first one). As we already compute a bugwarrior identifier, why can't we store it as a UDA (hashing it first) for all tasks created by bugwarrior ? Retrieving a single issue from taskwarrior (or all of them) would be much simpler and straightforward. 
   
   * I'm not sure about this one, but if I understand correctly, the current behavior also explains why each service needs to have specific UDAs (`githuburl`, `gitlaburl`, `linearurl`...). Wouldn't it be cleaner to have more generic UDAs (`url` in that case) ? The `UNIQUE_KEY` tuple could simply contain the `target` / `service` (depending on whether we want to consider  duplicated issues across targets from the same service as actual duplicates or not) to ensure the identifier is indeed unique. We probably can't change this overnight, but I still think we should consider the idea
  
   *  This behavior in case of multiple targets using the same service (e.g. in my own config, multiple Gmail targets) is not explicit: should we consider duplicated issues from multiple targets as the same one (currently the case, based on `make_identifier`) or not ? 