### PR TITLE
taiga: import due dates

### DIFF
--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -36,7 +36,7 @@ class TaigaIssue(Issue):
     UNIQUE_KEY = (URL,)
 
     def to_taskwarrior(self) -> dict[str, Any]:
-        task = {
+        return {
             'project': self.extra['project'],
             'annotations': self.extra['annotations'],
             self.URL: self.extra['url'],
@@ -44,12 +44,8 @@ class TaigaIssue(Issue):
             'tags': self.get_tags(),
             self.FOREIGN_ID: self.record['ref'],
             self.SUMMARY: self.record['subject'],
+            'due': self.parse_date(self.record.get('due_date'))
         }
-
-        if self.record.get('due_date'):
-            task['due'] = self.parse_date(self.record['due_date'])
-
-        return task
 
     def get_tags(self) -> list[str]:
         return [x if isinstance(x, str) else x[0] for x in self.record['tags']]

--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -44,7 +44,7 @@ class TaigaIssue(Issue):
             'tags': self.get_tags(),
             self.FOREIGN_ID: self.record['ref'],
             self.SUMMARY: self.record['subject'],
-            'due': self.parse_date(self.record.get('due_date'))
+            'due': self.parse_date(self.record.get('due_date')),
         }
 
     def get_tags(self) -> list[str]:

--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -35,19 +35,19 @@ class TaigaIssue(Issue):
     }
     UNIQUE_KEY = (URL,)
 
-    def to_taskwarrior(self):
+    def to_taskwarrior(self) -> dict[str, Any]:
         task = {
-            "project": self.extra["project"],
-            "annotations": self.extra["annotations"],
-            self.URL: self.extra["url"],
-            "priority": self.config.default_priority,
-            "tags": self.get_tags(),
-            self.FOREIGN_ID: self.record["ref"],
-            self.SUMMARY: self.record["subject"],
+            'project': self.extra['project'],
+            'annotations': self.extra['annotations'],
+            self.URL: self.extra['url'],
+            'priority': self.config.default_priority,
+            'tags': self.get_tags(),
+            self.FOREIGN_ID: self.record['ref'],
+            self.SUMMARY: self.record['subject'],
         }
 
-        if self.record.get("due_date"):
-            task["due"] = self.parse_date(self.record["due_date"])
+        if self.record.get('due_date'):
+            task['due'] = self.parse_date(self.record['due_date'])
 
         return task
 

--- a/bugwarrior/services/taiga.py
+++ b/bugwarrior/services/taiga.py
@@ -35,16 +35,21 @@ class TaigaIssue(Issue):
     }
     UNIQUE_KEY = (URL,)
 
-    def to_taskwarrior(self) -> dict[str, Any]:
-        return {
-            'project': self.extra['project'],
-            'annotations': self.extra['annotations'],
-            self.URL: self.extra['url'],
-            'priority': self.config.default_priority,
-            'tags': self.get_tags(),
-            self.FOREIGN_ID: self.record['ref'],
-            self.SUMMARY: self.record['subject'],
+    def to_taskwarrior(self):
+        task = {
+            "project": self.extra["project"],
+            "annotations": self.extra["annotations"],
+            self.URL: self.extra["url"],
+            "priority": self.config.default_priority,
+            "tags": self.get_tags(),
+            self.FOREIGN_ID: self.record["ref"],
+            self.SUMMARY: self.record["subject"],
         }
+
+        if self.record.get("due_date"):
+            task["due"] = self.parse_date(self.record["due_date"])
+
+        return task
 
     def get_tags(self) -> list[str]:
         return [x if isinstance(x, str) else x[0] for x in self.record['tags']]

--- a/tests/test_taiga.py
+++ b/tests/test_taiga.py
@@ -18,7 +18,7 @@ class TestTaigaIssue(AbstractServiceTest, ServiceTest):
         'ref': 40,
         'subject': 'this is a title',
         'tags': ['single', ['bugwarrior', None], ['task', '#c0ffee']],
-        'due_date': '2026-05-18'
+        'due_date': '2026-05-18',
     }
 
     def setUp(self):
@@ -44,7 +44,7 @@ class TestTaigaIssue(AbstractServiceTest, ServiceTest):
             'taigaid': 40,
             'taigasummary': 'this is a title',
             'taigaurl': 'this is a url',
-            'due': issue.parse_date('2026-05-18')
+            'due': issue.parse_date('2026-05-18'),
         }
 
         self.assertEqual(actual, expected)
@@ -83,7 +83,7 @@ class TestTaigaIssue(AbstractServiceTest, ServiceTest):
             'taigaid': 40,
             'taigasummary': 'this is a title',
             'taigaurl': 'https://one/project/something/us/40',
-            'due': issue.parse_date('2026-05-18')
+            'due': issue.parse_date('2026-05-18'),
         }
 
         self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)

--- a/tests/test_taiga.py
+++ b/tests/test_taiga.py
@@ -18,6 +18,7 @@ class TestTaigaIssue(AbstractServiceTest, ServiceTest):
         'ref': 40,
         'subject': 'this is a title',
         'tags': ['single', ['bugwarrior', None], ['task', '#c0ffee']],
+        'due_date': '2026-05-18'
     }
 
     def setUp(self):
@@ -43,6 +44,7 @@ class TestTaigaIssue(AbstractServiceTest, ServiceTest):
             'taigaid': 40,
             'taigasummary': 'this is a title',
             'taigaurl': 'this is a url',
+            'due': issue.parse_date('2026-05-18')
         }
 
         self.assertEqual(actual, expected)
@@ -81,6 +83,7 @@ class TestTaigaIssue(AbstractServiceTest, ServiceTest):
             'taigaid': 40,
             'taigasummary': 'this is a title',
             'taigaurl': 'https://one/project/something/us/40',
+            'due': issue.parse_date('2026-05-18')
         }
 
         self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)


### PR DESCRIPTION
Taiga exposes a due_date field for user stories/tasks, but the Taiga service did not map it to Taskwarrior's native due field.

This patch imports due_date using the existing Issue.parse_date() helper, inspired in the pattern used by other services such as Trello. Includes tests.