### PR TITLE
fix typing errors coming from requests==2.34.2

### DIFF
--- a/bugwarrior/services/azuredevops.py
+++ b/bugwarrior/services/azuredevops.py
@@ -50,11 +50,13 @@ class AzureDevopsClient(Client):
         self.host = host
         self.base_url = f"https://{host}/{org}/{project}/_apis/wit"
         self.session = requests.Session()
-        self.session.headers = {
-            "authorization": f"Basic {self.pat}",
-            "accept": "application/json",
-            "content-type": "application/json",
-        }
+        self.session.headers.update(
+            {
+                "authorization": f"Basic {self.pat}",
+                "accept": "application/json",
+                "content-type": "application/json",
+            }
+        )
         self.params = {"api-version": "6.0-preview.2"}
 
     def get_work_item(self, workitemid: str | int) -> dict[str, Any]:

--- a/bugwarrior/services/trac.py
+++ b/bugwarrior/services/trac.py
@@ -158,7 +158,7 @@ class TracService(Service[TracIssue]):
                 raise RuntimeError("Trac responded with %s" % resp)
             # strip Trac's bogus BOM
             text = resp.text[1:].lstrip('\ufeff')
-            tickets = list(csv.DictReader(StringIO.StringIO(text.encode('utf-8'))))
+            tickets = list(csv.DictReader(StringIO.StringIO(text)))
             issues = [(self.config.target, ticket) for ticket in tickets]
             for i in range(len(issues)):
                 issues[i][1]['url'] = "%s/ticket/%s" % (base_url, tickets[i]['id'])


### PR DESCRIPTION
Fix typing issue related to https://github.com/GothenburgBitFactory/bugwarrior/pull/1211

The error appeared with recent version of `requests`, which has better typing

One related question: why don't we commit the `uv.lock` file ? bugwarrior is a standalone CLI, not a shared library, so is there a good reason not to pin all dependencies for users ? Right now, if a dependency upgrade breaks something, it's not easily detectable. We could also pin the dependencies in pyproject.toml, but it's not as easy to upgrade as a single `uv lock --upgrade`