### PR TITLE
Simplify get_tags_from_labels

### DIFF
--- a/bugwarrior/docs/other-services/api.rst
+++ b/bugwarrior/docs/other-services/api.rst
@@ -26,3 +26,5 @@ v2.0
   define ``KEYRING_SERVICE`` instead.
 - Added ``ServiceConfig.KEYRING_SERVICE`` as a format string for generating the
   keyring service identifier from service configuration fields.
+- Added ``Issue.render_tags_from_labels(labels)`` for rendering taskwarrior tags
+  from service labels with ``label_template``.

--- a/bugwarrior/docs/services/pagure.rst
+++ b/bugwarrior/docs/services/pagure.rst
@@ -70,12 +70,12 @@ Import Labels as Tags
 
 The Pagure issue tracker allows you to attach tags to issues; to
 use those pagure tags as taskwarrior tags, you can use the
-``import_tags`` option:
+``import_labels_as_tags`` option:
 
 .. config::
     :fragment: pagure
 
-    pagure.import_tags = True
+    pagure.import_labels_as_tags = True
 
 Also, if you would like to control how these taskwarrior tags are created, you
 can specify a template used for converting the Pagure tag into a Taskwarrior
@@ -88,7 +88,7 @@ add the following configuration option:
 .. config::
     :fragment: pagure
 
-    pagure.tag_template = pagure_{{label}}
+    pagure.label_template = pagure_{{label}}
 
 In addition to the context variable ``{{label}}``, you also have access
 to all fields on the Taskwarrior task if needed.

--- a/bugwarrior/docs/services/youtrack.rst
+++ b/bugwarrior/docs/services/youtrack.rst
@@ -110,7 +110,7 @@ to tasks by default. To disable this behavior, set:
 .. config::
     :fragment: youtrack
 
-    youtrack.import_tags = False
+    youtrack.import_labels_as_tags = False
 
 If you would like to control how these tags are formatted, you can
 specify a template used for converting the YouTrack tag into a Taskwarrior
@@ -123,9 +123,9 @@ add the following configuration option:
 .. config::
     :fragment: youtrack
 
-    youtrack.tag_template = yt_{{tag|lower}}
+    youtrack.label_template = yt_{{label|lower}}
 
-In addition to the context variable ``{{tag}}``, you also have access
+In addition to the context variable ``{{label}}``, you also have access
 to all fields on the Taskwarrior task if needed.
 
 .. note::

--- a/bugwarrior/services/__init__.py
+++ b/bugwarrior/services/__init__.py
@@ -134,6 +134,16 @@ class Issue(abc.ABC):
         """
         raise NotImplementedError()
 
+    def render_tags_from_labels(self, labels: list[str]) -> list[str]:
+        """Transform labels into suitable taskwarrior tags using the label template."""
+
+        return [
+            Template(self.config.label_template).render(
+                {**self.record, "label": re.sub(r'[^a-zA-Z0-9]', '_', label)}
+            )
+            for label in labels
+        ]
+
     def get_tags_from_labels(
         self,
         labels: list[str],
@@ -141,23 +151,29 @@ class Issue(abc.ABC):
         template_option: str = 'label_template',
         template_variable: str = 'label',
     ) -> list[str]:
-        """Transform labels into suitable taskwarrior tags, respecting configuration options.
-
-        :param `labels`: Returned from the service.
-        :param `toggle_option`: Option which, if false, would not import labels as tags.
-        :param `template_option`: Configuration to use as the
-            :ref:`field template<common_configuration:Field Templates>` for each label.
-        :param `template_variable`: Name to use in the
-            :ref:`field template<common_configuration:Field Templates>` context to refer to the
-            label.
-        """
-        tags: list[str] = []
+        """Transform labels into suitable taskwarrior tags, respecting configuration options."""
+        using_deprecated_parameters = (
+            toggle_option != 'import_labels_as_tags'
+            or template_option != 'label_template'
+            or template_variable != 'label'
+        )
+        if using_deprecated_parameters:
+            log.warning(
+                "Deprecation Warning: Issue.get_tags_from_labels's toggle_option, "
+                "template_option, and template_variable parameters are deprecated and "
+                "will be removed in a future API version."
+            )
 
         if not getattr(self.config, toggle_option):
-            return tags
+            return []
 
+        if not using_deprecated_parameters:
+            return self.render_tags_from_labels(labels)
+
+        # deprecated path, to be removed once we remove the deprecated parameters.
         context = self.record.copy()
         label_template = Template(getattr(self.config, template_option))
+        tags = []
 
         for label in labels:
             normalized_label = re.sub(r'[^a-zA-Z0-9]', '_', label)

--- a/bugwarrior/services/jira.py
+++ b/bugwarrior/services/jira.py
@@ -236,8 +236,10 @@ class JiraIssue(Issue):
         label_tags = self.get_tags_from_labels(labels)
 
         sprints = [sprint['name'] for sprint in self.__get_sprints()]
-        sprint_tags = self.get_tags_from_labels(
-            sprints, toggle_option='import_sprints_as_tags'
+        sprint_tags = (
+            self.render_tags_from_labels(sprints)
+            if self.config.import_sprints_as_tags
+            else []
         )
 
         return label_tags + sprint_tags

--- a/bugwarrior/services/pagure.py
+++ b/bugwarrior/services/pagure.py
@@ -4,7 +4,7 @@ import logging
 import typing
 from typing import Any
 
-from pydantic import model_validator
+from pydantic import AliasChoices, Field, model_validator
 import requests
 
 from bugwarrior import config
@@ -25,8 +25,25 @@ class PagureConfig(config.ServiceConfig):
     # optional
     include_repos: config.ConfigList = []
     exclude_repos: config.ConfigList = []
-    import_tags: bool = False
-    tag_template: str = '{{label}}'
+    import_labels_as_tags: bool = Field(
+        False, validation_alias=AliasChoices('import_labels_as_tags', 'import_tags')
+    )
+    label_template: str = Field(
+        '{{label}}', validation_alias=AliasChoices('label_template', 'tag_template')
+    )
+
+    @model_validator(mode='before')
+    @classmethod
+    def deprecate_legacy_tag_options(cls, values: Any) -> Any:
+        if not isinstance(values, dict):
+            return values
+
+        if 'import_tags' in values:
+            log.warning('import_tags is deprecated in favor of import_labels_as_tags')
+        if 'tag_template' in values:
+            log.warning('tag_template is deprecated in favor of label_template')
+
+        return values
 
     @model_validator(mode='after')
     def require_tag_or_repo(self) -> "PagureConfig":
@@ -75,11 +92,7 @@ class PagureIssue(Issue):
         }
 
     def get_tags(self) -> list[str]:
-        return self.get_tags_from_labels(
-            self.record.get('tags', []),
-            toggle_option='import_tags',
-            template_option='tag_template',
-        )
+        return self.get_tags_from_labels(self.record.get('tags', []))
 
     def get_default_description(self) -> str:
         return self.build_default_description(

--- a/bugwarrior/services/youtrack.py
+++ b/bugwarrior/services/youtrack.py
@@ -3,7 +3,13 @@ import logging
 import typing
 from typing import Any
 
-from pydantic import computed_field
+from pydantic import (
+    AliasChoices,
+    Field,
+    computed_field,
+    field_validator,
+    model_validator,
+)
 import requests
 import urllib3
 
@@ -27,11 +33,41 @@ class YoutrackConfig(config.ServiceConfig):
     incloud_instance: bool = False
     query: str = 'for:me #Unresolved'
     query_limit: int = 100
-    import_tags: bool = True
-    tag_template: str = '{{tag|lower}}'
+    import_labels_as_tags: bool = Field(
+        True, validation_alias=AliasChoices('import_labels_as_tags', 'import_tags')
+    )
+    label_template: str = Field(
+        '{{label|lower}}',
+        validation_alias=AliasChoices('label_template', 'tag_template'),
+    )
 
     only_if_assigned: config.UnsupportedOption[str] = ''
     also_unassigned: config.UnsupportedOption[bool] = False
+
+    @model_validator(mode='before')
+    @classmethod
+    def deprecate_legacy_tag_options(cls, values: Any) -> Any:
+        if not isinstance(values, dict):
+            return values
+
+        if 'import_tags' in values:
+            log.warning('import_tags is deprecated in favor of import_labels_as_tags')
+        if 'tag_template' in values:
+            log.warning('tag_template is deprecated in favor of label_template')
+
+        template = values.get('label_template', values.get('tag_template'))
+        if isinstance(template, str) and 'tag' in template:
+            log.warning(
+                "The 'tag' variable in YouTrack label templates is deprecated "
+                "in favor of 'label'."
+            )
+
+        return values
+
+    @field_validator('label_template', mode='after')
+    @classmethod
+    def migrate_legacy_tag_template(cls, value: str) -> str:
+        return value.replace('tag', 'label')
 
     @computed_field
     @property
@@ -103,10 +139,7 @@ class YoutrackIssue(Issue):
 
     def get_tags(self) -> list[str]:
         return self.get_tags_from_labels(
-            [tag['name'] for tag in self.record.get('tags', [])],
-            toggle_option='import_tags',
-            template_option='tag_template',
-            template_variable='tag',
+            [tag['name'] for tag in self.record.get('tags', [])]
         )
 
 

--- a/tests/test_pagure.py
+++ b/tests/test_pagure.py
@@ -1,0 +1,54 @@
+from bugwarrior.collect import TaskConstructor
+from bugwarrior.config import schema
+from bugwarrior.services.pagure import PagureIssue, PagureService
+
+from .base import ServiceTest
+
+
+class TestPagureIssue(ServiceTest):
+    arbitrary_issue = {
+        'html_url': 'https://pagure.io/repo/issue/1',
+        'repo': 'repo',
+        'title': 'Hello World',
+        'id': 1,
+        'date_created': '0',
+        'tags': ['Bug', 'Needs Work'],
+    }
+    arbitrary_extra = {'type': 'issue', 'project': 'repo'}
+
+    def get_issue(self):
+        service_config = PagureService.CONFIG_SCHEMA(
+            service='pagure',
+            target='pagure',
+            base_url='https://pagure.io',
+            repo='repo',
+            import_tags=True,
+            tag_template='pg_{{label}}',
+        )
+        main_config = schema.MainSectionConfig(
+            targets=['pagure'], annotation_length=100, description_length=100
+        )
+        return PagureIssue(
+            self.arbitrary_issue, service_config, main_config, self.arbitrary_extra
+        )
+
+    def test_get_tags_from_labels_uses_legacy_tag_options(self):
+        issue = self.get_issue()
+
+        self.assertEqual(issue.get_tags(), ['pg_Bug', 'pg_Needs_Work'])
+        self.assertIn(
+            'import_tags is deprecated in favor of import_labels_as_tags',
+            self.caplog.text,
+        )
+        self.assertIn(
+            'tag_template is deprecated in favor of label_template', self.caplog.text
+        )
+
+    def test_refine_record_does_not_apply_legacy_tag_template_as_field_template(self):
+        issue = self.get_issue()
+
+        self.assertEqual(issue.config.templates, {})
+        self.assertEqual(
+            TaskConstructor(issue).get_taskwarrior_record()['tags'],
+            ['pg_Bug', 'pg_Needs_Work'],
+        )

--- a/tests/test_youtrak.py
+++ b/tests/test_youtrak.py
@@ -49,6 +49,40 @@ class TestYoutrackIssue(AbstractServiceTest, ServiceTest):
         super().setUp()
         self.service = self.get_mock_service(YoutrackService)
 
+    def test_get_tags_from_labels_uses_legacy_tag_options(self):
+        service = self.get_mock_service(
+            YoutrackService,
+            config_overrides={'import_tags': True, 'tag_template': 'yt_{{tag|lower}}'},
+        )
+        issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
+
+        self.assertEqual(service.config.label_template, 'yt_{{label|lower}}')
+        self.assertEqual(issue.get_tags(), ['yt_bug', 'yt_new_feature'])
+        self.assertIn(
+            'import_tags is deprecated in favor of import_labels_as_tags',
+            self.caplog.text,
+        )
+        self.assertIn(
+            'tag_template is deprecated in favor of label_template', self.caplog.text
+        )
+        self.assertIn(
+            "The 'tag' variable in YouTrack label templates is deprecated in favor of 'label'.",
+            self.caplog.text,
+        )
+
+    def test_refine_record_does_not_apply_legacy_tag_template_as_field_template(self):
+        service = self.get_mock_service(
+            YoutrackService,
+            config_overrides={'import_tags': True, 'tag_template': 'yt_{{tag|lower}}'},
+        )
+        issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
+
+        self.assertEqual(service.config.templates, {})
+        self.assertEqual(
+            TaskConstructor(issue).get_taskwarrior_record()['tags'],
+            ['yt_bug', 'yt_new_feature'],
+        )
+
     def test_to_taskwarrior(self):
         self.service.import_tags = True
         issue = self.service.get_issue_for_record(


### PR DESCRIPTION
A few services were not using the default parameter names for the `get_tags_from_labels` (pagure and youtrack)

I changed the config param names for those service, while allowing multiple aliases, to ensure backward compatibility. 

This allows for a much simpler `get_tags_from_labels`, only parameters being the labels and the config. 
We could even consider moving this function outside the `Service` class, since it does not depend on the Service subclass (or this could be a `ServiceConfig` method instead). 