### PR TITLE
Drop python 310

### DIFF
--- a/.github/workflows/bugwarrior.yml
+++ b/.github/workflows/bugwarrior.yml
@@ -41,7 +41,9 @@ jobs:
 
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install --upgrade "pip>=25.1" setuptools
+          pip install --upgrade "pip>=26.1"
+          pip config --site set install.uploaded-prior-to P3D
+          pip install --upgrade setuptools
 
           pip install -e ".[all]"
           pip install --group test
@@ -80,7 +82,9 @@ jobs:
             mkdir .venv
             python3 -m venv .venv
             source .venv/bin/activate
-            pip install --upgrade "pip>=25.1" setuptools
+            pip install --upgrade "pip>=26.1"
+            pip config --site set install.uploaded-prior-to P3D
+            pip install --upgrade setuptools
 
             pip install -e .[all]
             pip install --group test

--- a/.github/workflows/bugwarrior.yml
+++ b/.github/workflows/bugwarrior.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: ["3.10", 3.11, 3.12, 3.13, 3.14]
+        python-version: [3.11, 3.12, 3.13, 3.14]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ sphinx:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
   jobs:
     pre_create_environment:
       - asdf plugin add uv

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+Unreleased
+----------
+
+Dependency Updates
+==================
+
+- Drop python-3.10 support.
+- Drop tomli.
+
 2.1.0
 -----
 

--- a/bugwarrior/config/load.py
+++ b/bugwarrior/config/load.py
@@ -2,13 +2,8 @@ import configparser
 import logging
 import os
 from pathlib import Path
-import sys
+import tomllib
 from typing import Any
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
 
 from .validation import Config, validate_config
 

--- a/bugwarrior/docs/_ext/extras.py
+++ b/bugwarrior/docs/_ext/extras.py
@@ -1,13 +1,8 @@
 import pathlib
-import sys
+import tomllib
 
 from docutils import nodes
 from sphinx.util.docutils import SphinxDirective
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
 
 
 class Extras(SphinxDirective):

--- a/bugwarrior/docs/contributing.rst
+++ b/bugwarrior/docs/contributing.rst
@@ -19,14 +19,20 @@ Now use your favorite tool to attain an editable installation.
 
 .. tab:: pip
 
-   Requires pip >= 25.1 for `dependency group <https://peps.python.org/pep-0735/>`_ support.
+   Requires pip >= 26.1 for `dependency group <https://peps.python.org/pep-0735/>`_
+   support and ``--uploaded-prior-to`` duration support. The commands below
+   configure the virtual environment's pip installation to use the same ``P3D``
+   dependency cooldown as the uv ``exclude-newer = "3 days"`` setting in
+   ``pyproject.toml``.
 
    .. code-block:: bash
 
     $ mkdir .venv
     $ python -m venv .venv
     $ source .venv/bin/activate
-    $ pip install --upgrade "pip>=25.1"
+    $ pip install --upgrade "pip>=26.1"
+    $ pip config --site set install.uploaded-prior-to P3D
+    $ pip install --upgrade setuptools
     $ pip install -e .[all]
     $ pip install --group test
 

--- a/bugwarrior/services/azuredevops.py
+++ b/bugwarrior/services/azuredevops.py
@@ -242,7 +242,7 @@ class AzureDevopsService(Service[AzureDevopsIssue]):
                         name = comment["revisedBy"]["displayName"]
                     except KeyError:
                         name = comment["modifiedBy"]["displayName"]
-                    text = format_item(comment["text"])
+                    text = format_item(comment["text"]) or ""
                     annotations.append((name, text))
         return self.build_annotations(annotations, url)
 

--- a/bugwarrior/services/bitbucket.py
+++ b/bugwarrior/services/bitbucket.py
@@ -113,7 +113,7 @@ class BitbucketService(Service[BitbucketIssue]):
                 'bitbucket_refresh_token', response['refresh_token']
             )
 
-        self.requests_kwargs = {
+        self.requests_kwargs: dict[str, Any] = {
             'headers': {'Authorization': f"Bearer {response['access_token']}"}
         }
 

--- a/bugwarrior/services/pivotaltracker.py
+++ b/bugwarrior/services/pivotaltracker.py
@@ -170,25 +170,25 @@ class PivotalTrackerService(Service[PivotalTrackerIssue]):
     def issues(self) -> Iterator[PivotalTrackerIssue]:
         for project in self.get_projects(self.config.account_ids):
             project_id = project.get('id')
-            if project_id not in self.config.exclude_projects:
-                for story in self.get_query(project_id, query=self.query):
-                    story_id = story.get('id')
-                    if story_id is None:
-                        continue
-                    tasks = self.get_tasks(project_id, story_id)
-                    blockers = self.get_blockers(project_id, story_id)
-                    extra = {
-                        'project_name': project.get('name'),
-                        'annotations': self.annotations(tasks, story),
-                        'owned_user': self.get_user_by_id(
-                            project_id, story['owner_ids']
-                        ),
-                        'request_user': self.get_user_by_id(
-                            project_id, [story['requested_by_id']]
-                        ),
-                        'blockers': self.blockers(blockers),
-                    }
-                    yield self.get_issue_for_record(story, extra)
+            if project_id is None or project_id in self.config.exclude_projects:
+                continue
+
+            for story in self.get_query(project_id, query=self.query):
+                story_id = story.get('id')
+                if story_id is None:
+                    continue
+                tasks = self.get_tasks(project_id, story_id)
+                blockers = self.get_blockers(project_id, story_id)
+                extra = {
+                    'project_name': project.get('name'),
+                    'annotations': self.annotations(tasks, story),
+                    'owned_user': self.get_user_by_id(project_id, story['owner_ids']),
+                    'request_user': self.get_user_by_id(
+                        project_id, [story['requested_by_id']]
+                    ),
+                    'blockers': self.blockers(blockers),
+                }
+                yield self.get_issue_for_record(story, extra)
 
     def api_request(self, endpoint: str, params: dict[str, Any] | None = None) -> Any:
         """

--- a/bugwarrior/services/trac.py
+++ b/bugwarrior/services/trac.py
@@ -106,7 +106,7 @@ class TracService(Service[TracIssue]):
         annotations = []
         # without offtrac, we can't get issue comments
         if self.trac is None:
-            return annotations
+            return []
         changelog = typing.cast(
             list, self.trac.server.ticket.changeLog(issue['number'])
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "bugwarrior"
 version = "2.1.0.post"
 description = "a command line utility for updating your local taskwarrior database from your forge issue trackers"
 readme = "bugwarrior/README.rst"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = "GPL-3.0-or-later"
 license-files = ["LICENSE.txt"]
 keywords=["task", "taskwarrior", "todo", "github"]
@@ -11,6 +11,10 @@ classifiers=[
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Software Development :: Bug Tracking",
   "Topic :: Utilities",
 ]
@@ -26,7 +30,6 @@ dependencies = [
   # which is no longer bundled in venvs since Python 3.12 (see #1150).
   "setuptools",
   "taskw>=0.8",
-  "tomli ; python_version <= '3.10'",
 ]
 
 [project.optional-dependencies]
@@ -128,8 +131,7 @@ build-backend = "setuptools.build_meta"
 docs = [
     # sphinx-inline-tabs is incompatible with docutils-0.22 https://github.com/pradyunsg/sphinx-inline-tabs/pull/51
     "docutils<0.22",
-    "sphinx>=1.0,<9.0 ; python_version <= '3.10'",
-    "sphinx>=9.0.3 ; python_version >= '3.11'",
+    "sphinx>=9.0.3",
     "sphinx-click",
     "sphinx-inline-tabs",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,5 +141,5 @@ test = [
     "responses",
     # ruff and ty are required by tests/test_general.py
     "ruff",
-    "ty==0.0.32",
+    "ty==0.0.51",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,9 @@ clickup = "bugwarrior.services.clickup:ClickupService"
 [project.entry-points."ini2toml.processing"]
 bugwarrior = "bugwarrior.config.ini2toml_plugin:activate"
 
+[tool.uv]
+exclude-newer = "3 days"
+
 [tool.ruff.format]
 quote-style = "preserve"
 skip-magic-trailing-comma = true

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,7 +1,6 @@
 import contextlib
 import os.path
 import shutil
-import sys
 import tempfile
 import typing
 import unittest
@@ -132,14 +131,6 @@ class ConfigTest(unittest.TestCase):
     @pytest.fixture(autouse=True)
     def inject_fixtures(self, caplog):
         self.caplog = caplog
-
-    if sys.version_info < (3, 11):
-
-        def enterContext(self, cm):
-            """Backport of unittest.TestCase.enterContext for Python 3.10."""
-            value = cm.__enter__()
-            self.addCleanup(cm.__exit__, None, None, None)
-            return value
 
     def validate(self) -> validation.Config:
         config = self.config.copy()

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -2,14 +2,9 @@ import configparser
 import itertools
 import os
 from pathlib import Path
-import sys
 import textwrap
+import tomllib
 from unittest import TestCase
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
 
 from bugwarrior.config import load
 


### PR DESCRIPTION
Also upgrade ty to latest version (0.49)

About `exclude-newer`:  There are more and more attacks targeting package dependencies, it's now consider a good practice to add a cooldown to reduce the risk. it supports friendly timedeltas (e.g. "3 days") since 0.9.17, released 2025-12-09. It wouldn't work with older uv versions. Is that acceptable to you, or should I drop the commit for now ? 