### PR TITLE
Migrate tests to pytest style

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -139,13 +139,13 @@ class ConfigTest(unittest.TestCase):
         return validation.validate_config(formatted_config, 'general', 'configpath')
 
     def assertValidationError(self, expected):
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             self.validate()
 
         # Only one message should be logged.
-        self.assertEqual(len(self.caplog.records), 1)
+        assert len(self.caplog.records) == 1
 
-        self.assertIn(expected, self.caplog.records[0].message)
+        assert expected in self.caplog.records[0].message
 
         # We may want to use this assertion more than once per test.
         self.caplog.clear()

--- a/tests/config/test_data.py
+++ b/tests/config/test_data.py
@@ -14,7 +14,7 @@ class TestData(ConfigTest):
     def assert0600(self):
         permissions = oct(os.stat(self.data._datafile).st_mode & 0o777)
         # python2 -> 0600, python3 -> 0o600
-        self.assertIn(permissions, ['0600', '0o600'])
+        assert permissions in ['0600', '0o600']
 
     def test_get_set(self):
         # "touch" data file.
@@ -23,18 +23,18 @@ class TestData(ConfigTest):
 
         self.data.set('key', 'value')
 
-        self.assertEqual(self.data.get('key'), 'value')
-        self.assertEqual(self.data.get_data(), {'old': 'stuff', 'key': 'value'})
+        assert self.data.get('key') == 'value'
+        assert self.data.get_data() == {'old': 'stuff', 'key': 'value'}
         self.assert0600()
 
     def test_set_first_time(self):
         self.data.set('key', 'value')
 
-        self.assertEqual(self.data.get('key'), 'value')
+        assert self.data.get('key') == 'value'
         self.assert0600()
 
     def test_path_attribute(self):
-        self.assertEqual(self.data.path, self.lists_path)
+        assert self.data.path == self.lists_path
 
 
 class TestGetDataPath(ConfigTest):
@@ -43,7 +43,7 @@ class TestGetDataPath(ConfigTest):
         self.main_config = schema.MainSectionConfig(targets=[])
 
     def assertDataPath(self, expected_datapath):
-        self.assertEqual(expected_datapath, data.get_data_path(self.main_config.taskrc))
+        assert expected_datapath == data.get_data_path(self.main_config.taskrc)
 
     def test_TASKDATA(self):
         """
@@ -56,7 +56,7 @@ class TestGetDataPath(ConfigTest):
         """
         When TASKDATA is not set, data.location in taskrc should be respected.
         """
-        self.assertTrue('TASKDATA' not in os.environ)
+        assert 'TASKDATA' not in os.environ
         self.assertDataPath(self.lists_path)
 
     def test_unassigned(self):
@@ -67,6 +67,6 @@ class TestGetDataPath(ConfigTest):
         with open(self.taskrc, 'w'):
             pass
 
-        self.assertTrue('TASKDATA' not in os.environ)
+        assert 'TASKDATA' not in os.environ
 
         self.assertDataPath(os.path.expanduser('~/.task'))

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -4,7 +4,6 @@ import os
 from pathlib import Path
 import textwrap
 import tomllib
-from unittest import TestCase
 
 import pytest
 
@@ -103,24 +102,22 @@ class TestGetConfigPath(LoadTest):
         assert load.get_config_path() == rc
 
 
-class TestBugwarriorConfigParser(TestCase):
-    def setUp(self):
-        self.config = load.BugwarriorConfigParser()
-        self.config['general'] = {
-            'someint': '4',
-            'somenone': '',
-            'somechar': 'somestring',
-        }
+class TestBugwarriorConfigParser:
+    @pytest.fixture
+    def config(self):
+        config = load.BugwarriorConfigParser()
+        config['general'] = {'someint': '4', 'somenone': '', 'somechar': 'somestring'}
+        return config
 
-    def test_getint(self):
-        assert self.config.getint('general', 'someint') == 4
+    def test_getint(self, config):
+        assert config.getint('general', 'someint') == 4
 
-    def test_getint_none(self):
-        assert self.config.getint('general', 'somenone') is None
+    def test_getint_none(self, config):
+        assert config.getint('general', 'somenone') is None
 
-    def test_getint_valueerror(self):
+    def test_getint_valueerror(self, config):
         with pytest.raises(ValueError):
-            self.config.getint('general', 'somechar')
+            config.getint('general', 'somechar')
 
 
 class TestParseFile(LoadTest):

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -6,6 +6,8 @@ import textwrap
 import tomllib
 from unittest import TestCase
 
+import pytest
+
 from bugwarrior.config import load
 
 from ..base import ConfigTest
@@ -60,7 +62,7 @@ class TestGetConfigPath(LoadTest):
                 try:
                     config1 = self.create(path1)
                     self.create(path2)
-                    self.assertEqual(load.get_config_path(), config1)
+                    assert load.get_config_path() == config1
                 finally:
                     self.tearDown()
 
@@ -69,16 +71,15 @@ class TestGetConfigPath(LoadTest):
         Falls back on .bugwarriorrc if it exists
         """
         rc = self.create('.bugwarriorrc')
-        self.assertEqual(load.get_config_path(), rc)
+        assert load.get_config_path() == rc
 
     def test_no_file(self):
         """
         If no bugwarriorrc exist anywhere, the path to the prefered one is
         returned.
         """
-        self.assertEqual(
-            load.get_config_path(),
-            os.path.join(self.tempdir, '.config/bugwarrior/bugwarriorrc'),
+        assert load.get_config_path() == os.path.join(
+            self.tempdir, '.config/bugwarrior/bugwarriorrc'
         )
 
     def test_BUGWARRIORRC(self):
@@ -90,7 +91,7 @@ class TestGetConfigPath(LoadTest):
         os.environ['BUGWARRIORRC'] = rc
         self.create('.bugwarriorrc')
         self.create('.config/bugwarrior/bugwarriorrc')
-        self.assertEqual(load.get_config_path(), rc)
+        assert load.get_config_path() == rc
 
     def test_BUGWARRIORRC_empty(self):
         """
@@ -99,7 +100,7 @@ class TestGetConfigPath(LoadTest):
         """
         os.environ['BUGWARRIORRC'] = ''
         rc = self.create('.config/bugwarrior/bugwarriorrc')
-        self.assertEqual(load.get_config_path(), rc)
+        assert load.get_config_path() == rc
 
 
 class TestBugwarriorConfigParser(TestCase):
@@ -112,13 +113,13 @@ class TestBugwarriorConfigParser(TestCase):
         }
 
     def test_getint(self):
-        self.assertEqual(self.config.getint('general', 'someint'), 4)
+        assert self.config.getint('general', 'someint') == 4
 
     def test_getint_none(self):
-        self.assertEqual(self.config.getint('general', 'somenone'), None)
+        assert self.config.getint('general', 'somenone') is None
 
     def test_getint_valueerror(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.config.getint('general', 'somechar')
 
 
@@ -146,9 +147,7 @@ class TestParseFile(LoadTest):
             )
         config = load.parse_file(config_path)
 
-        self.assertEqual(
-            config, {'flavor': {'general': {'foo': 'bar'}}, 'services': []}
-        )
+        assert config == {'flavor': {'general': {'foo': 'bar'}}, 'services': []}
 
     def test_toml_invalid(self):
         config_path = self.create('.bugwarrior.toml')
@@ -160,7 +159,7 @@ class TestParseFile(LoadTest):
             """)
             )
 
-        with self.assertRaises(tomllib.TOMLDecodeError):
+        with pytest.raises(tomllib.TOMLDecodeError):
             load.parse_file(config_path)
 
     def test_ini_invalid(self):
@@ -173,7 +172,7 @@ class TestParseFile(LoadTest):
             """)
             )
 
-        with self.assertRaises(configparser.MissingSectionHeaderError):
+        with pytest.raises(configparser.MissingSectionHeaderError):
             load.parse_file(config_path)
 
     def test_toml_flavors(self):
@@ -182,9 +181,10 @@ class TestParseFile(LoadTest):
         with open(config_path, 'w') as fout:
             fout.write('[flavor.myflavor]\ntargets = ["my_gitlab"]')
         config = load.parse_file(config_path)
-        self.assertEqual(
-            config, {'flavor': {'myflavor': {'targets': ['my_gitlab']}}, 'services': []}
-        )
+        assert config == {
+            'flavor': {'myflavor': {'targets': ['my_gitlab']}},
+            'services': [],
+        }
 
     def test_ini_flavors(self):
         config_path = self.create('.bugwarriorrc')
@@ -197,9 +197,10 @@ class TestParseFile(LoadTest):
             )
         config = load.parse_file(config_path)
 
-        self.assertEqual(
-            config, {'flavor': {'myflavor': {'targets': 'my_gitlab'}}, 'services': []}
-        )
+        assert config == {
+            'flavor': {'myflavor': {'targets': 'my_gitlab'}},
+            'services': [],
+        }
 
     def test_ini_options_renamed(self):
         """
@@ -221,11 +222,11 @@ class TestParseFile(LoadTest):
         config = load.parse_file(config_path)
 
         baz_service = next(svc for svc in config['services'] if svc['target'] == 'baz')
-        self.assertIn('optionname', baz_service)
-        self.assertNotIn('prefix.optionname', baz_service)
+        assert 'optionname' in baz_service
+        assert 'prefix.optionname' not in baz_service
 
-        self.assertIn('log_level', config['flavor']['general'])
-        self.assertNotIn('log.level', config['flavor']['general'])
+        assert 'log_level' in config['flavor']['general']
+        assert 'log.level' not in config['flavor']['general']
 
     def test_ini_missing_prefix(self):
         config_path = self.create('.bugwarriorrc')
@@ -240,7 +241,7 @@ class TestParseFile(LoadTest):
             """)
             )
 
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             load.parse_file(config_path)
 
     def test_ini_wrong_prefix(self):
@@ -256,7 +257,7 @@ class TestParseFile(LoadTest):
             """)
             )
 
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             load.parse_file(config_path)
 
 
@@ -276,8 +277,8 @@ class TestLoadConfig(LoadTest):
             """)
             )
 
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             load.load_config("general", False)
 
-        self.assertEqual(len(self.caplog.records), 1)
-        self.assertIn("No section: 'general'", self.caplog.records[0].message)
+        assert len(self.caplog.records) == 1
+        assert "No section: 'general'" in self.caplog.records[0].message

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -35,9 +35,8 @@ class TestExpandedPath(unittest.TestCase):
         os.chdir(self.dir)
 
 
-class TestConfigList(unittest.TestCase):
-    def setUp(self):
-        self.adapter = TypeAdapter(schema.ConfigList)
+class TestConfigList:
+    adapter = TypeAdapter(schema.ConfigList)
 
     def test_configlist(self):
         assert self.adapter.validate_python('project_bar,project_baz') == [
@@ -102,9 +101,8 @@ class TestTaskrcPath(ConfigTest):
             self.validate()
 
 
-class TestUnsupportedOption(unittest.TestCase):
-    def setUp(self):
-        self.adapter = TypeAdapter(schema.UnsupportedOption[str])
+class TestUnsupportedOption:
+    adapter = TypeAdapter(schema.UnsupportedOption[str])
 
     def test_unsupportedoption_falsey(self):
         assert self.adapter.validate_python('') == ''

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -114,7 +114,7 @@ class TestUnsupportedOption(unittest.TestCase):
             self.adapter.validate_python('foo')
 
 
-class TestComputeTemplates(unittest.TestCase):
+class TestComputeTemplates:
     def test_template(self):
         raw_values = {'templates': {}, 'project_template': 'foo'}
         computed_values = DumbConfig.compute_templates(raw_values)

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -7,6 +7,7 @@ import unittest
 
 import pydantic
 from pydantic import TypeAdapter
+import pytest
 
 from bugwarrior.config import schema
 
@@ -22,13 +23,13 @@ class TestExpandedPath(unittest.TestCase):
 
     def test_log(self):
         filename = os.path.join(os.path.expandvars('$HOME'), self.log)
-        self.assertEqual(self.adapter.validate_python(filename), self.log)
+        assert self.adapter.validate_python(filename) == self.log
 
     def test_log_userhome(self):
-        self.assertEqual(self.adapter.validate_python('~/bugwarrior.log'), self.log)
+        assert self.adapter.validate_python('~/bugwarrior.log') == self.log
 
     def test_log_envvar(self):
-        self.assertEqual(self.adapter.validate_python('$HOME/bugwarrior.log'), self.log)
+        assert self.adapter.validate_python('$HOME/bugwarrior.log') == self.log
 
     def tearDown(self):
         os.chdir(self.dir)
@@ -39,18 +40,15 @@ class TestConfigList(unittest.TestCase):
         self.adapter = TypeAdapter(schema.ConfigList)
 
     def test_configlist(self):
-        self.assertEqual(
-            self.adapter.validate_python('project_bar,project_baz'),
-            ['project_bar', 'project_baz'],
-        )
+        assert self.adapter.validate_python('project_bar,project_baz') == [
+            'project_bar',
+            'project_baz',
+        ]
 
     def test_configlist_jinja(self):
-        self.assertEqual(
-            self.adapter.validate_python(
-                "work, jira, {{jirastatus|lower|replace(' ','_')}}"
-            ),
-            ['work', 'jira', "{{jirastatus|lower|replace(' ','_')}}"],
-        )
+        assert self.adapter.validate_python(
+            "work, jira, {{jirastatus|lower|replace(' ','_')}}"
+        ) == ['work', 'jira', "{{jirastatus|lower|replace(' ','_')}}"]
 
 
 class TestTaskrcPath(ConfigTest):
@@ -60,7 +58,7 @@ class TestTaskrcPath(ConfigTest):
 
     def test_default_factory_default(self):
         config = self.validate()
-        self.assertEqual(str(config.main.taskrc), os.path.join(self.tempdir, '.taskrc'))
+        assert str(config.main.taskrc) == os.path.join(self.tempdir, '.taskrc')
 
     def test_default_factory_env_override(self):
         override = os.path.join(self.tempdir, 'override_taskrc')
@@ -69,7 +67,7 @@ class TestTaskrcPath(ConfigTest):
         os.environ['TASKRC'] = override
 
         config = self.validate()
-        self.assertEqual(str(config.main.taskrc), override)
+        assert str(config.main.taskrc) == override
 
     def test_default_factory_xdg_config_home(self):
         os.remove(self.taskrc)
@@ -81,7 +79,7 @@ class TestTaskrcPath(ConfigTest):
             fout.write('data.location=%s\n' % self.lists_path)
 
         config = self.validate()
-        self.assertEqual(str(config.main.taskrc), taskrc)
+        assert str(config.main.taskrc) == taskrc
 
     def test_default_factory_dot_config_taskrc(self):
         """Taskrc is still found if XDG_CONFIG_HOME is unset."""
@@ -95,12 +93,12 @@ class TestTaskrcPath(ConfigTest):
         del os.environ['XDG_CONFIG_HOME']
 
         config = self.validate()
-        self.assertEqual(str(config.main.taskrc), taskrc)
+        assert str(config.main.taskrc) == taskrc
 
     def test_no_taskrc_file_found(self):
         os.remove(self.taskrc)
 
-        with self.assertRaisesRegex(OSError, r"Unable to find taskrc file\."):
+        with pytest.raises(OSError, match=r"Unable to find taskrc file\."):
             self.validate()
 
 
@@ -109,10 +107,10 @@ class TestUnsupportedOption(unittest.TestCase):
         self.adapter = TypeAdapter(schema.UnsupportedOption[str])
 
     def test_unsupportedoption_falsey(self):
-        self.assertEqual(self.adapter.validate_python(''), '')
+        assert self.adapter.validate_python('') == ''
 
     def test_unsupportedoption_truthy(self):
-        with self.assertRaises(pydantic.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             self.adapter.validate_python('foo')
 
 
@@ -120,7 +118,7 @@ class TestComputeTemplates(unittest.TestCase):
     def test_template(self):
         raw_values = {'templates': {}, 'project_template': 'foo'}
         computed_values = DumbConfig.compute_templates(raw_values)
-        self.assertEqual(computed_values['templates'], {'project': 'foo'})
+        assert computed_values['templates'] == {'project': 'foo'}
 
     def test_empty_template(self):
         """
@@ -133,7 +131,7 @@ class TestComputeTemplates(unittest.TestCase):
         """
         raw_values = {'templates': {}, 'project_template': ''}
         computed_values = DumbConfig.compute_templates(raw_values)
-        self.assertEqual(computed_values['templates'], {'project': ''})
+        assert computed_values['templates'] == {'project': ''}
 
 
 class TestServices(unittest.TestCase):
@@ -150,17 +148,17 @@ class TestServices(unittest.TestCase):
                     service_code = f.read()
                 for option in ['only_if_assigned', 'also_unassigned']:
                     with self.subTest(option=option):
-                        self.assertIsNotNone(
-                            re.search(option, service_code),
-                            msg=f'\
-Service should support common configuration option self.config.{option}',
+                        assert re.search(option, service_code) is not None, (
+                            f'\
+Service should support common configuration option self.config.{option}'
                         )
 
                 # get_priority() makes use of the default_priority option
                 with self.subTest(option='default_priority'):
-                    self.assertIsNotNone(
+                    assert (
                         re.search('default_priority', service_code)
-                        or re.search('get_priority', service_code),
-                        msg='\
-Service should support self.config.default_priority or use self.get_priority()',
+                        or re.search('get_priority', service_code)
+                    ) is not None, (
+                        '\
+Service should support self.config.default_priority or use self.get_priority()'
                     )

--- a/tests/config/test_secrets.py
+++ b/tests/config/test_secrets.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest.mock import MagicMock, patch
 
 import keyring.errors
@@ -7,12 +6,12 @@ import pytest
 from bugwarrior.config import secrets
 
 
-class TestOracleEval(unittest.TestCase):
+class TestOracleEval:
     def test_echo(self):
         assert secrets.oracle_eval("echo fööbår") == "fööbår"
 
 
-class TestGetServicePassword(unittest.TestCase):
+class TestGetServicePassword:
     """Tests for get_service_password, covering every oracle code path."""
 
     SERVICE = "myservice"

--- a/tests/config/test_secrets.py
+++ b/tests/config/test_secrets.py
@@ -2,13 +2,14 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import keyring.errors
+import pytest
 
 from bugwarrior.config import secrets
 
 
 class TestOracleEval(unittest.TestCase):
     def test_echo(self):
-        self.assertEqual(secrets.oracle_eval("echo fööbår"), "fööbår")
+        assert secrets.oracle_eval("echo fööbår") == "fööbår"
 
 
 class TestGetServicePassword(unittest.TestCase):
@@ -38,7 +39,7 @@ class TestGetServicePassword(unittest.TestCase):
         with patch.object(secrets, "oracle_eval", return_value="s3cr3t") as mock_eval:
             result = self._call(oracle="@oracle:eval:echo s3cr3t")
         mock_eval.assert_called_once_with("echo s3cr3t")
-        self.assertEqual(result, "s3cr3t")
+        assert result == "s3cr3t"
 
     def test_ask_password_interactive_prompts_user(self):
         with (
@@ -48,12 +49,12 @@ class TestGetServicePassword(unittest.TestCase):
             mock_stdin.isatty.return_value = True
             result = self._call(oracle="@oracle:ask_password")
         mock_getpass.assert_called_once()
-        self.assertEqual(result, "typed")
+        assert result == "typed"
 
     def test_ask_password_non_interactive_exits(self):
         with patch("sys.stdin") as mock_stdin, patch("getpass.getpass") as mock_getpass:
             mock_stdin.isatty.return_value = False
-            with self.assertRaises(SystemExit):
+            with pytest.raises(SystemExit):
                 self._call(oracle="@oracle:ask_password")
         mock_getpass.assert_not_called()
 
@@ -62,21 +63,21 @@ class TestGetServicePassword(unittest.TestCase):
         with patch.object(secrets, "get_keyring", return_value=mock):
             result = self._call(oracle="@oracle:use_keyring")
         mock.get_password.assert_called_once_with(self.SERVICE, self.USERNAME)
-        self.assertEqual(result, "stored")
+        assert result == "stored"
 
     def test_default_oracle_also_uses_keyring(self):
         """Passing oracle=None should behave identically to @oracle:use_keyring."""
         mock = self._mock_keyring(password="stored")
         with patch.object(secrets, "get_keyring", return_value=mock):
             result = self._call(oracle=None)
-        self.assertEqual(result, "stored")
+        assert result == "stored"
 
     def test_keyring_locked_exits(self):
         """When the keyring is locked and the unlock dialog is dismissed,
         keyring raises KeyringLocked. bugwarrior should exit fatally."""
         mock = self._mock_keyring(locked=True)
         with patch.object(secrets, "get_keyring", return_value=mock):
-            with self.assertRaises(SystemExit):
+            with pytest.raises(SystemExit):
                 self._call(oracle="@oracle:use_keyring")
 
     def test_keyring_empty_interactive_prompts_and_stores(self):
@@ -90,7 +91,7 @@ class TestGetServicePassword(unittest.TestCase):
         ):
             mock_stdin.isatty.return_value = True
             result = self._call(oracle="@oracle:use_keyring")
-        self.assertEqual(result, "newpass")
+        assert result == "newpass"
         mock.set_password.assert_called_once_with(
             self.SERVICE, self.USERNAME, "newpass"
         )
@@ -104,10 +105,10 @@ class TestGetServicePassword(unittest.TestCase):
             patch("getpass.getpass") as mock_getpass,
         ):
             mock_stdin.isatty.return_value = False
-            with self.assertRaises(SystemExit):
+            with pytest.raises(SystemExit):
                 self._call(oracle="@oracle:use_keyring")
         mock_getpass.assert_not_called()
 
     def test_unknown_oracle_exits(self):
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             self._call(oracle="@oracle:unknown_strategy")

--- a/tests/config/test_validation.py
+++ b/tests/config/test_validation.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import typing
 
 import pydantic
+import pytest
 
 from bugwarrior import config
 from bugwarrior.config import validation
@@ -54,12 +55,12 @@ class TestValidation(ConfigTest):
     def test_main_section_required(self):
         del self.config['general']
 
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             formatted = format_config(self.config)
             validation.validate_config(formatted, 'general', 'configpath')
 
-        self.assertEqual(len(self.caplog.records), 1)
-        self.assertIn("No section: 'general'", self.caplog.records[0].message)
+        assert len(self.caplog.records) == 1
+        assert "No section: 'general'" in self.caplog.records[0].message
 
     def test_main_section_missing_targets_option(self):
         del self.config['general']['targets']
@@ -95,12 +96,12 @@ class TestValidation(ConfigTest):
 
     def test_no_scheme_url_validator_default(self):
         service_config = self.validate().service_configs[0]
-        self.assertEqual(service_config.host, 'example.com')
+        assert service_config.host == 'example.com'
 
     def test_no_scheme_url_validator_set(self):
         self.config['my_service']['host'] = 'example.com'
         service_config = self.validate().service_configs[0]
-        self.assertEqual(service_config.host, 'example.com')
+        assert service_config.host == 'example.com'
 
     def test_no_scheme_url_validator_scheme(self):
         self.config['my_service']['host'] = 'https://example.com'
@@ -111,15 +112,15 @@ class TestValidation(ConfigTest):
     def test_stripped_trailing_slash_url(self):
         self.config['my_service']['url'] = 'https://example.org/'
         service_config = self.validate().service_configs[0]
-        self.assertEqual(service_config.url, 'https://example.org')
+        assert service_config.url == 'https://example.org'
 
     def test_deprecated_filter_merge_requests(self):
         service_config = self.validate().service_configs[0]
-        self.assertEqual(service_config.include_merge_requests, True)
+        assert service_config.include_merge_requests is True
 
         self.config['my_service']['filter_merge_requests'] = 'true'
         service_config = self.validate().service_configs[0]
-        self.assertEqual(service_config.include_merge_requests, False)
+        assert service_config.include_merge_requests is False
 
     def test_deprecated_filter_merge_requests_and_include_merge_requests(self):
         self.config['my_service']['filter_merge_requests'] = 'true'
@@ -201,7 +202,6 @@ class TestExampleFiles(ConfigTest):
                     config = validation.validate_config(
                         formatted_config, main_section, str(config_path)
                     )
-                    self.assertEqual(
-                        {conf.__class__.__name__ for conf in config.service_configs},
-                        expected_configs,
-                    )
+                    assert {
+                        conf.__class__.__name__ for conf in config.service_configs
+                    } == expected_configs

--- a/tests/services/test_azuredevops.py
+++ b/tests/services/test_azuredevops.py
@@ -195,7 +195,7 @@ class TestAzureDevopsService(ServiceIssueTest):
             "adoparent": None,
         }
         actual_output = issue.to_taskwarrior()
-        self.assertEqual(actual_output, expected)
+        assert actual_output == expected
 
     def test_issues(self):
         expected = {
@@ -219,7 +219,7 @@ class TestAzureDevopsService(ServiceIssueTest):
             "tags": [],
         }
         issue = next(self.service.issues())
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     def test_issues_wiql_filter(self):
         expected = {
@@ -244,4 +244,4 @@ class TestAzureDevopsService(ServiceIssueTest):
         }
         service = self.get_service(config_overrides={'wiql_filter': 'something'})
         issue = next(service.issues())
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected

--- a/tests/services/test_bitbucket.py
+++ b/tests/services/test_bitbucket.py
@@ -44,7 +44,7 @@ class TestBitbucketIssue(ServiceIssueTest):
         }
         actual_output = issue.to_taskwarrior()
 
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     @responses.activate
     def test_issues(self):
@@ -106,9 +106,7 @@ class TestBitbucketIssue(ServiceIssueTest):
             'tags': [],
         }
 
-        self.assertEqual(
-            TaskConstructor(issue).get_taskwarrior_record(), expected_issue
-        )
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected_issue
 
         expected_pr = {
             'annotations': ['@nobody - Some comment.'],
@@ -121,15 +119,15 @@ class TestBitbucketIssue(ServiceIssueTest):
             'tags': [],
         }
 
-        self.assertEqual(TaskConstructor(pr).get_taskwarrior_record(), expected_pr)
+        assert TaskConstructor(pr).get_taskwarrior_record() == expected_pr
 
     def test_get_owner(self):
         issue = {'title': 'Foobar', 'assignee': {'username': 'tintin'}}
-        self.assertEqual(self.service.get_owner(('foo', issue)), 'tintin')
+        assert self.service.get_owner(('foo', issue)) == 'tintin'
 
     def test_get_owner_none(self):
         issue = {'title': 'Foobar', 'assignee': None}
-        self.assertIsNone(self.service.get_owner(('foo', issue)))
+        assert self.service.get_owner(('foo', issue)) is None
 
     @responses.activate
     def test_fetch_issues_pagination(self):
@@ -181,4 +179,4 @@ class TestBitbucketIssue(ServiceIssueTest):
                 },
             ),
         ]
-        self.assertEqual(issues, expected)
+        assert issues == expected

--- a/tests/services/test_bts.py
+++ b/tests/services/test_bts.py
@@ -58,7 +58,7 @@ class TestBTSService(ServiceIssueTest):
         }
         actual_output = issue.to_taskwarrior()
 
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     def test_issues(self):
         with mock.patch('bugwarrior.services.bts.debianbts', FakeBTSLib()):
@@ -86,4 +86,4 @@ class TestBTSService(ServiceIssueTest):
             'tags': [],
         }
 
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected

--- a/tests/services/test_bugzilla.py
+++ b/tests/services/test_bugzilla.py
@@ -2,6 +2,8 @@ from collections import namedtuple
 import datetime
 from unittest import mock
 
+import pytest
+
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.bz import BugzillaService
 
@@ -55,10 +57,10 @@ class TestBugzillaServiceConfig(ConfigTest):
 
         self.validate()
 
-        self.assertEqual(len(self.caplog.records), 1)
-        self.assertIn(
-            'bugzilla.base_uri should include the scheme',
-            self.caplog.records[0].message,
+        assert len(self.caplog.records) == 1
+        assert (
+            'bugzilla.base_uri should include the scheme'
+            in self.caplog.records[0].message
         )
 
 
@@ -127,7 +129,7 @@ class TestBugzillaService(ServiceIssueTest):
         }
         actual_output = issue.to_taskwarrior()
 
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     def test_issues(self):
         issue = next(self.service.issues())
@@ -149,7 +151,7 @@ class TestBugzillaService(ServiceIssueTest):
             'tags': [],
         }
 
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     def test_only_if_assigned(self):
         with mock.patch('bugzilla.Bugzilla'):
@@ -201,12 +203,11 @@ class TestBugzillaService(ServiceIssueTest):
             'tags': [],
         }
 
-        self.assertEqual(
-            TaskConstructor(next(issues)).get_taskwarrior_record(), expected
-        )
+        assert TaskConstructor(next(issues)).get_taskwarrior_record() == expected
 
         # Only one issue is assigned.
-        self.assertRaises(StopIteration, lambda: next(issues))
+        with pytest.raises(StopIteration):
+            next(issues)
 
     def test_also_unassigned(self):
         with mock.patch('bugzilla.Bugzilla'):
@@ -241,13 +242,12 @@ class TestBugzillaService(ServiceIssueTest):
 
         issues = self.service.issues()
 
-        self.assertIn(
-            TaskConstructor(next(issues)).get_taskwarrior_record()['bugzillabugid'],
-            [1234567, 1234568],
-        )
-        self.assertIn(
-            TaskConstructor(next(issues)).get_taskwarrior_record()['bugzillabugid'],
-            [1234567, 1234568],
-        )
+        assert TaskConstructor(next(issues)).get_taskwarrior_record()[
+            'bugzillabugid'
+        ] in [1234567, 1234568]
+        assert TaskConstructor(next(issues)).get_taskwarrior_record()[
+            'bugzillabugid'
+        ] in [1234567, 1234568]
         # Only two issues are assigned to the user or unassigned.
-        self.assertRaises(StopIteration, lambda: next(issues))
+        with pytest.raises(StopIteration):
+            next(issues)

--- a/tests/services/test_clickup.py
+++ b/tests/services/test_clickup.py
@@ -131,9 +131,9 @@ class TestClickupClient(TestCase):
 
     def test_init(self):
         http_client = ClickupClient('12345')
-        self.assertEqual(
-            "https://api.clickup.com/api/v2/team/1234/task?include_closed=false&page=0",
-            http_client._get_url_for_tasks(1234, 0),
+        assert (
+            "https://api.clickup.com/api/v2/team/1234/task?include_closed=false&page=0"
+            == http_client._get_url_for_tasks(1234, 0)
         )
 
     @responses.activate
@@ -147,7 +147,7 @@ class TestClickupClient(TestCase):
             json=self.data.get_page(1),
         )
         result = [item for item in self.client.get_tasks_for_team(team_id=1234)]
-        self.assertSequenceEqual(self.data.get_task_contents(), result)
+        assert self.data.get_task_contents() == result
 
 
 class TestClickupService(ConfigTest):
@@ -172,20 +172,20 @@ class TestClickupService(ConfigTest):
 
     def test_keyring_service(self):
         conf = self.validate().service_configs[0]
-        self.assertEqual(conf.keyring_service, 'clickup://')
+        assert conf.keyring_service == 'clickup://'
 
     def test_is_assigned(self):
         task = self.data.get_task()
 
-        self.assertTrue(self.service.is_assigned(task))
+        assert self.service.is_assigned(task)
 
         self.config["myservice"]["only_if_assigned"] = "Pedro Manobrista"
 
-        self.assertTrue(self.service.is_assigned(task))
+        assert self.service.is_assigned(task)
 
         self.config["myservice"]["also_unassigned"] = False
 
-        self.assertFalse(self.service.is_assigned(task))
+        assert not self.service.is_assigned(task)
 
         task["assignees"] = [
             {
@@ -197,7 +197,7 @@ class TestClickupService(ConfigTest):
                 "profilePicture": None,
             }
         ]
-        self.assertTrue(self.service.is_assigned(task))
+        assert self.service.is_assigned(task)
 
 
 class TestClickupIssue(ServiceIssueTest):
@@ -236,7 +236,7 @@ class TestClickupIssue(ServiceIssueTest):
         }
         actual_output = issue.to_taskwarrior()
 
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     @responses.activate
     def test_issues(self):
@@ -272,6 +272,4 @@ class TestClickupIssue(ServiceIssueTest):
             issue.NAME: task["name"],
         }
 
-        self.assertEqual(
-            TaskConstructor(issue).get_taskwarrior_record(), expected_output
-        )
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected_output

--- a/tests/services/test_clickup.py
+++ b/tests/services/test_clickup.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timezone
-from unittest import TestCase
 
 import responses
 
@@ -123,12 +122,7 @@ class TestData:
         return self.get_task_contents()[0]
 
 
-class TestClickupClient(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.client = ClickupClient('XXXXXX')
-        self.data = TestData()
-
+class TestClickupClient:
     def test_init(self):
         http_client = ClickupClient('12345')
         assert (
@@ -138,16 +132,18 @@ class TestClickupClient(TestCase):
 
     @responses.activate
     def test_get_repo(self):
+        client = ClickupClient('XXXXXX')
+        data = TestData()
         responses.get(
             "https://api.clickup.com/api/v2/team/1234/task?include_closed=false&page=0",
-            json=self.data.get_page(0),
+            json=data.get_page(0),
         )
         responses.get(
             "https://api.clickup.com/api/v2/team/1234/task?include_closed=false&page=1",
-            json=self.data.get_page(1),
+            json=data.get_page(1),
         )
-        result = [item for item in self.client.get_tasks_for_team(team_id=1234)]
-        assert self.data.get_task_contents() == result
+        result = [item for item in client.get_tasks_for_team(team_id=1234)]
+        assert data.get_task_contents() == result
 
 
 class TestClickupService(ConfigTest):

--- a/tests/services/test_deck.py
+++ b/tests/services/test_deck.py
@@ -142,7 +142,7 @@ class TestNextcloudDeckIssue(ServiceIssueTest):
         }
         actual = issue.to_taskwarrior()
 
-        self.assertEqual(actual, expected)
+        assert actual == expected
 
     def test_issues(self):
         issue = next(self.service.issues())
@@ -167,7 +167,7 @@ class TestNextcloudDeckIssue(ServiceIssueTest):
             'tags': ['Later'],
         }
 
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     def test_get_owner(self):
         # Regression test: the old get_owner did `issue[issue.ASSIGNEE]`, treating
@@ -182,14 +182,14 @@ class TestNextcloudDeckIssue(ServiceIssueTest):
                 'annotations': [],
             },
         )
-        self.assertEqual(self.service.get_owner(issue), 'rainbow')
+        assert self.service.get_owner(issue) == 'rainbow'
 
     def test_filter_boards_include(self):
         self.config['deck']['include_board_ids'] = '5'
-        self.assertTrue(self.service.filter_boards({'title': 'testboard', 'id': 5}))
-        self.assertFalse(self.service.filter_boards({'title': 'testboard', 'id': 6}))
+        assert self.service.filter_boards({'title': 'testboard', 'id': 5})
+        assert not self.service.filter_boards({'title': 'testboard', 'id': 6})
 
     def test_filter_boards_exclude(self):
         self.config['deck']['exclude_board_ids'] = '5'
-        self.assertFalse(self.service.filter_boards({'title': 'testboard', 'id': 5}))
-        self.assertTrue(self.service.filter_boards({'title': 'testboard', 'id': 6}))
+        assert not self.service.filter_boards({'title': 'testboard', 'id': 5})
+        assert self.service.filter_boards({'title': 'testboard', 'id': 6})

--- a/tests/services/test_gerrit.py
+++ b/tests/services/test_gerrit.py
@@ -74,7 +74,7 @@ class TestGerritIssue(ServiceIssueTest):
             'tags': [],
         }
 
-        self.assertEqual(actual, expected)
+        assert actual == expected
 
     def test_work_in_progress(self):
         wip_record = dict(self.record)  # make a copy of the dict
@@ -96,7 +96,7 @@ class TestGerritIssue(ServiceIssueTest):
             'tags': [],
         }
 
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     @responses.activate
     def test_issues(self):
@@ -123,4 +123,4 @@ class TestGerritIssue(ServiceIssueTest):
             'tags': [],
         }
 
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected

--- a/tests/services/test_gitbug.py
+++ b/tests/services/test_gitbug.py
@@ -60,7 +60,7 @@ class TestGitBugIssue(ServiceIssueTest):
         }
         actual = issue.to_taskwarrior()
 
-        self.assertEqual(actual, expected)
+        assert actual == expected
 
     def test_issues(self):
         issue = next(self.service.issues())
@@ -80,7 +80,7 @@ class TestGitBugIssue(ServiceIssueTest):
             'tags': [],
         }
 
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
 
 class TestGitBugConfig(ConfigTest):
@@ -92,4 +92,4 @@ class TestGitBugConfig(ConfigTest):
 
     def test_home_path_expansion(self):
         expected = self.tempdir + "/custom-gitbug-repo"
-        self.assertEqual(str(self.config.path), expected)
+        assert str(self.config.path) == expected

--- a/tests/services/test_github.py
+++ b/tests/services/test_github.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta, timezone
-from unittest import TestCase
 
 import responses
 
@@ -358,7 +357,7 @@ class TestGithubValidation(ConfigTest):
         self.validate()
 
 
-class TestGithubClient(TestCase):
+class TestGithubClient:
     def test_api_url(self):
         auth = {'token': 'xxxx'}
         client = GithubClient('github.com', auth)

--- a/tests/services/test_github.py
+++ b/tests/services/test_github.py
@@ -80,7 +80,7 @@ class TestGithubIssue(ServiceIssueTest):
             'tags': [],
         }
 
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     def test_to_taskwarrior(self):
         service = self.get_mock_service(
@@ -112,7 +112,7 @@ class TestGithubIssue(ServiceIssueTest):
         }
         actual_output = issue.to_taskwarrior()
 
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     @responses.activate
     def test_issues(self):
@@ -170,7 +170,7 @@ class TestGithubIssue(ServiceIssueTest):
             'tags': [],
         }
 
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
 
 class TestGithubIssueQuery(ServiceIssueTest):
@@ -229,7 +229,7 @@ class TestGithubIssueQuery(ServiceIssueTest):
             'tags': [],
         }
 
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
 
 class TestGithubService(ServiceTest):
@@ -246,27 +246,27 @@ class TestGithubService(ServiceTest):
             GithubService,
             config_overrides={'token': '@oracle:eval:echo 1234567890ABCDEF'},
         )
-        self.assertEqual(
-            service.client.session.headers['Authorization'], "token 1234567890ABCDEF"
+        assert (
+            service.client.session.headers['Authorization'] == "token 1234567890ABCDEF"
         )
 
     def test_default_host(self):
         """Check that if host is not set, we default to github.com"""
         service = self.get_mock_service(GithubService)
-        self.assertEqual("github.com", service.config.host)
+        assert "github.com" == service.config.host
 
     def test_overwrite_host(self):
         """Check that if host is set, we use its value as host"""
         service = self.get_mock_service(
             GithubService, config_overrides={'host': 'github.example.com'}
         )
-        self.assertEqual("github.example.com", service.config.host)
+        assert "github.example.com" == service.config.host
 
     def test_keyring_service(self):
         """Checks that the keyring service name"""
         service_config = GithubConfig(**self.SERVICE_CONFIG, target="myservice")
         keyring_service = service_config.keyring_service
-        self.assertEqual("github://tintin@github.com/milou", keyring_service)
+        assert "github://tintin@github.com/milou" == keyring_service
 
     def test_keyring_service_host(self):
         """Checks that the keyring key depends on the github host."""
@@ -274,39 +274,39 @@ class TestGithubService(ServiceTest):
             **{'host': 'github.example.com'}, **self.SERVICE_CONFIG, target="myservice"
         )
         keyring_service = service_config.keyring_service
-        self.assertEqual("github://tintin@github.example.com/milou", keyring_service)
+        assert "github://tintin@github.example.com/milou" == keyring_service
 
     def test_get_repository_from_issue_url__issue(self):
         issue = dict(repos_url="https://github.com/foo/bar")
         repository = GithubService.get_repository_from_issue(issue)
-        self.assertEqual("foo/bar", repository)
+        assert "foo/bar" == repository
 
     def test_get_repository_from_issue_url__pull_request(self):
         issue = dict(repos_url="https://github.com/foo/bar")
         repository = GithubService.get_repository_from_issue(issue)
-        self.assertEqual("foo/bar", repository)
+        assert "foo/bar" == repository
 
     def test_get_repository_from_issue__enterprise_github(self):
         issue = dict(repos_url="https://github.acme.biz/foo/bar")
         repository = GithubService.get_repository_from_issue(issue)
-        self.assertEqual("foo/bar", repository)
+        assert "foo/bar" == repository
 
     def test_body_no_limit(self):
         service = self.get_mock_service(GithubService)
         issue = dict(body="A very short issue body.  Fixes #42.")
-        self.assertEqual(issue["body"], service.body(issue))
+        assert issue["body"] == service.body(issue)
 
     def test_body_newline_style(self):
         service = self.get_mock_service(GithubService)
         issue = dict(body="An\r\nIssue\r\nWith\r\nNewlines")
-        self.assertEqual("An\nIssue\nWith\nNewlines", service.body(issue))
+        assert "An\nIssue\nWith\nNewlines" == service.body(issue)
 
     def test_body_length_limit(self):
         service = self.get_mock_service(
             GithubService, config_overrides={'body_length': 5}
         )
         issue = dict(body="A very short issue body.  Fixes #42.")
-        self.assertEqual(issue["body"][:5], service.body(issue))
+        assert issue["body"][:5] == service.body(issue)
 
 
 class TestGithubValidation(ConfigTest):
@@ -362,22 +362,21 @@ class TestGithubClient(TestCase):
     def test_api_url(self):
         auth = {'token': 'xxxx'}
         client = GithubClient('github.com', auth)
-        self.assertEqual(
-            client._api_url('/some/path'), 'https://api.github.com/some/path'
-        )
+        assert client._api_url('/some/path') == 'https://api.github.com/some/path'
 
     def test_api_url_with_context(self):
         auth = {'token': 'xxxx'}
         client = GithubClient('github.com', auth)
-        self.assertEqual(
-            client._api_url('/some/path/{foo}', foo='bar'),
-            'https://api.github.com/some/path/bar',
+        assert (
+            client._api_url('/some/path/{foo}', foo='bar')
+            == 'https://api.github.com/some/path/bar'
         )
 
     def test_api_url_with_custom_host(self):
         """Test generating an API URL with a custom host"""
         auth = {'token': 'xxxx'}
         client = GithubClient('github.example.com', auth)
-        self.assertEqual(
-            client._api_url('/some/path'), 'https://github.example.com/api/v3/some/path'
+        assert (
+            client._api_url('/some/path')
+            == 'https://github.example.com/api/v3/some/path'
         )

--- a/tests/services/test_gitlab.py
+++ b/tests/services/test_gitlab.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime, timedelta, timezone
 from unittest import TestCase
 
+import pytest
 import responses
 
 from bugwarrior.collect import TaskConstructor, get_service_instances
@@ -318,7 +319,7 @@ class TestGitlabClient(TestCase):
             verify_ssl=False,
         )
         expected_base_url = 'http://my-git.org/api/v4/'
-        self.assertEqual(expected_base_url, http_client._base_url())
+        assert expected_base_url == http_client._base_url()
         http_client = GitlabClient(
             'my-git.org',
             '12345',
@@ -328,7 +329,7 @@ class TestGitlabClient(TestCase):
             verify_ssl=True,
         )
         expected_base_url = 'http://my-git.org/api/v4/'
-        self.assertEqual(expected_base_url, http_client._base_url())
+        assert expected_base_url == http_client._base_url()
         http_client = GitlabClient(
             'my-git.org',
             '12345',
@@ -338,7 +339,7 @@ class TestGitlabClient(TestCase):
             verify_ssl=False,
         )
         expected_base_url = 'https://my-git.org/api/v4/'
-        self.assertEqual(expected_base_url, http_client._base_url())
+        assert expected_base_url == http_client._base_url()
         http_client = GitlabClient(
             'my-git.org',
             '12345',
@@ -348,7 +349,7 @@ class TestGitlabClient(TestCase):
             verify_ssl=True,
         )
         expected_base_url = 'https://my-git.org/api/v4/'
-        self.assertEqual(expected_base_url, http_client._base_url())
+        assert expected_base_url == http_client._base_url()
 
     @responses.activate
     def test_get_repo(self):
@@ -356,7 +357,7 @@ class TestGitlabClient(TestCase):
             'https://my-git.org/api/v4/projects/8', json=self.data.arbitrary_project
         )
         result = self.client.get_repo_cached(repo_id=8)
-        self.assertEqual(result, self.data.arbitrary_project)
+        assert result == self.data.arbitrary_project
 
     @responses.activate
     def test_get_repos(self):
@@ -400,34 +401,34 @@ class TestGitlabClient(TestCase):
         result = self.client.get_repos(
             include_repos=[], only_membership=False, only_owned=False
         )
-        self.assertEqual(result, [self.data.arbitrary_project])
+        assert result == [self.data.arbitrary_project]
 
         result = self.client.get_repos(
             include_repos=[], only_membership=True, only_owned=False
         )
-        self.assertEqual(result, [self.data.arbitrary_project])
+        assert result == [self.data.arbitrary_project]
 
         result = self.client.get_repos(
             include_repos=[], only_membership=True, only_owned=True
         )
-        self.assertEqual(result, [])
+        assert result == []
 
         result = self.client.get_repos(
             include_repos=['arbitrary_namespace/arbitrary_project'],
             only_membership=False,
             only_owned=False,
         )
-        self.assertEqual(result, [self.data.arbitrary_project])
+        assert result == [self.data.arbitrary_project]
 
         result = self.client.get_repos(
             include_repos=['id:8'], only_membership=False, only_owned=False
         )
-        self.assertEqual(result, [self.data.arbitrary_project])
+        assert result == [self.data.arbitrary_project]
 
         result = self.client.get_repos(
             include_repos=['non_existing'], only_membership=False, only_owned=False
         )
-        self.assertRaises(OSError)
+        pytest.raises(OSError)
 
     @responses.activate
     def test_get_notes(self):
@@ -441,7 +442,7 @@ class TestGitlabClient(TestCase):
             'issues',
             self.data.arbitrary_issue['iid'],
         )
-        self.assertEqual(result, expected)
+        assert result == expected
 
     @responses.activate
     def test_get_repo_issues(self):
@@ -449,15 +450,12 @@ class TestGitlabClient(TestCase):
             'https://my-git.org/api/v4/projects/8/issues?state=opened&page=1&per_page=100',
             json=[self.data.arbitrary_issue],
         )
-        self.assertEqual(
-            self.client.get_repo_issues(self.data.arbitrary_issue['project_id']),
-            {
-                self.data.arbitrary_issue['id']: (
-                    self.data.arbitrary_issue['project_id'],
-                    self.data.arbitrary_issue,
-                )
-            },
-        )
+        assert self.client.get_repo_issues(self.data.arbitrary_issue['project_id']) == {
+            self.data.arbitrary_issue['id']: (
+                self.data.arbitrary_issue['project_id'],
+                self.data.arbitrary_issue,
+            )
+        }
 
     @responses.activate
     def test_get_repo_merge_requests(self):
@@ -465,17 +463,14 @@ class TestGitlabClient(TestCase):
             'https://my-git.org/api/v4/projects/8/merge_requests?state=opened&page=1&per_page=100',
             json=[self.data.arbitrary_mr],
         )
-        self.assertEqual(
-            self.client.get_repo_merge_requests(
-                self.data.arbitrary_issue['project_id']
-            ),
-            {
-                self.data.arbitrary_mr['id']: (
-                    self.data.arbitrary_issue['project_id'],
-                    self.data.arbitrary_mr,
-                )
-            },
-        )
+        assert self.client.get_repo_merge_requests(
+            self.data.arbitrary_issue['project_id']
+        ) == {
+            self.data.arbitrary_mr['id']: (
+                self.data.arbitrary_issue['project_id'],
+                self.data.arbitrary_mr,
+            )
+        }
 
     @responses.activate
     def test_get_issues_from_query(self):
@@ -484,17 +479,14 @@ class TestGitlabClient(TestCase):
             + 'issues?assignee_id=2&state=opened&scope=all&page=1&per_page=100',
             json=[self.data.arbitrary_issue],
         )
-        self.assertEqual(
-            self.client.get_issues_from_query(
-                'issues?assignee_id=2&state=opened&scope=all'
-            ),
-            {
-                self.data.arbitrary_issue['id']: (
-                    self.data.arbitrary_issue['project_id'],
-                    self.data.arbitrary_issue,
-                )
-            },
-        )
+        assert self.client.get_issues_from_query(
+            'issues?assignee_id=2&state=opened&scope=all'
+        ) == {
+            self.data.arbitrary_issue['id']: (
+                self.data.arbitrary_issue['project_id'],
+                self.data.arbitrary_issue,
+            )
+        }
 
     @responses.activate
     def test_get_todos(self):
@@ -502,10 +494,9 @@ class TestGitlabClient(TestCase):
             'https://my-git.org/api/v4/todos?state=pending&page=1&per_page=100',
             json=[self.data.arbitrary_todo],
         )
-        self.assertEqual(
-            self.client.get_todos('todos?state=pending'),
-            [(self.data.arbitrary_todo['project'], self.data.arbitrary_todo)],
-        )
+        assert self.client.get_todos('todos?state=pending') == [
+            (self.data.arbitrary_todo['project'], self.data.arbitrary_todo)
+        ]
 
 
 class TestGitlabService(ConfigTest):
@@ -535,13 +526,13 @@ class TestGitlabService(ConfigTest):
     def test_keyring_service_default_host(self):
         conf = self.validate()
         conf = conf.service_configs[0]
-        self.assertEqual(conf.keyring_service, 'gitlab://foobar@gitlab.com')
+        assert conf.keyring_service == 'gitlab://foobar@gitlab.com'
 
     def test_keyring_service_custom_host(self):
         self.config['myservice']['host'] = 'my-git.org'
         conf = self.validate()
         conf = conf.service_configs[0]
-        self.assertEqual(conf.keyring_service, 'gitlab://foobar@my-git.org')
+        assert conf.keyring_service == 'gitlab://foobar@my-git.org'
 
     def test_filter_gitlab_dot_com(self):
         self.config['myservice'].update({'host': 'gitlab.com', 'owned': 'false'})
@@ -569,46 +560,42 @@ class TestGitlabService(ConfigTest):
 
     def test_add_default_namespace_to_included_repos(self):
         self.config['myservice']['include_repos'] = 'baz, banana/tree'
-        self.assertEqual(
-            self.service.config.include_repos, ['foobar/baz', 'banana/tree']
-        )
+        assert self.service.config.include_repos == ['foobar/baz', 'banana/tree']
 
     def test_add_default_namespace_to_excluded_repos(self):
         self.config['myservice']['exclude_repos'] = 'baz, banana/tree'
-        self.assertEqual(
-            self.service.config.exclude_repos, ['foobar/baz', 'banana/tree']
-        )
+        assert self.service.config.exclude_repos == ['foobar/baz', 'banana/tree']
 
     def test_filter_repos_default(self):
         repo = {'path_with_namespace': 'foobar/baz', 'id': 1234}
-        self.assertTrue(self.service.filter_repos(repo))
+        assert self.service.filter_repos(repo)
 
     def test_filter_repos_exclude(self):
         self.config['myservice']['exclude_repos'] = 'foobar/baz'
         repo = {'path_with_namespace': 'foobar/baz', 'id': 1234}
-        self.assertFalse(self.service.filter_repos(repo))
+        assert not self.service.filter_repos(repo)
 
     def test_filter_repos_exclude_id(self):
         self.config['myservice']['exclude_repos'] = 'id:1234'
         repo = {'path_with_namespace': 'foobar/baz', 'id': 1234}
-        self.assertFalse(self.service.filter_repos(repo))
+        assert not self.service.filter_repos(repo)
 
     def test_filter_repos_include(self):
         self.config['myservice']['include_repos'] = 'foobar/baz'
         repo = {'path_with_namespace': 'foobar/baz', 'id': 1234}
-        self.assertTrue(self.service.filter_repos(repo))
+        assert self.service.filter_repos(repo)
 
     def test_filter_repos_include_id(self):
         self.config['myservice']['include_repos'] = 'id:1234'
         repo = {'path_with_namespace': 'foobar/baz', 'id': 1234}
-        self.assertTrue(self.service.filter_repos(repo))
+        assert self.service.filter_repos(repo)
 
     def test_include_only_if_assigned(self):
         self.config['myservice']['only_if_assigned'] = 'jack_smith'
         data = TestData()
-        self.assertTrue(self.service.include((1, data.arbitrary_issue)))
+        assert self.service.include((1, data.arbitrary_issue))
         self.config['myservice']['only_if_assigned'] = 'smack_jith'
-        self.assertFalse(self.service.include((1, data.arbitrary_issue)))
+        assert not self.service.include((1, data.arbitrary_issue))
 
     def test_default_priorities(self):
         self.config['myservice'].update(
@@ -618,42 +605,40 @@ class TestGitlabService(ConfigTest):
                 'default_todo_priority': 'H',
             }
         )
-        self.assertEqual('L', self.service.config.default_issue_priority)
-        self.assertEqual('M', self.service.config.default_mr_priority)
-        self.assertEqual('H', self.service.config.default_todo_priority)
+        assert 'L' == self.service.config.default_issue_priority
+        assert 'M' == self.service.config.default_mr_priority
+        assert 'H' == self.service.config.default_todo_priority
 
     def test_default_priorities_fallback(self):
         self.config['myservice']['default_priority'] = 'H'
-        self.assertEqual('H', self.service.config.default_issue_priority)
-        self.assertEqual('H', self.service.config.default_mr_priority)
-        self.assertEqual('H', self.service.config.default_todo_priority)
+        assert 'H' == self.service.config.default_issue_priority
+        assert 'H' == self.service.config.default_mr_priority
+        assert 'H' == self.service.config.default_todo_priority
 
     def test_body_zero_limit(self):
         self.config['myservice']['body_length'] = 0
         issue = dict(description="A very short issue body.  Fixes #42.")
-        self.assertEqual("", self.service.description(issue))
+        assert "" == self.service.description(issue)
 
     def test_body_short_limit(self):
         size_limit = 5
         self.config['myservice']['body_length'] = size_limit
         issue = dict(description="A very short issue body.  Fixes #42.")
-        self.assertEqual(
-            issue["description"][:size_limit], self.service.description(issue)
-        )
+        assert issue["description"][:size_limit] == self.service.description(issue)
 
     def test_body_no_limit(self):
         issue = dict(description="A very short issue body.  Fixes #42.")
-        self.assertEqual(issue["description"], self.service.description(issue))
+        assert issue["description"] == self.service.description(issue)
 
     def test_undefined_owned_warning(self):
         self.config['myservice'].pop('owned')
         self.config['myservice']['membership'] = 'true'
         self.validate()
-        self.assertEqual(len(self.caplog.records), 1)
-        self.assertIn(
+        assert len(self.caplog.records) == 1
+        assert (
             "WARNING: Gitlab's 'owned' configuration field should be set "
-            "explicitly. In a future release, this will be an error.",
-            self.caplog.records[0].message,
+            "explicitly. In a future release, this will be an error."
+            in self.caplog.records[0].message
         )
 
 
@@ -704,7 +689,7 @@ class TestGitlabIssue(ServiceIssueTest):
         }
         actual_output = issue.to_taskwarrior()
 
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     def test_custom_issue_priority(self):
         overrides = {'default_issue_priority': 'L'}
@@ -740,7 +725,7 @@ class TestGitlabIssue(ServiceIssueTest):
         }
         actual_output = issue.to_taskwarrior()
 
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     def test_custom_todo_priority(self):
         overrides = {'default_todo_priority': 'H'}
@@ -781,7 +766,7 @@ class TestGitlabIssue(ServiceIssueTest):
         }
         actual_output = issue.to_taskwarrior()
 
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     def test_custom_mr_priority(self):
         overrides = {'default_mr_priority': '', 'import_labels_as_tags': True}
@@ -817,7 +802,7 @@ class TestGitlabIssue(ServiceIssueTest):
         }
         actual_output = issue.to_taskwarrior()
 
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     def test_work_in_progress(self):
         self.data.arbitrary_issue['work_in_progress'] = False
@@ -853,7 +838,7 @@ class TestGitlabIssue(ServiceIssueTest):
         }
         actual_output = issue.to_taskwarrior()
 
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     @responses.activate
     def test_issues_from_query(self):
@@ -905,7 +890,7 @@ class TestGitlabIssue(ServiceIssueTest):
             'project': 'arbitrary_username/project',
             'tags': [],
         }
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     @responses.activate
     def test_mrs_from_query(self):
@@ -963,7 +948,7 @@ class TestGitlabIssue(ServiceIssueTest):
             'project': 'arbitrary_username/project',
             'tags': [],
         }
-        self.assertEqual(TaskConstructor(mr).get_taskwarrior_record(), expected)
+        assert TaskConstructor(mr).get_taskwarrior_record() == expected
 
     @responses.activate
     def test_todos_from_query(self):
@@ -1027,7 +1012,7 @@ class TestGitlabIssue(ServiceIssueTest):
             'project': 'project',
             'tags': [],
         }
-        self.assertEqual(TaskConstructor(todo).get_taskwarrior_record(), expected)
+        assert TaskConstructor(todo).get_taskwarrior_record() == expected
 
         overrides = {
             'include_issues': 'false',
@@ -1038,7 +1023,7 @@ class TestGitlabIssue(ServiceIssueTest):
         }
         service = self.get_mock_service(GitlabService, config_overrides=overrides)
         todo = next(service.issues())
-        self.assertEqual(TaskConstructor(todo).get_taskwarrior_record(), expected)
+        assert TaskConstructor(todo).get_taskwarrior_record() == expected
 
     @responses.activate
     def test_issues(self):
@@ -1095,7 +1080,7 @@ class TestGitlabIssue(ServiceIssueTest):
             'tags': [],
         }
 
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     @responses.activate
     def test_only_if_assigned_user_lookup(self):
@@ -1119,7 +1104,7 @@ class TestGitlabIssue(ServiceIssueTest):
         service = self.get_mock_service(GitlabService, config_overrides=overrides)
 
         # Verify service was created successfully
-        self.assertIsNotNone(service)
+        assert service is not None
 
     @responses.activate
     def test_only_if_assigned_user_not_found(self):
@@ -1132,9 +1117,9 @@ class TestGitlabIssue(ServiceIssueTest):
         overrides = {'only_if_assigned': 'nonexistent_user'}
 
         # Should exit with 1
-        with self.assertRaises(SystemExit) as cm:
+        with pytest.raises(SystemExit) as cm:
             self.get_mock_service(GitlabService, config_overrides=overrides)
-        self.assertEqual(cm.exception.code, 1)
+        assert cm.value.code == 1
 
     @responses.activate
     def test_only_if_assigned_multiple_users(self):
@@ -1161,6 +1146,6 @@ class TestGitlabIssue(ServiceIssueTest):
         overrides = {'only_if_assigned': 'smith'}
 
         # Should exit with 1
-        with self.assertRaises(SystemExit) as cm:
+        with pytest.raises(SystemExit) as cm:
             self.get_mock_service(GitlabService, config_overrides=overrides)
-        self.assertEqual(cm.exception.code, 1)
+        assert cm.value.code == 1

--- a/tests/services/test_gmail.py
+++ b/tests/services/test_gmail.py
@@ -41,16 +41,16 @@ class TestGmailService(ConfigTest):
 
     def test_get_credentials_exists_and_valid(self):
         expected = Credentials(**copy(TEST_CREDENTIAL))
-        self.assertEqual(expected.valid, True)
+        assert expected.valid is True
         with open(self.service.credentials_path, "wb") as token:
             pickle.dump(expected, token)
 
-        self.assertEqual(self.service.get_credentials().to_json(), expected.to_json())
+        assert self.service.get_credentials().to_json() == expected.to_json()
 
     def test_get_credentials_with_refresh(self):
         expired_credential = Credentials(**copy(TEST_CREDENTIAL))
         expired_credential.expiry = datetime.now(timezone.utc).replace(tzinfo=None)
-        self.assertEqual(expired_credential.valid, False)
+        assert expired_credential.valid is False
         with open(self.service.credentials_path, "wb") as token:
             pickle.dump(expired_credential, token)
 
@@ -70,7 +70,7 @@ class TestGmailService(ConfigTest):
                 rapt_token,
             )
             refreshed_credential = self.service.get_credentials()
-        self.assertEqual(refreshed_credential.valid, True)
+        assert refreshed_credential.valid is True
 
 
 TEST_THREAD = {
@@ -132,7 +132,7 @@ class TestGmailIssue(ServiceIssueTest):
             self.service.main_config.data.path,
             'gmail_credentials_test_example_com.pickle',
         )
-        self.assertEqual(self.service.credentials_path, credentials_path)
+        assert self.service.credentials_path == credentials_path
 
     def test_to_taskwarrior(self):
         thread = TEST_THREAD
@@ -157,7 +157,7 @@ class TestGmailIssue(ServiceIssueTest):
         taskwarrior = issue.to_taskwarrior()
         taskwarrior['tags'] = set(taskwarrior['tags'])
 
-        self.assertEqual(taskwarrior, expected)
+        assert taskwarrior == expected
 
     def test_issues(self):
         issue = next(self.service.issues())
@@ -180,7 +180,7 @@ class TestGmailIssue(ServiceIssueTest):
         taskwarrior = TaskConstructor(issue).get_taskwarrior_record()
         taskwarrior['tags'] = set(taskwarrior['tags'])
 
-        self.assertEqual(taskwarrior, expected)
+        assert taskwarrior == expected
 
     def test_last_sender(self):
         test_thread = {
@@ -199,6 +199,7 @@ class TestGmailIssue(ServiceIssueTest):
                 },
             ]
         }
-        self.assertEqual(
-            gmail.thread_last_sender(test_thread), ('Foo Bar', 'foobar@example.com')
+        assert gmail.thread_last_sender(test_thread) == (
+            'Foo Bar',
+            'foobar@example.com',
         )

--- a/tests/services/test_jira.py
+++ b/tests/services/test_jira.py
@@ -47,7 +47,7 @@ class testJiraService(ConfigTest):
         service = JiraService(conf.service_configs[0], conf.main, _skip_server=True)
         issue = mock.Mock()
         issue.record = dict(fields=dict(description=description))
-        self.assertEqual(description[:5], service.body(issue))
+        assert description[:5] == service.body(issue)
 
     def test_body_length_limit(self):
         description = "A very short issue body.  Fixes #828."
@@ -56,7 +56,7 @@ class testJiraService(ConfigTest):
         service = JiraService(conf.service_configs[0], conf.main, _skip_server=True)
         issue = mock.Mock()
         issue.record = dict(fields=dict(description=description))
-        self.assertEqual(description, service.body(issue))
+        assert description == service.body(issue)
 
 
 class TestJiraIssue(ServiceIssueTest):
@@ -163,7 +163,7 @@ class TestJiraIssue(ServiceIssueTest):
         with mock.patch.object(issue, 'get_url', side_effect=get_url):
             actual_output = issue.to_taskwarrior()
 
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     def test_to_taskwarrior_sprint_with_goal(self):
         record_with_goal = self.arbitrary_record.copy()
@@ -208,7 +208,7 @@ class TestJiraIssue(ServiceIssueTest):
         with mock.patch.object(issue, 'get_url', side_effect=get_url):
             actual_output = issue.to_taskwarrior()
 
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     def test_issues(self):
         issue = next(self.service.issues())
@@ -237,7 +237,7 @@ class TestJiraIssue(ServiceIssueTest):
             'tags': [],
         }
 
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     def test_get_due(self):
         issue = self.service.get_issue_for_record(
@@ -245,9 +245,7 @@ class TestJiraIssue(ServiceIssueTest):
             extra={'sprint_field_names': self.service.sprint_field_names},
         )
 
-        self.assertEqual(
-            issue.get_due(), datetime(2016, 9, 23, 16, 8, tzinfo=timezone.utc)
-        )
+        assert issue.get_due() == datetime(2016, 9, 23, 16, 8, tzinfo=timezone.utc)
 
     def test_get_due_sprint_dict_missing_end_date(self):
         record = self.arbitrary_record.copy()
@@ -258,4 +256,4 @@ class TestJiraIssue(ServiceIssueTest):
             record, extra={'sprint_field_names': self.service.sprint_field_names}
         )
 
-        self.assertIsNone(issue.get_due())
+        assert issue.get_due() is None

--- a/tests/services/test_kanboard.py
+++ b/tests/services/test_kanboard.py
@@ -39,9 +39,7 @@ class TestKanboardServiceConfig(ConfigTest):
             {"url": "http://example.com/", "username": "myuser", "password": "mypass"}
         )
         service_config = self.validate().service_configs[0]
-        self.assertEqual(
-            service_config.keyring_service, "kanboard://myuser@example.com"
-        )
+        assert service_config.keyring_service == "kanboard://myuser@example.com"
 
 
 class TestKanboardService(ServiceIssueTest):
@@ -68,7 +66,7 @@ class TestKanboardService(ServiceIssueTest):
 
         annotations = self.service.annotations(task, url)
 
-        self.assertListEqual(annotations, [])
+        assert annotations == []
         self.service.client.get_all_comments.assert_not_called()
 
     def test_annotations_some_comments(self):
@@ -81,7 +79,7 @@ class TestKanboardService(ServiceIssueTest):
         ]
         annotations = self.service.annotations(task, url)
 
-        self.assertListEqual(annotations, ["@a - c1", "@b - c2"])
+        assert annotations == ["@a - c1", "@b - c2"]
         self.service.client.get_all_comments.assert_called_once_with(task_id=1)
 
     def test_to_taskwarrior(self):
@@ -120,7 +118,7 @@ class TestKanboardService(ServiceIssueTest):
         }
         actual_output = issue.to_taskwarrior()
 
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     def test_issues(self):
         # Setup the fake client
@@ -205,4 +203,4 @@ class TestKanboardService(ServiceIssueTest):
             "priority": "M",  # default priority
         }
 
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected

--- a/tests/services/test_linear.py
+++ b/tests/services/test_linear.py
@@ -108,21 +108,23 @@ class TestLinearServiceConfig(ConfigTest):
     def test_status_types_defaults_when_neither_set(self):
         self.config["linear"].update({"api_token": "abc123"})
         conf = self.validate()
-        self.assertEqual(
-            conf.service_configs[0].status_types, ["backlog", "unstarted", "started"]
-        )
+        assert conf.service_configs[0].status_types == [
+            "backlog",
+            "unstarted",
+            "started",
+        ]
 
     def test_statuses_only(self):
         self.config["linear"].update({"api_token": "abc123", "statuses": "Done, Todo"})
         conf = self.validate()
-        self.assertEqual(conf.service_configs[0].statuses, ["Done", "Todo"])
-        self.assertIsNone(conf.service_configs[0].status_types)
+        assert conf.service_configs[0].statuses == ["Done", "Todo"]
+        assert conf.service_configs[0].status_types is None
 
     def test_status_types_only(self):
         self.config["linear"].update({"api_token": "abc123", "status_types": "started"})
         conf = self.validate()
-        self.assertEqual(conf.service_configs[0].status_types, ["started"])
-        self.assertEqual(conf.service_configs[0].statuses, [])
+        assert conf.service_configs[0].status_types == ["started"]
+        assert conf.service_configs[0].statuses == []
 
 
 class TestLinearIssue(ServiceIssueTest):
@@ -165,7 +167,7 @@ class TestLinearIssue(ServiceIssueTest):
         }
 
         actual_output = issue.to_taskwarrior()
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
         issue = RESPONSE["data"]["issues"]["nodes"][1]
         issue = self.service.get_issue_for_record(issue, {})
@@ -194,7 +196,7 @@ class TestLinearIssue(ServiceIssueTest):
         }
 
         actual_output = issue.to_taskwarrior()
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     @responses.activate
     def test_issues(self):
@@ -223,7 +225,7 @@ class TestLinearIssue(ServiceIssueTest):
             "project": 'prj',
             "tags": [],
         }
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     def test_priority_mapping(self):
         # Linear priority integers must map onto taskwarrior's H/M/L buckets,
@@ -243,7 +245,7 @@ class TestLinearIssue(ServiceIssueTest):
                     "priority": linear_priority,
                 }
                 issue = self.service.get_issue_for_record(record, {})
-                self.assertEqual(issue.to_taskwarrior()["priority"], expected)
+                assert issue.to_taskwarrior()["priority"] == expected
 
         # A record without a priority key at all should also fall back.
         record = {
@@ -252,7 +254,7 @@ class TestLinearIssue(ServiceIssueTest):
             if k != "priority"
         }
         issue = self.service.get_issue_for_record(record, {})
-        self.assertEqual(issue.to_taskwarrior()["priority"], "M")
+        assert issue.to_taskwarrior()["priority"] == "M"
 
     @responses.activate
     def test_issues_paginates(self):
@@ -280,12 +282,12 @@ class TestLinearIssue(ServiceIssueTest):
         responses.add(responses.POST, "https://api.linear.app/graphql", json=page_two)
 
         identifiers = [issue.record["identifier"] for issue in self.service.issues()]
-        self.assertEqual(identifiers, ["DUS-5", "DUS-1"])
+        assert identifiers == ["DUS-5", "DUS-1"]
 
         # Two HTTP calls were made, and the second one carried the cursor
         # returned by the first.
-        self.assertEqual(len(responses.calls), 2)
+        assert len(responses.calls) == 2
         first_body = json.loads(responses.calls[0].request.body)
         second_body = json.loads(responses.calls[1].request.body)
-        self.assertIsNone(first_body["variables"]["after"])
-        self.assertEqual(second_body["variables"]["after"], "cursor-page-2")
+        assert first_body["variables"]["after"] is None
+        assert second_body["variables"]["after"] == "cursor-page-2"

--- a/tests/services/test_logseq.py
+++ b/tests/services/test_logseq.py
@@ -106,7 +106,7 @@ class TestLogseqIssue(ServiceIssueTest):
 
         actual = issue.to_taskwarrior()
 
-        self.assertEqual(actual, expected)
+        assert actual == expected
 
     def test_to_taskwarrior_with_tags(self):
         overrides = {"import_labels_as_tags": "True"}
@@ -114,7 +114,7 @@ class TestLogseqIssue(ServiceIssueTest):
         issue = service.get_issue_for_record(self.test_record, self.test_extra)
 
         actual = issue.to_taskwarrior()
-        self.assertEqual(actual["tags"], ["Testtagone", "TestTagTwo", "TestTagThree"])
+        assert actual["tags"] == ["Testtagone", "TestTagTwo", "TestTagThree"]
 
     def test_to_taskwarrior_todo(self):
         test_record = copy.copy(self.test_record)
@@ -122,7 +122,7 @@ class TestLogseqIssue(ServiceIssueTest):
         test_record["marker"] = "TODO"
         issue = self.service.get_issue_for_record(test_record, self.test_extra)
         actual = issue.to_taskwarrior()
-        self.assertEqual(actual["status"], "pending")
+        assert actual["status"] == "pending"
 
     def test_to_taskwarrior_waiting(self):
         test_record = copy.copy(self.test_record)
@@ -130,8 +130,8 @@ class TestLogseqIssue(ServiceIssueTest):
         test_record["marker"] = "WAITING"
         issue = self.service.get_issue_for_record(test_record, self.test_extra)
         actual = issue.to_taskwarrior()
-        self.assertEqual(actual["status"], "pending")
-        self.assertEqual(actual["wait"], LogseqIssue.SOMEDAY)
+        assert actual["status"] == "pending"
+        assert actual["wait"] == LogseqIssue.SOMEDAY
 
     def test_to_taskwarrior_dates_with_time(self):
         test_record = copy.copy(self.test_record)
@@ -147,10 +147,10 @@ class TestLogseqIssue(ServiceIssueTest):
 
         scheduled = datetime.datetime(year=2025, month=7, day=1, hour=12, minute=30)
         deadline = datetime.datetime(year=2025, month=7, day=31, hour=12, minute=30)
-        self.assertEqual(actual["scheduled"], scheduled)
-        self.assertEqual(actual["due"], deadline)
-        self.assertEqual(actual[issue.SCHEDULED], scheduled)
-        self.assertEqual(actual[issue.DEADLINE], deadline)
+        assert actual["scheduled"] == scheduled
+        assert actual["due"] == deadline
+        assert actual[issue.SCHEDULED] == scheduled
+        assert actual[issue.DEADLINE] == deadline
 
     def test_to_taskwarrior_dates_with_repeat(self):
         test_record = copy.copy(self.test_record)
@@ -166,10 +166,10 @@ class TestLogseqIssue(ServiceIssueTest):
 
         scheduled = datetime.datetime(year=2025, month=7, day=1, hour=12, minute=30)
         deadline = datetime.datetime(year=2025, month=7, day=31)
-        self.assertEqual(actual["scheduled"], scheduled)
-        self.assertEqual(actual["due"], deadline)
-        self.assertEqual(actual[issue.SCHEDULED], scheduled)
-        self.assertEqual(actual[issue.DEADLINE], deadline)
+        assert actual["scheduled"] == scheduled
+        assert actual["due"] == deadline
+        assert actual[issue.SCHEDULED] == scheduled
+        assert actual[issue.DEADLINE] == deadline
 
     def test_issues(self):
         self.service.client.get_graph_name.return_value = self.test_extra["graph"]
@@ -203,4 +203,4 @@ class TestLogseqIssue(ServiceIssueTest):
             issue.PAGE: "Jul 1st, 2025",
         }
 
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected

--- a/tests/services/test_pagure.py
+++ b/tests/services/test_pagure.py
@@ -35,20 +35,20 @@ class TestPagureIssue(ConfigTest):
     def test_get_tags_from_labels_uses_legacy_tag_options(self):
         issue = self.get_issue()
 
-        self.assertEqual(issue.get_tags(), ['pg_Bug', 'pg_Needs_Work'])
-        self.assertIn(
-            'import_tags is deprecated in favor of import_labels_as_tags',
-            self.caplog.text,
+        assert issue.get_tags() == ['pg_Bug', 'pg_Needs_Work']
+        assert (
+            'import_tags is deprecated in favor of import_labels_as_tags'
+            in self.caplog.text
         )
-        self.assertIn(
-            'tag_template is deprecated in favor of label_template', self.caplog.text
+        assert (
+            'tag_template is deprecated in favor of label_template' in self.caplog.text
         )
 
     def test_refine_record_does_not_apply_legacy_tag_template_as_field_template(self):
         issue = self.get_issue()
 
-        self.assertEqual(issue.config.templates, {})
-        self.assertEqual(
-            TaskConstructor(issue).get_taskwarrior_record()['tags'],
-            ['pg_Bug', 'pg_Needs_Work'],
-        )
+        assert issue.config.templates == {}
+        assert TaskConstructor(issue).get_taskwarrior_record()['tags'] == [
+            'pg_Bug',
+            'pg_Needs_Work',
+        ]

--- a/tests/services/test_phab.py
+++ b/tests/services/test_phab.py
@@ -50,7 +50,7 @@ class TestPhabricatorIssue(ServiceIssueTest):
         }
         actual_output = issue.to_taskwarrior()
 
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     @unittest.skip('The phabricator library is hard to mock.')
     def test_issues(self):

--- a/tests/services/test_phab.py
+++ b/tests/services/test_phab.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime, timedelta, timezone
-import unittest
+
+import pytest
 
 from bugwarrior.services.phab import PhabricatorService
 
@@ -52,6 +53,6 @@ class TestPhabricatorIssue(ServiceIssueTest):
 
         assert actual_output == expected_output
 
-    @unittest.skip('The phabricator library is hard to mock.')
+    @pytest.mark.skip(reason='The phabricator library is hard to mock.')
     def test_issues(self):
         pass

--- a/tests/services/test_pivotaltracker.py
+++ b/tests/services/test_pivotaltracker.py
@@ -294,7 +294,7 @@ class TestPivotalTrackerIssue(ServiceIssueTest):
             'tags': ['look_sir_metal'],
         }
         actual_output = story.to_taskwarrior()
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     @responses.activate
     def test_issues(self):
@@ -326,4 +326,4 @@ class TestPivotalTrackerIssue(ServiceIssueTest):
             'project': 'death_star',
             'tags': ['look_sir_metal'],
         }
-        self.assertEqual(TaskConstructor(story).get_taskwarrior_record(), expected)
+        assert TaskConstructor(story).get_taskwarrior_record() == expected

--- a/tests/services/test_redmine.py
+++ b/tests/services/test_redmine.py
@@ -71,7 +71,7 @@ class TestRedmineIssue(ServiceIssueTest):
         with mock.patch.object(issue, 'get_issue_url', side_effect=get_url):
             actual_output = issue.to_taskwarrior()
 
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     @responses.activate
     def test_issues(self):
@@ -106,4 +106,4 @@ class TestRedmineIssue(ServiceIssueTest):
             'tags': [],
         }
 
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected

--- a/tests/services/test_taiga.py
+++ b/tests/services/test_taiga.py
@@ -47,7 +47,7 @@ class TestTaigaIssue(ServiceIssueTest):
             'due': issue.parse_date('2026-05-18'),
         }
 
-        self.assertEqual(actual, expected)
+        assert actual == expected
 
     @responses.activate
     def test_issues(self):
@@ -86,4 +86,4 @@ class TestTaigaIssue(ServiceIssueTest):
             'due': issue.parse_date('2026-05-18'),
         }
 
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected

--- a/tests/services/test_teamwork_projects.py
+++ b/tests/services/test_teamwork_projects.py
@@ -102,7 +102,7 @@ class TestTeamworkIssue(ServiceIssueTest):
             "annotations": [('Greg McCoy', 'Test comment'), ('Bob Test', 'testing')],
         }
         actual_output = issue.to_taskwarrior()
-        self.assertEqual(actual_output, expected_data)
+        assert actual_output == expected_data
 
     @responses.activate
     def test_issues(self):
@@ -132,4 +132,4 @@ class TestTeamworkIssue(ServiceIssueTest):
             "annotations": ['@Demo User - A test comment'],
             "tags": [],
         }
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected_data)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected_data

--- a/tests/services/test_todoist.py
+++ b/tests/services/test_todoist.py
@@ -124,7 +124,7 @@ class TestTodoistIssue(ServiceIssueTest):
 
         actual = issue.to_taskwarrior()
 
-        self.assertEqual(actual, expected)
+        assert actual == expected
 
     def test_to_taskwarrior_with_labels(self):
         # Test lables when `import_labels_as_tags` is enabled
@@ -132,7 +132,7 @@ class TestTodoistIssue(ServiceIssueTest):
         service = self.get_mock_service(TodoistService, config_overrides=overrides)
         issue = service.get_issue_for_record(self.test_record, self.test_extra)
         actual = issue.to_taskwarrior()
-        self.assertEqual(actual.get("tags"), ["TESTLABEL"])
+        assert actual.get("tags") == ["TESTLABEL"]
 
     def test_to_taskwarrior_task_with_low_priority(self):
         # Test with priority set to lowest (1 in the API, which is P4 on the Todoist UI)
@@ -140,7 +140,7 @@ class TestTodoistIssue(ServiceIssueTest):
         test_record["priority"] = 1
         issue = self.service.get_issue_for_record(test_record, self.test_extra)
         actual = issue.to_taskwarrior()
-        self.assertIs(actual.get("priority"), None)
+        assert actual.get("priority") is None
 
     def test_to_taskwarrior_subtask(self):
         # subtasks have a parent id
@@ -149,12 +149,11 @@ class TestTodoistIssue(ServiceIssueTest):
         test_record["parent_id"] = "1212121212121212"
         issue = self.service.get_issue_for_record(test_record, test_extras)
         actual = issue.to_taskwarrior()
-        self.assertIs(actual.get("todoistparentid"), "1212121212121212")
-        self.assertEqual(
-            issue.get_default_description(),
-            "(bw)Subtask ##1111111111111111"
+        assert actual.get("todoistparentid") == "1212121212121212"
+        assert (
+            issue.get_default_description() == "(bw)Subtask ##1111111111111111"
             " - TESTTASK .."
-            " https://app.todoist.com/app/task/testtask-1111111111111111",
+            " https://app.todoist.com/app/task/testtask-1111111111111111"
         )
 
     def test_issues(self):
@@ -189,4 +188,4 @@ class TestTodoistIssue(ServiceIssueTest):
             issue.PARENT_ID: None,
         }
 
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected

--- a/tests/services/test_trac.py
+++ b/tests/services/test_trac.py
@@ -68,7 +68,7 @@ class TestTracIssue(ServiceIssueTest):
         }
         actual_output = issue.to_taskwarrior()
 
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     def test_issues(self):
         issue = next(self.service.issues())
@@ -85,4 +85,4 @@ class TestTracIssue(ServiceIssueTest):
             'traccomponent': 'testcomponent',
         }
 
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected

--- a/tests/services/test_trello.py
+++ b/tests/services/test_trello.py
@@ -43,14 +43,12 @@ class TestTrelloIssue(ConfigTest):
         expected_desc = (
             "(bw)#42 - So long, and thanks for all the .. https://trello.com/c/AAaaBBbb"
         )
-        self.assertEqual(expected_desc, self.issue.get_default_description())
+        assert expected_desc == self.issue.get_default_description()
 
     def test_to_taskwarrior__project(self):
         """By default, the project is the board name"""
         expected_project = "Hyperspatial express route"
-        self.assertEqual(
-            expected_project, self.issue.to_taskwarrior().get('project', None)
-        )
+        assert expected_project == self.issue.to_taskwarrior().get('project', None)
 
 
 class TestTrelloService(ConfigTest):
@@ -125,24 +123,24 @@ class TestTrelloService(ConfigTest):
         conf = self.validate()
         service = get_service_instances(conf)[0]
         boards = service.get_boards()
-        self.assertEqual(
-            list(boards),
-            [{'id': 'F00', 'name': 'Foo Board'}, {'id': 'B4R', 'name': 'Bar Board'}],
-        )
+        assert list(boards) == [
+            {'id': 'F00', 'name': 'Foo Board'},
+            {'id': 'B4R', 'name': 'Bar Board'},
+        ]
 
     @responses.activate
     def test_get_boards_api(self):
         conf = self.validate()
         service = get_service_instances(conf)[0]
         boards = service.get_boards()
-        self.assertEqual(list(boards), [self.BOARD])
+        assert list(boards) == [self.BOARD]
 
     @responses.activate
     def test_get_lists(self):
         conf = self.validate()
         service = get_service_instances(conf)[0]
         lists = service.get_lists('B04RD')
-        self.assertEqual(list(lists), [self.LIST1, self.LIST2])
+        assert list(lists) == [self.LIST1, self.LIST2]
 
     @responses.activate
     def test_get_lists_include(self):
@@ -150,7 +148,7 @@ class TestTrelloService(ConfigTest):
         conf = self.validate()
         service = get_service_instances(conf)[0]
         lists = service.get_lists('B04RD')
-        self.assertEqual(list(lists), [self.LIST1])
+        assert list(lists) == [self.LIST1]
 
     @responses.activate
     def test_get_lists_exclude(self):
@@ -158,14 +156,14 @@ class TestTrelloService(ConfigTest):
         conf = self.validate()
         service = get_service_instances(conf)[0]
         lists = service.get_lists('B04RD')
-        self.assertEqual(list(lists), [self.LIST2])
+        assert list(lists) == [self.LIST2]
 
     @responses.activate
     def test_get_cards(self):
         conf = self.validate()
         service = get_service_instances(conf)[0]
         cards = service.get_cards('L15T')
-        self.assertEqual(list(cards), [self.CARD1, self.CARD2, self.CARD3])
+        assert list(cards) == [self.CARD1, self.CARD2, self.CARD3]
 
     @responses.activate
     def test_get_cards_assigned(self):
@@ -173,7 +171,7 @@ class TestTrelloService(ConfigTest):
         conf = self.validate()
         service = get_service_instances(conf)[0]
         cards = service.get_cards('L15T')
-        self.assertEqual(list(cards), [self.CARD1])
+        assert list(cards) == [self.CARD1]
 
     @responses.activate
     def test_get_cards_assigned_unassigned(self):
@@ -183,21 +181,21 @@ class TestTrelloService(ConfigTest):
         conf = self.validate()
         service = get_service_instances(conf)[0]
         cards = service.get_cards('L15T')
-        self.assertEqual(list(cards), [self.CARD1, self.CARD3])
+        assert list(cards) == [self.CARD1, self.CARD3]
 
     @responses.activate
     def test_get_comments(self):
         conf = self.validate()
         service = get_service_instances(conf)[0]
         comments = service.get_comments('C4RD')
-        self.assertEqual(list(comments), [self.COMMENT1, self.COMMENT2])
+        assert list(comments) == [self.COMMENT1, self.COMMENT2]
 
     @responses.activate
     def test_annotations(self):
         conf = self.validate()
         service = get_service_instances(conf)[0]
         annotations = service.annotations(self.CARD1)
-        self.assertEqual(list(annotations), ["@luidgi - Preums", "@mario - Deuz"])
+        assert list(annotations) == ["@luidgi - Preums", "@mario - Deuz"]
 
     @responses.activate
     def test_annotations_with_link(self):
@@ -205,10 +203,11 @@ class TestTrelloService(ConfigTest):
         conf = self.validate()
         service = get_service_instances(conf)[0]
         annotations = service.annotations(self.CARD1)
-        self.assertEqual(
-            list(annotations),
-            ["https://trello.com/c/AAaaBBbb", "@luidgi - Preums", "@mario - Deuz"],
-        )
+        assert list(annotations) == [
+            "https://trello.com/c/AAaaBBbb",
+            "@luidgi - Preums",
+            "@mario - Deuz",
+        ]
 
     @responses.activate
     def test_issues(self):
@@ -236,7 +235,7 @@ class TestTrelloService(ConfigTest):
             'tags': [],
         }
         actual = TaskConstructor(next(issues)).get_taskwarrior_record()
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
     maxDiff = None
 
@@ -257,4 +256,4 @@ class TestTrelloService(ConfigTest):
         """Checks that the keyring service name"""
         conf = self.validate()
         keyring_service = conf.service_configs[0].keyring_service
-        self.assertEqual("trello://XXXX@trello.com", keyring_service)
+        assert "trello://XXXX@trello.com" == keyring_service

--- a/tests/services/test_youtrak.py
+++ b/tests/services/test_youtrak.py
@@ -17,8 +17,8 @@ class TestYoutrackService(ConfigTest):
     def test_keyring_service(self):
         self.config['myservice']['host'] = 'youtrack.example.com'
         service_config = self.validate().service_configs[0]
-        self.assertEqual(
-            service_config.keyring_service, 'youtrack://foobar@youtrack.example.com'
+        assert (
+            service_config.keyring_service == 'youtrack://foobar@youtrack.example.com'
         )
 
 
@@ -55,18 +55,18 @@ class TestYoutrackIssue(ServiceIssueTest):
         )
         issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
 
-        self.assertEqual(service.config.label_template, 'yt_{{label|lower}}')
-        self.assertEqual(issue.get_tags(), ['yt_bug', 'yt_new_feature'])
-        self.assertIn(
-            'import_tags is deprecated in favor of import_labels_as_tags',
-            self.caplog.text,
+        assert service.config.label_template == 'yt_{{label|lower}}'
+        assert issue.get_tags() == ['yt_bug', 'yt_new_feature']
+        assert (
+            'import_tags is deprecated in favor of import_labels_as_tags'
+            in self.caplog.text
         )
-        self.assertIn(
-            'tag_template is deprecated in favor of label_template', self.caplog.text
+        assert (
+            'tag_template is deprecated in favor of label_template' in self.caplog.text
         )
-        self.assertIn(
-            "The 'tag' variable in YouTrack label templates is deprecated in favor of 'label'.",
-            self.caplog.text,
+        assert (
+            "The 'tag' variable in YouTrack label templates is deprecated in favor of 'label'."
+            in self.caplog.text
         )
 
     def test_refine_record_does_not_apply_legacy_tag_template_as_field_template(self):
@@ -76,11 +76,11 @@ class TestYoutrackIssue(ServiceIssueTest):
         )
         issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
 
-        self.assertEqual(service.config.templates, {})
-        self.assertEqual(
-            TaskConstructor(issue).get_taskwarrior_record()['tags'],
-            ['yt_bug', 'yt_new_feature'],
-        )
+        assert service.config.templates == {}
+        assert TaskConstructor(issue).get_taskwarrior_record()['tags'] == [
+            'yt_bug',
+            'yt_new_feature',
+        ]
 
     def test_to_taskwarrior(self):
         self.service.import_tags = True
@@ -100,7 +100,7 @@ class TestYoutrackIssue(ServiceIssueTest):
         }
         actual_output = issue.to_taskwarrior()
 
-        self.assertEqual(actual_output, expected_output)
+        assert actual_output == expected_output
 
     @responses.activate
     def test_issues(self):
@@ -123,4 +123,4 @@ class TestYoutrackIssue(ServiceIssueTest):
             'youtracknumber': 1,
         }
 
-        self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -113,9 +113,9 @@ class TestPull(ConfigTest):
 
         logs = [rec.message for rec in self.caplog.records]
 
-        self.assertIn('Adding 1 tasks', logs)
-        self.assertIn('Updating 0 tasks', logs)
-        self.assertIn('Closing 0 tasks', logs)
+        assert 'Adding 1 tasks' in logs
+        assert 'Updating 0 tasks' in logs
+        assert 'Closing 0 tasks' in logs
 
     def test_failure(self):
         """
@@ -127,14 +127,14 @@ class TestPull(ConfigTest):
         ):
             self.runner.invoke(command.cli, args=('pull', '--debug'))
 
-        self.assertNotEqual(self.caplog.records, [])
-        self.assertEqual(len(self.caplog.records), 2)
-        self.assertEqual(
-            self.caplog.records[0].message, "Worker for [my_service] failed: message"
+        assert self.caplog.records != []
+        assert len(self.caplog.records) == 2
+        assert (
+            self.caplog.records[0].message == "Worker for [my_service] failed: message"
         )
-        self.assertEqual(
-            self.caplog.records[1].message,
-            "Aborted [my_service] due to critical error.",
+        assert (
+            self.caplog.records[1].message
+            == "Aborted [my_service] due to critical error."
         )
 
     def test_partial_failure_survival(self):
@@ -160,8 +160,8 @@ class TestPull(ConfigTest):
             self.runner.invoke(command.cli, args=('pull', '--debug'))
 
         logs = [rec.message for rec in self.caplog.records]
-        self.assertIn('Aborted [my_broken_service] due to critical error.', logs)
-        self.assertIn('Adding 0 tasks', logs)
+        assert 'Aborted [my_broken_service] due to critical error.' in logs
+        assert 'Adding 0 tasks' in logs
 
     def test_partial_failure_database_integrity(self):
         """
@@ -183,7 +183,7 @@ class TestPull(ConfigTest):
         with register_services(both_working), self.caplog.at_level(logging.DEBUG):
             self.runner.invoke(command.cli, args=('pull', '--debug'))
         logs = [rec.message for rec in self.caplog.records]
-        self.assertIn('Adding 2 tasks', logs)
+        assert 'Adding 2 tasks' in logs
 
         # Break the secondary service and run pull again.
         secondary_broken = {
@@ -195,12 +195,12 @@ class TestPull(ConfigTest):
         logs = [rec.message for rec in self.caplog.records]
 
         # Make sure my_broken_service failed while my_service succeeded.
-        self.assertIn('Aborted [my_broken_service] due to critical error.', logs)
-        self.assertNotIn('Aborted my_service due to critical error.', logs)
+        assert 'Aborted [my_broken_service] due to critical error.' in logs
+        assert 'Aborted my_service due to critical error.' not in logs
 
         # Assert that issues weren't closed or marked complete.
-        self.assertNotIn('Closing 1 tasks', logs)
-        self.assertNotIn('Completing task', logs)
+        assert 'Closing 1 tasks' not in logs
+        assert 'Completing task' not in logs
 
     @mock.patch('bugwarrior.command.FileLock')
     def test_locked_repository(self, file_lock):
@@ -218,12 +218,10 @@ class TestPull(ConfigTest):
         ):
             result = self.runner.invoke(command.cli, args=('pull', '--debug'))
 
-        self.assertEqual(result.exit_code, 1)
+        assert result.exit_code == 1
         file_lock.assert_called_once_with(str(lockfile_path), timeout=10)
         logs = [rec.message for rec in self.caplog.records]
-        self.assertTrue(
-            any('Your taskrc repository is currently locked.' in log for log in logs)
-        )
+        assert any('Your taskrc repository is currently locked.' in log for log in logs)
 
     def test_legacy_cli(self):
         """
@@ -239,9 +237,9 @@ class TestPull(ConfigTest):
 
         logs = [rec.message for rec in self.caplog.records]
 
-        self.assertIn('Adding 1 tasks', logs)
-        self.assertIn('Updating 0 tasks', logs)
-        self.assertIn('Closing 0 tasks', logs)
+        assert 'Adding 1 tasks' in logs
+        assert 'Updating 0 tasks' in logs
+        assert 'Closing 0 tasks' in logs
 
 
 class TestIni2Toml(TestCase):
@@ -255,8 +253,8 @@ class TestIni2Toml(TestCase):
             command.cli, args=('ini2toml', str(basedir / 'config/example-bugwarriorrc'))
         )
 
-        self.assertEqual(result.exit_code, 0)
+        assert result.exit_code == 0
 
         self.maxDiff = None
         with open(basedir / 'config/example-bugwarrior.toml', 'r') as f:
-            self.assertEqual(result.stdout, f.read())
+            assert result.stdout == f.read()

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -2,7 +2,7 @@ import logging
 import os
 import pathlib
 import typing
-from unittest import TestCase, mock
+from unittest import mock
 
 from click.testing import CliRunner
 
@@ -242,19 +242,15 @@ class TestPull(ConfigTest):
         assert 'Closing 0 tasks' in logs
 
 
-class TestIni2Toml(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.runner = CliRunner()
-
+class TestIni2Toml:
     def test_bugwarriorrc(self):
         basedir = pathlib.Path(__file__).parent
-        result = self.runner.invoke(
+        runner = CliRunner()
+        result = runner.invoke(
             command.cli, args=('ini2toml', str(basedir / 'config/example-bugwarriorrc'))
         )
 
         assert result.exit_code == 0
 
-        self.maxDiff = None
         with open(basedir / 'config/example-bugwarrior.toml', 'r') as f:
             assert result.stdout == f.read()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -102,7 +102,7 @@ class TestSynchronize(ConfigTest):
 
     def test_synchronize(self):
 
-        self.assertEqual(self.tw.load_tasks(), {'completed': [], 'pending': []})
+        assert self.tw.load_tasks() == {'completed': [], 'pending': []}
 
         issue = {
             'description': 'Blah blah blah. ☃',
@@ -123,25 +123,22 @@ class TestSynchronize(ConfigTest):
             # https://github.com/ralphbean/bugwarrior/issues/601
             self.synchronize([issue, duplicate_issue])
 
-            self.assertEqual(
-                self.get_tasks(),
-                {
-                    'completed': [],
-                    'pending': [
-                        {
-                            'project': 'sample_project',
-                            'priority': 'M',
-                            'status': 'pending',
-                            'description': 'Blah blah blah. ☃',
-                            'dumburl': 'https://example.com',
-                            'dumbtype': 'issue',
-                            'id': 1,
-                            'tags': ['bar', 'foo'],
-                            'urgency': 5.8,
-                        }
-                    ],
-                },
-            )
+            assert self.get_tasks() == {
+                'completed': [],
+                'pending': [
+                    {
+                        'project': 'sample_project',
+                        'priority': 'M',
+                        'status': 'pending',
+                        'description': 'Blah blah blah. ☃',
+                        'dumburl': 'https://example.com',
+                        'dumbtype': 'issue',
+                        'id': 1,
+                        'tags': ['bar', 'foo'],
+                        'urgency': 5.8,
+                    }
+                ],
+            }
 
         # TEST CHANGED ISSUE.
         issue['description'] = 'Yada yada yada.'
@@ -150,25 +147,22 @@ class TestSynchronize(ConfigTest):
         issue['project'] = 'other_project'
         self.synchronize([issue])
 
-        self.assertEqual(
-            self.get_tasks(),
-            {
-                'completed': [],
-                'pending': [
-                    {
-                        'priority': 'M',
-                        'project': 'sample_project',
-                        'status': 'pending',
-                        'description': 'Yada yada yada.',
-                        'dumburl': 'https://example.com',
-                        'dumbtype': 'issue',
-                        'id': 1,
-                        'tags': ['bar', 'foo'],
-                        'urgency': 5.8,
-                    }
-                ],
-            },
-        )
+        assert self.get_tasks() == {
+            'completed': [],
+            'pending': [
+                {
+                    'priority': 'M',
+                    'project': 'sample_project',
+                    'status': 'pending',
+                    'description': 'Yada yada yada.',
+                    'dumburl': 'https://example.com',
+                    'dumbtype': 'issue',
+                    'id': 1,
+                    'tags': ['bar', 'foo'],
+                    'urgency': 5.8,
+                }
+            ],
+        }
 
         # TEST CLOSED ISSUE.
         self.synchronize([])
@@ -177,54 +171,46 @@ class TestSynchronize(ConfigTest):
 
         tasks = self.remove_non_deterministic_keys(copy.deepcopy(completed_tasks))
         del tasks['completed'][0]['end']
-        self.assertEqual(
-            tasks,
-            {
-                'completed': [
-                    {
-                        'project': 'sample_project',
-                        'description': 'Yada yada yada.',
-                        'dumbtype': 'issue',
-                        'dumburl': 'https://example.com',
-                        'id': 0,
-                        'priority': 'M',
-                        'status': 'completed',
-                        'tags': ['bar', 'foo'],
-                        'urgency': 5.8,
-                    }
-                ],
-                'pending': [],
-            },
-        )
+        assert tasks == {
+            'completed': [
+                {
+                    'project': 'sample_project',
+                    'description': 'Yada yada yada.',
+                    'dumbtype': 'issue',
+                    'dumburl': 'https://example.com',
+                    'id': 0,
+                    'priority': 'M',
+                    'status': 'completed',
+                    'tags': ['bar', 'foo'],
+                    'urgency': 5.8,
+                }
+            ],
+            'pending': [],
+        }
 
         # TEST REOPENED ISSUE
         self.synchronize([issue])
 
         tasks = self.tw.load_tasks()
-        self.assertEqual(
-            completed_tasks['completed'][0]['uuid'], tasks['pending'][0]['uuid']
-        )
+        assert completed_tasks['completed'][0]['uuid'] == tasks['pending'][0]['uuid']
 
         tasks = self.remove_non_deterministic_keys(tasks)
-        self.assertEqual(
-            tasks,
-            {
-                'completed': [],
-                'pending': [
-                    {
-                        'priority': 'M',
-                        'project': 'sample_project',
-                        'status': 'pending',
-                        'description': 'Yada yada yada.',
-                        'dumburl': 'https://example.com',
-                        'dumbtype': 'issue',
-                        'id': 1,
-                        'tags': ['bar', 'foo'],
-                        'urgency': 5.8,
-                    }
-                ],
-            },
-        )
+        assert tasks == {
+            'completed': [],
+            'pending': [
+                {
+                    'priority': 'M',
+                    'project': 'sample_project',
+                    'status': 'pending',
+                    'description': 'Yada yada yada.',
+                    'dumburl': 'https://example.com',
+                    'dumbtype': 'issue',
+                    'id': 1,
+                    'tags': ['bar', 'foo'],
+                    'urgency': 5.8,
+                }
+            ],
+        }
 
 
 class TestUDAs(ConfigTest):
@@ -237,12 +223,9 @@ class TestUDAs(ConfigTest):
                 ),
             )
             udas = sorted(db.get_defined_udas_as_strings(conf))
-        self.assertEqual(
-            udas,
-            [
-                'uda.dumbtype.label=Dumb Type',
-                'uda.dumbtype.type=string',
-                'uda.dumburl.label=Dumb URL',
-                'uda.dumburl.type=string',
-            ],
-        )
+        assert udas == [
+            'uda.dumbtype.label=Dumb Type',
+            'uda.dumbtype.type=string',
+            'uda.dumburl.label=Dumb URL',
+            'uda.dumburl.type=string',
+        ]

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -33,7 +33,7 @@ class ReadmeTest(unittest.TestCase):
 
         readme_document = docutils.core.publish_doctree(readme)
         service_list_search = readme_document.traverse(condition=is_services)
-        self.assertEqual(len(service_list_search), 1)
+        assert len(service_list_search) == 1
         service_list_element = service_list_search.pop()
         readme_listed_services = set(
             list_item.astext() for list_item in service_list_element.children
@@ -49,7 +49,7 @@ class ReadmeTest(unittest.TestCase):
                     firstline = f.readline().strip()
                 documented_services.add(firstline)
 
-        self.assertEqual(documented_services, readme_listed_services)
+        assert documented_services == readme_listed_services
 
 
 class DocsTest(unittest.TestCase):
@@ -88,4 +88,4 @@ class DocsTest(unittest.TestCase):
             if re.match(r'.*\.rst$', p):
                 documented_services.add(re.sub(r'\.rst$', '', p))
 
-        self.assertEqual(registered_services, documented_services)
+        assert registered_services == documented_services

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -6,7 +6,6 @@ import re
 import socket
 import subprocess
 import tempfile
-import unittest
 
 import docutils.core
 import pytest
@@ -20,7 +19,7 @@ except OSError:
     INTERNET = False
 
 
-class ReadmeTest(unittest.TestCase):
+class TestReadme:
     def test_service_list(self):
         # GET README LISTED SERVICES
         def is_services(node):
@@ -53,7 +52,7 @@ class ReadmeTest(unittest.TestCase):
         assert documented_services == readme_listed_services
 
 
-class DocsTest(unittest.TestCase):
+class TestDocs:
     @pytest.mark.skipif(not INTERNET, reason='no internet')
     def test_docs_build_without_warning(self):
         with tempfile.TemporaryDirectory() as buildDir:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -9,6 +9,7 @@ import tempfile
 import unittest
 
 import docutils.core
+import pytest
 
 DOCS_PATH = pathlib.Path(__file__).parent / '../bugwarrior/docs'
 
@@ -53,14 +54,14 @@ class ReadmeTest(unittest.TestCase):
 
 
 class DocsTest(unittest.TestCase):
-    @unittest.skipIf(not INTERNET, 'no internet')
+    @pytest.mark.skipif(not INTERNET, reason='no internet')
     def test_docs_build_without_warning(self):
         with tempfile.TemporaryDirectory() as buildDir:
             subprocess.run(
                 ['sphinx-build', '-n', '-W', '-v', str(DOCS_PATH), buildDir], check=True
             )
 
-    @unittest.skipIf(not INTERNET, 'no internet')
+    @pytest.mark.skipif(not INTERNET, reason='no internet')
     def test_manpage_build_without_warning(self):
         with tempfile.TemporaryDirectory() as buildDir:
             subprocess.run(

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,8 +1,7 @@
 import subprocess
-import unittest
 
 
-class TestGeneral(unittest.TestCase):
+class TestGeneral:
     def test_ruff_check(self):
         subprocess.run(['ruff', 'check'], check=True)
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import re
 import unittest.mock
 
+import pytest
+
 from bugwarrior import services
 from bugwarrior.config import ServiceConfig, schema
 
@@ -43,7 +45,7 @@ class ServiceBase(ConfigTest):
 
         for method in klass.__abstractmethods__:
             references = re.findall(rf'{method}\(', base)
-            self.assertEqual(len(references), 1, references)
+            assert len(references) == 1, references
 
 
 class TestService(ServiceBase):
@@ -56,10 +58,9 @@ class TestService(ServiceBase):
         annotations = service.build_annotations(
             (('some_author', LONG_MESSAGE),), 'example.com'
         )
-        self.assertEqual(
-            annotations,
-            ['@some_author - Some message that is over 100 characters. Thi...'],
-        )
+        assert annotations == [
+            '@some_author - Some message that is over 100 characters. Thi...'
+        ]
 
     def test_build_annotations_limited(self):
         service = self.makeService(general_overrides={'annotation_length': '20'})
@@ -67,7 +68,7 @@ class TestService(ServiceBase):
         annotations = service.build_annotations(
             (('some_author', LONG_MESSAGE),), 'example.com'
         )
-        self.assertEqual(annotations, ['@some_author - Some message that is...'])
+        assert annotations == ['@some_author - Some message that is...']
 
     def test_build_annotations_limitless(self):
         service = self.makeService(general_overrides={'annotation_length': None})
@@ -75,13 +76,13 @@ class TestService(ServiceBase):
         annotations = service.build_annotations(
             (('some_author', LONG_MESSAGE),), 'example.com'
         )
-        self.assertEqual(annotations, [f'@some_author - {LONG_MESSAGE}'])
+        assert annotations == [f'@some_author - {LONG_MESSAGE}']
 
     def test_api_incompatibility_error(self):
         with unittest.mock.patch.object(
             DumbService, 'API_VERSION', new=services.LATEST_API_VERSION + 1
         ):
-            with self.assertRaisesRegex(ValueError, "Incompatible Service"):
+            with pytest.raises(ValueError, match="Incompatible Service"):
                 self.makeService()
 
     def test_api_latest_version(self):
@@ -91,7 +92,7 @@ class TestService(ServiceBase):
             match = re.fullmatch(r'Python API v(?P<version>[0-9]+\.[0-9]+)', header)
             latest_documented = float(match.groupdict()['version'])
 
-        self.assertEqual(latest_documented, services.LATEST_API_VERSION)
+        assert latest_documented == services.LATEST_API_VERSION
 
     def test_api_v1_keyring_service_backwards_compatibility(self):
         class LegacyService:
@@ -105,7 +106,7 @@ class TestService(ServiceBase):
         with unittest.mock.patch(
             'bugwarrior.config.schema.get_service', lambda _: LegacyService
         ):
-            self.assertEqual(service_config.keyring_service, 'legacy://legacy-target')
+            assert service_config.keyring_service == 'legacy://legacy-target'
 
 
 class TestIssue(ServiceBase):
@@ -116,21 +117,21 @@ class TestIssue(ServiceBase):
         issue = self.makeIssue()
 
         description = issue.build_default_description(LONG_MESSAGE)
-        self.assertEqual(description, '(bw)Is# - Some message that is over 100 chara')
+        assert description == '(bw)Is# - Some message that is over 100 chara'
 
     def test_build_default_description_limited(self):
         issue = self.makeIssue(general_overrides={'description_length': '20'})
 
         description = issue.build_default_description(LONG_MESSAGE)
-        self.assertEqual(description, '(bw)Is# - Some message that is')
+        assert description == '(bw)Is# - Some message that is'
 
     def test_build_default_description_limitless(self):
         issue = self.makeIssue(general_overrides={'description_length': None})
 
         description = issue.build_default_description(LONG_MESSAGE)
-        self.assertEqual(description, f'(bw)Is# - {LONG_MESSAGE}')
+        assert description == f'(bw)Is# - {LONG_MESSAGE}'
 
     def test_get_tags_from_labels_normalization(self):
         issue = self.makeIssue(config_overrides={'import_labels_as_tags': True})
 
-        self.assertEqual(issue.get_tags_from_labels(['needs work']), ['needs_work'])
+        assert issue.get_tags_from_labels(['needs work']) == ['needs_work']

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -36,7 +36,7 @@ class TestTemplates(ConfigTest):
             {'description': self.arbitrary_default_description, 'tags': []}
         )
 
-        self.assertEqual(record, expected_record)
+        assert record == expected_record
 
     def test_override_description(self):
         description_template = "{{ priority }} - {{ description }}"
@@ -56,7 +56,7 @@ class TestTemplates(ConfigTest):
             }
         )
 
-        self.assertEqual(record, expected_record)
+        assert record == expected_record
 
     def test_override_project(self):
         project_template = "wat_{{ project|upper }}"
@@ -73,7 +73,7 @@ class TestTemplates(ConfigTest):
             }
         )
 
-        self.assertEqual(record, expected_record)
+        assert record == expected_record
 
     def test_tag_templates(self):
         issue = self.get_issue(add_tags=['one', '{{ project }}'])
@@ -87,4 +87,4 @@ class TestTemplates(ConfigTest):
             }
         )
 
-        self.assertEqual(record, expected_record)
+        assert record == expected_record


### PR DESCRIPTION
Let's continue with test refactoring (related to #1160 )

This one mostly changes `self.assert` unittest-style assertions to plain `assert`. 
I also added some simple improvements, I keep the main changes (dropping TestCase, setUp, teardown, using fixtures instead) for another MR