### PR TITLE
Full migration to idiomatic pytest

### DIFF
--- a/bugwarrior/config/data.py
+++ b/bugwarrior/config/data.py
@@ -16,11 +16,12 @@ def get_data_path(taskrc: str | Path) -> str:
     env = dict(os.environ)
     env['TASKRC'] = str(taskrc)
 
-    tw_show = subprocess.Popen(('task', '_show'), stdout=subprocess.PIPE, env=env)
-    data_location = subprocess.check_output(
-        ('grep', '-e', '^' + line_prefix), stdin=tw_show.stdout
-    )
-    tw_show.wait()
+    with subprocess.Popen(
+        ('task', '_show'), stdout=subprocess.PIPE, env=env
+    ) as tw_show:
+        data_location = subprocess.check_output(
+            ('grep', '-e', '^' + line_prefix), stdin=tw_show.stdout
+        )
     data_path = data_location[len(line_prefix) :].rstrip().decode('utf-8')
 
     if not data_path:

--- a/bugwarrior/config/ini2toml_plugin.py
+++ b/bugwarrior/config/ini2toml_plugin.py
@@ -1,3 +1,4 @@
+import functools
 import importlib
 import inspect
 import logging
@@ -53,10 +54,18 @@ def get_field_type(attrs: dict) -> typing.Optional[str]:
     return None
 
 
+@functools.cache
+def _schema_properties(schema: type[pydantic.BaseModel]) -> dict:
+    # model_json_schema() rebuilds the schema from scratch on every call, and
+    # this is invoked once per config example in the docs build (~150+
+    # times), so cache it per schema class.
+    return schema.model_json_schema()['properties']
+
+
 def convert_section(
     section: IntermediateRepr, schema: type[pydantic.BaseModel]
 ) -> None:
-    for prop, attrs in schema.model_json_schema()['properties'].items():
+    for prop, attrs in _schema_properties(schema).items():
         field_type = get_field_type(attrs)
         if field_type == 'boolean':
             to_bool(section, prop)
@@ -64,6 +73,20 @@ def convert_section(
             to_int(section, prop)
         elif field_type == 'array':
             to_list(section, prop)
+
+
+@functools.cache
+def _service_schema(service: str) -> type[ServiceConfig]:
+    # Resolving a service's config class scans the module with
+    # inspect.getmembers() on every call, and this is invoked once per
+    # config example in the docs build (~150+ times), so cache it per
+    # service name.
+    module_name = {'bugzilla': 'bz', 'phabricator': 'phab'}.get(service, service)
+    service_module = importlib.import_module(f'bugwarrior.services.{module_name}')
+    for _, obj in inspect.getmembers(service_module, predicate=inspect.isclass):
+        if issubclass(obj, ServiceConfig):
+            return obj
+    raise ValueError(f"ServiceConfig class not found in {service} module.")
 
 
 def process_values(doc: IntermediateRepr) -> IntermediateRepr:
@@ -96,22 +119,7 @@ def process_values(doc: IntermediateRepr) -> IntermediateRepr:
                         section.rename(key, newkey)
 
                 # Get Config
-                module_name = {'bugzilla': 'bz', 'phabricator': 'phab'}.get(
-                    service, service
-                )
-                service_module = importlib.import_module(
-                    f'bugwarrior.services.{module_name}'
-                )
-                for name, obj in inspect.getmembers(
-                    service_module, predicate=inspect.isclass
-                ):
-                    if issubclass(obj, ServiceConfig):
-                        schema = obj
-                        break
-                else:
-                    raise ValueError(
-                        f"ServiceConfig class not found in {service} module."
-                    )
+                schema = _service_schema(service)
 
                 # Convert Types
                 convert_section(section, schema)

--- a/bugwarrior/config/load.py
+++ b/bugwarrior/config/load.py
@@ -50,15 +50,19 @@ def get_config_path() -> str:
 
 
 def format_config(config: dict) -> dict[str, Any]:
+    config = config.copy()
+    formatted: dict[str, Any] = {}
+    if "flavor" in config:
+        formatted["flavor"] = {**config.pop("flavor")}
     if "general" in config:
-        config.setdefault("flavor", {})["general"] = config.pop("general")
-
-    config["services"] = [
-        {**config.pop(section), "target": section}
-        for section in list(config)
-        if section not in {"hooks", "notifications", "flavor"}
+        formatted.setdefault("flavor", {})["general"] = config.pop("general")
+    for key in ("hooks", "notifications"):
+        if key in config:
+            formatted[key] = config.pop(key)
+    formatted["services"] = [
+        {**config.pop(section), "target": section} for section in list(config)
     ]
-    return config
+    return formatted
 
 
 def parse_toml_file(configpath: str) -> dict[str, Any]:

--- a/bugwarrior/config/secrets.py
+++ b/bugwarrior/config/secrets.py
@@ -90,15 +90,13 @@ def oracle_eval(command: str) -> str:
     p = subprocess.Popen(
         command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
-    p.wait()
-    assert p.stdout is not None
-    assert p.stderr is not None
+    stdout, stderr = p.communicate()
     if p.returncode == 0:
-        return p.stdout.readline().strip().decode('utf-8')
+        return stdout.split(b'\n', 1)[0].strip().decode('utf-8')
     else:
         log.critical(
             "Error retrieving password: `{command}` returned '{error}'".format(
-                command=command, error=p.stderr.read().strip()
+                command=command, error=stderr.strip()
             )
         )
         sys.exit(1)

--- a/bugwarrior/docs/_ext/config.py
+++ b/bugwarrior/docs/_ext/config.py
@@ -1,7 +1,18 @@
+import functools
+
 from ini2toml.api import Translator
 from sphinx.directives.code import CodeBlock
 from sphinx.util.docutils import SphinxDirective
 from sphinx_inline_tabs._impl import TabDirective
+
+
+@functools.cache
+def _translator() -> Translator:
+    # Translator() discovers its ini/toml plugins via importlib.metadata
+    # entry points on every instantiation, which is expensive. The plugin
+    # set is fixed for the lifetime of the process, so build one and reuse
+    # it across every ``.. config::`` directive instead of once per call.
+    return Translator()
 
 
 class Config(SphinxDirective):
@@ -29,7 +40,7 @@ class Config(SphinxDirective):
                 '[some_section]\nservice = ' + self.options['fragment'] + '\n'
             )
             initext = stub_section + initext
-        tomltext = Translator().translate(initext, 'bugwarriorrc')
+        tomltext = _translator().translate(initext, 'bugwarriorrc')
         if 'fragment' in self.options:  # remove stub
             stub_len = len(stub_section) + 2  # toml adds quotes to strings
             tomltext = tomltext[stub_len:]

--- a/bugwarrior/docs/other-services/tutorial.rst
+++ b/bugwarrior/docs/other-services/tutorial.rst
@@ -247,15 +247,13 @@ If you're developing your service in a separate package, it's time to create a `
 If you're developing in the bugwarrior repo, you can simply add your entry to the existing ``[project.entry-points."bugwarrior.service"]`` table.
 
 8. Tests
-----------
+--------
 
 .. note::
 
    The remainder of this tutorial is not geared towards third-party services. While you are free to use bugwarrior's testing infrastructure, no attempt is being made to maintain the stability of these interfaces at this time.
 
-
-
-Create a test file and implement at least the minimal service tests by inheriting from ``ServiceIssueTest``.
+Create a test file. Declare ``SERVICE_CLASS`` and ``SERVICE_CONFIG`` at module level -- these are picked up by the ``service`` and ``make_service`` fixtures shared across all service tests (see ``tests/services/conftest.py``), which build a mock service instance for you. Fake record data belongs in a ``record`` fixture rather than instance state, since a fresh dictionary per test avoids accidental sharing between tests.
 
 .. code:: bash
 
@@ -263,38 +261,57 @@ Create a test file and implement at least the minimal service tests by inheritin
 
 .. code:: python
 
-  class TestGitBugIssue(ServiceIssueTest):
-      SERVICE_CONFIG = {
-          'service': 'gitbug',
-          'path': '/dev/null',
+  from unittest import mock
+
+  import pytest
+
+  from bugwarrior.collect import TaskConstructor
+  from bugwarrior.services.gitbug import GitBugClient, GitBugService
+
+  SERVICE_CLASS = GitBugService
+
+  SERVICE_CONFIG = {
+      'service': 'gitbug',
+      'path': '/dev/null',
+  }
+
+
+  @pytest.fixture
+  def record():
+      return {
+          'id': 'arbitrary_id',
+          'title': 'arbitrary_title',
+          'state': 'open',
+          'author': {'name': 'arbitrary_author'},
+          'labels': [],
+          'createdAt': '2016-06-06T06:07:08.123-0700',
       }
 
-      def setUp(self):
-          super().setUp()
 
-          self.data = TestData()
+  class TestGitBugIssue:
+      @pytest.fixture
+      def service(self, make_service):
+          service = make_service()
+          service.client = mock.MagicMock(spec=GitBugClient)
+          return service
 
-          self.service = self.get_mock_service(GitBugService)
-          self.service.client = mock.MagicMock(spec=GitBugClient)
-          self.service.client.get_issues = mock.MagicMock(
-              return_value=[self.data.arbitrary_bug])
-
-      def test_to_taskwarrior(self):
-          issue = self.service.get_issue_for_record(
-              self.data.arbitrary_bug, {})
+      def test_to_taskwarrior(self, service, record):
+          issue = service.get_issue_for_record(record, {})
 
           expected = { ... }
 
           actual = issue.to_taskwarrior()
 
-          self.assertEqual(actual, expected)
+          assert actual == expected
 
-      def test_issues(self):
-          issue = next(self.service.issues())
+      def test_issues(self, service, record):
+          service.client.get_issues.return_value = [record]
+
+          issue = next(service.issues())
 
           expected = { ... }
 
-          self.assertEqual(TaskConstructor(issue).get_taskwarrior_record(), expected)
+          assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
 9. Documentation
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,11 +94,12 @@ quote-style = "preserve"
 skip-magic-trailing-comma = true
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "W", "I", "E501", "ANN"]
+select = ["E4", "E7", "E9", "F", "W", "I", "E501", "ANN", "PT"]
 ignore = ["ANN401"]
 # ANN rules (flake8-annotations) detect untyped code — useful for gradual typing.
 # Enforced in application code under bugwarrior/ (excluding tests/ and bugwarrior/docs/).
 # ANN401 (disallow Any) is too strict for wrappers, *args/**kwargs, and data storage.
+# PT rules (flake8-pytest-style) enforce pytest conventions in the test suite.
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["ANN"]
@@ -114,6 +115,14 @@ split-on-trailing-comma = false
 
 [tool.ruff.lint.pycodestyle]
 max-line-length = 100
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+filterwarnings = [
+    "error",
+    # taskw still uses deprecated distutils version classes.
+    "ignore::DeprecationWarning:taskw",
+]
 
 [tool.setuptools.packages.find]
 include = ["bugwarrior*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,11 @@ bugwarrior = "bugwarrior.config.ini2toml_plugin:activate"
 
 [tool.uv]
 exclude-newer = "3 days"
+# tomlkit 0.15.1's parser rewrite changed comment-whitespace serialization
+# (undocumented in its changelog): blank comment lines lose a trailing
+# space. tests/config/example-bugwarrior.toml reflects this new output;
+# pin forward so we never silently regress to the old 0.15.0 formatting.
+constraint-dependencies = ["tomlkit>=0.15.1"]
 
 [tool.ruff.format]
 quote-style = "preserve"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,8 +120,9 @@ max-line-length = 100
 testpaths = ["tests"]
 filterwarnings = [
     "error",
-    # taskw still uses deprecated distutils version classes.
-    "ignore::DeprecationWarning:taskw",
+    # taskw still uses deprecated distutils version classes; show the warning
+    # without failing the suite.
+    "default::DeprecationWarning:taskw",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,8 +3,10 @@ import typing
 import unittest.mock
 
 from bugwarrior import config, services
-from bugwarrior.config import schema, validation
+from bugwarrior.config import validation
 from bugwarrior.config.load import format_config
+
+from .services.base import get_mock_service
 
 
 class DumbConfig(config.ServiceConfig):
@@ -53,16 +55,10 @@ class DumbService(services.Service):
         raise NotImplementedError
 
 
-def make_service(general_overrides=None, config_overrides=None):
-    main_config = schema.MainSectionConfig(
-        targets=['test'], **(general_overrides or {})
-    )
-    service_config = DumbConfig(target='test', **(config_overrides or {}))
-    return DumbService(service_config, main_config)
-
-
 def make_issue(general_overrides=None, config_overrides=None):
-    service = make_service(general_overrides, config_overrides)
+    service = get_mock_service(
+        DumbService, config_overrides, general_overrides=general_overrides
+    )
     return service.get_issue_for_record({})
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,12 +1,6 @@
 import contextlib
-import os.path
-import shutil
-import tempfile
 import typing
-import unittest
 import unittest.mock
-
-import pytest
 
 from bugwarrior import config, services
 from bugwarrior.config import validation
@@ -99,53 +93,6 @@ def register_services(mapping=None):
         yield
 
 
-class ConfigTest(unittest.TestCase):
-    """
-    Creates config files, configures the environment, and cleans up afterwards.
-    """
-
-    def setUp(self):
-        self.old_environ = os.environ.copy()
-        self.tempdir = tempfile.mkdtemp(prefix='bugwarrior')
-
-        # Create temporary config files.
-        self.taskrc = os.path.join(self.tempdir, '.taskrc')
-        self.lists_path = os.path.join(self.tempdir, 'lists')
-        os.mkdir(self.lists_path)
-        with open(self.taskrc, 'w+') as fout:
-            fout.write('data.location=%s\n' % self.lists_path)
-
-        # Configure environment.
-        os.environ['HOME'] = self.tempdir
-        os.environ['XDG_CONFIG_HOME'] = os.path.join(self.tempdir, '.config')
-        os.environ.pop(config.BUGWARRIORRC, None)
-        os.environ.pop('TASKRC', None)
-        os.environ.pop('XDG_CONFIG_DIRS', None)
-
-    def tearDown(self):
-        shutil.rmtree(self.tempdir, ignore_errors=True)
-
-        os.environ.clear()
-        os.environ.update(self.old_environ)
-
-    @pytest.fixture(autouse=True)
-    def inject_fixtures(self, caplog):
-        self.caplog = caplog
-
-    def validate(self) -> validation.Config:
-        config = self.config.copy()
-        config['general'] = config.get('general', {})
-        formatted_config = format_config(config)
-        return validation.validate_config(formatted_config, 'general', 'configpath')
-
-    def assertValidationError(self, expected):
-        with pytest.raises(SystemExit):
-            self.validate()
-
-        # Only one message should be logged.
-        assert len(self.caplog.records) == 1
-
-        assert expected in self.caplog.records[0].message
-
-        # We may want to use this assertion more than once per test.
-        self.caplog.clear()
+def validate(config) -> validation.Config:
+    formatted_config = format_config(config)
+    return validation.validate_config(formatted_config, 'general', 'configpath')

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,7 +3,7 @@ import typing
 import unittest.mock
 
 from bugwarrior import config, services
-from bugwarrior.config import validation
+from bugwarrior.config import schema, validation
 from bugwarrior.config.load import format_config
 
 
@@ -51,6 +51,19 @@ class DumbService(services.Service):
 
     def issues(self):
         raise NotImplementedError
+
+
+def make_service(general_overrides=None, config_overrides=None):
+    main_config = schema.MainSectionConfig(
+        targets=['test'], **(general_overrides or {})
+    )
+    service_config = DumbConfig(target='test', **(config_overrides or {}))
+    return DumbService(service_config, main_config)
+
+
+def make_issue(general_overrides=None, config_overrides=None):
+    service = make_service(general_overrides, config_overrides)
+    return service.get_issue_for_record({})
 
 
 #: Modules that import get_service by name and must be patched together so the

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,6 +3,7 @@ import typing
 import unittest.mock
 
 from bugwarrior import config, services
+from bugwarrior.collect import get_service_instances
 from bugwarrior.config import validation
 from bugwarrior.config.load import format_config
 
@@ -105,3 +106,7 @@ def register_services(mapping=None):
 def validate(config) -> validation.Config:
     formatted_config = format_config(config)
     return validation.validate_config(formatted_config, 'general', 'configpath')
+
+
+def get_validated_service(config):
+    return get_service_instances(validate(config))[0]

--- a/tests/config/example-bugwarrior.toml
+++ b/tests/config/example-bugwarrior.toml
@@ -43,7 +43,7 @@ targets = ["gitlab_config", "jira_project", "my_github"]
 # Use hooks to run commands prior to importing from `bugwarrior pull`.
 # `bugwarrior pull` will run the commands in the order that they are specified
 # below.
-# 
+#
 # pre_import: The pre_import hook is invoked after all issues have been pulled
 # from remote sources, but before they are synced to the TW db. If your
 # pre_import script has a non-zero exit code, the `bugwarrior pull` command will
@@ -54,10 +54,10 @@ pre_import = ["/home/someuser/backup.sh", "/home/someuser/sometask.sh"]
 # This section is for configuring notifications when `bugwarrior pull` runs,
 # and when issues are created, updated, or deleted by `bugwarrior pull`.
 # Three backends are currently supported:
-# 
+#
 # - applescript        macOS      no external dependencies
 # - gobject            Linux      python gobject must be installed
-# 
+#
 
 [notifications]
 notifications = true
@@ -84,7 +84,7 @@ exclude_repos = ["project_bar", "project_baz"]
 include_repos = ["project_foo", "project_foz"]
 # Note that login and username can be different:  I can login as me, but
 # scrape issues from an organization's repos.
-# 
+#
 # - 'github.login' is the username you ask bugwarrior to
 # login as.  Set it to your account.
 # - 'github.username' is the github entity you want to pull

--- a/tests/config/test_data.py
+++ b/tests/config/test_data.py
@@ -9,8 +9,7 @@ from bugwarrior.config import data, schema
 
 def assert_0600(bw_data):
     permissions = oct(os.stat(bw_data._datafile).st_mode & 0o777)
-    # python2 -> 0600, python3 -> 0o600
-    assert permissions in ['0600', '0o600']
+    assert permissions == '0o600'
 
 
 class TestData:

--- a/tests/config/test_data.py
+++ b/tests/config/test_data.py
@@ -1,72 +1,74 @@
 import json
 import os
+from pathlib import Path
+
+import pytest
 
 from bugwarrior.config import data, schema
 
-from ..base import ConfigTest
+
+def assert_0600(bw_data):
+    permissions = oct(os.stat(bw_data._datafile).st_mode & 0o777)
+    # python2 -> 0600, python3 -> 0o600
+    assert permissions in ['0600', '0o600']
 
 
-class TestData(ConfigTest):
-    def setUp(self):
-        super().setUp()
-        self.data = data.BugwarriorData(self.lists_path)
+class TestData:
+    @pytest.fixture
+    def bw_data(self, config_environment):
+        return data.BugwarriorData(config_environment.lists_path)
 
-    def assert0600(self):
-        permissions = oct(os.stat(self.data._datafile).st_mode & 0o777)
-        # python2 -> 0600, python3 -> 0o600
-        assert permissions in ['0600', '0o600']
-
-    def test_get_set(self):
+    def test_get_set(self, bw_data):
         # "touch" data file.
-        with open(self.data._datafile, 'w+') as handle:
+        with open(bw_data._datafile, 'w+') as handle:
             json.dump({'old': 'stuff'}, handle)
 
-        self.data.set('key', 'value')
+        bw_data.set('key', 'value')
 
-        assert self.data.get('key') == 'value'
-        assert self.data.get_data() == {'old': 'stuff', 'key': 'value'}
-        self.assert0600()
+        assert bw_data.get('key') == 'value'
+        assert bw_data.get_data() == {'old': 'stuff', 'key': 'value'}
+        assert_0600(bw_data)
 
-    def test_set_first_time(self):
-        self.data.set('key', 'value')
+    def test_set_first_time(self, bw_data):
+        bw_data.set('key', 'value')
 
-        assert self.data.get('key') == 'value'
-        self.assert0600()
+        assert bw_data.get('key') == 'value'
+        assert_0600(bw_data)
 
-    def test_path_attribute(self):
-        assert self.data.path == self.lists_path
+    def test_path_attribute(self, bw_data, config_environment):
+        assert bw_data.path == config_environment.lists_path
 
 
-class TestGetDataPath(ConfigTest):
-    def setUp(self):
-        super().setUp()
-        self.main_config = schema.MainSectionConfig(targets=[])
+class TestGetDataPath:
+    @pytest.fixture
+    def main_config(self):
+        return schema.MainSectionConfig(targets=[])
 
-    def assertDataPath(self, expected_datapath):
-        assert expected_datapath == data.get_data_path(self.main_config.taskrc)
+    def assert_data_path(self, main_config, expected_datapath):
+        assert str(expected_datapath) == data.get_data_path(main_config.taskrc)
 
-    def test_TASKDATA(self):
+    def test_TASKDATA(self, main_config, monkeypatch, tmp_path):
         """
         TASKDATA should be respected, even when taskrc's data.location is set.
         """
-        datapath = os.environ['TASKDATA'] = os.path.join(self.tempdir, 'data')
-        self.assertDataPath(datapath)
+        datapath = tmp_path / 'data'
+        monkeypatch.setenv('TASKDATA', str(datapath))
+        self.assert_data_path(main_config, datapath)
 
-    def test_taskrc_datalocation(self):
+    def test_taskrc_datalocation(self, main_config, config_environment):
         """
         When TASKDATA is not set, data.location in taskrc should be respected.
         """
         assert 'TASKDATA' not in os.environ
-        self.assertDataPath(self.lists_path)
+        self.assert_data_path(main_config, config_environment.lists_path)
 
-    def test_unassigned(self):
+    def test_unassigned(self, main_config, config_environment):
         """
         When data path is not assigned, use default location.
         """
         # Empty taskrc.
-        with open(self.taskrc, 'w'):
-            pass
+        config_environment.taskrc.write_text('')
 
         assert 'TASKDATA' not in os.environ
 
-        self.assertDataPath(os.path.expanduser('~/.task'))
+        self.assert_data_path(main_config, Path.home() / '.task')

--- a/tests/config/test_load.py
+++ b/tests/config/test_load.py
@@ -1,6 +1,5 @@
 import configparser
 import itertools
-import os
 from pathlib import Path
 import textwrap
 import tomllib
@@ -9,96 +8,90 @@ import pytest
 
 from bugwarrior.config import load
 
-from ..base import ConfigTest
+
+@pytest.fixture
+def create_filepath(tmp_path):
+    """
+    Return a factory creating an empty file in the temporary home directory.
+    """
+
+    def create_filepath(path):
+        fpath = tmp_path / path
+        fpath.parent.mkdir(parents=True, exist_ok=True)
+        fpath.touch()
+        return str(fpath)
+
+    return create_filepath
 
 
-class LoadTest(ConfigTest):
-    def create(self, path):
-        """
-        Create an empty file in the temporary directory, return the full path.
-        """
-        fpath = os.path.join(self.tempdir, path)
-        if not os.path.exists(os.path.dirname(fpath)):
-            os.makedirs(os.path.dirname(fpath))
-        open(fpath, 'a').close()
-        return fpath
+class TestExample:
+    @pytest.mark.parametrize(
+        'rcfile', ['example-bugwarriorrc', 'example-bugwarrior.toml']
+    )
+    def test_example(self, rcfile, monkeypatch):
+        monkeypatch.setenv('BUGWARRIORRC', str(Path(__file__).parent / rcfile))
+        load.load_config('general', False)
 
 
-class ExampleTest(ConfigTest):
-    def setUp(self):
-        self.basedir = Path(__file__).parent
-        super().setUp()
-
-    def test_example(self):
-        for rcfile in ('example-bugwarriorrc', 'example-bugwarrior.toml'):
-            with self.subTest(rcfile=rcfile):
-                os.environ['BUGWARRIORRC'] = str(self.basedir / rcfile)
-                load.load_config('general', False)
+#: Candidate bugwarriorrc locations, ordered by precedence.
+CONFIG_PATHS = [
+    '.config/bugwarrior/bugwarriorrc',
+    '.config/bugwarrior/bugwarrior.toml',
+    '.bugwarriorrc',
+    '.bugwarrior.toml',
+]
 
 
-class TestGetConfigPath(LoadTest):
-    def test_path_precedence(self):
-        # We're going to manually setup and teardown each subTest.
-        self.tearDown()
+class TestGetConfigPath:
+    # https://docs.python.org/3/library/itertools.html#itertools.combinations
+    # > The combination tuples are emitted in lexicographic ordering
+    # > according to the order of the input iterable. So, if the input
+    # > iterable is sorted, the output tuples will be produced in sorted
+    # > order.
+    # So as long as the path list is in the correct order, path1 should have
+    # precedence.
+    @pytest.mark.parametrize(
+        ('path1', 'path2'), list(itertools.combinations(CONFIG_PATHS, 2))
+    )
+    def test_path_precedence(self, path1, path2, create_filepath):
+        config1 = create_filepath(path1)
+        create_filepath(path2)
+        assert load.get_config_path() == config1
 
-        config_paths = [  # ordered by precedence
-            '.config/bugwarrior/bugwarriorrc',
-            '.config/bugwarrior/bugwarrior.toml',
-            '.bugwarriorrc',
-            '.bugwarrior.toml',
-        ]
-
-        # https://docs.python.org/3/library/itertools.html#itertools.combinations
-        # > The combination tuples are emitted in lexicographic ordering
-        # > according to the order of the input iterable. So, if the input
-        # > iterable is sorted, the output tuples will be produced in sorted
-        # > order.
-        # So as long as the path list is in the correct order, path1 should have
-        # precedence.
-        for path1, path2 in itertools.combinations(config_paths, 2):
-            with self.subTest(path1=path1, path2=path2):
-                self.setUp()
-                try:
-                    config1 = self.create(path1)
-                    self.create(path2)
-                    assert load.get_config_path() == config1
-                finally:
-                    self.tearDown()
-
-    def test_legacy(self):
+    def test_legacy(self, create_filepath):
         """
         Falls back on .bugwarriorrc if it exists
         """
-        rc = self.create('.bugwarriorrc')
+        rc = create_filepath('.bugwarriorrc')
         assert load.get_config_path() == rc
 
-    def test_no_file(self):
+    def test_no_file(self, tmp_path):
         """
         If no bugwarriorrc exist anywhere, the path to the prefered one is
         returned.
         """
-        assert load.get_config_path() == os.path.join(
-            self.tempdir, '.config/bugwarrior/bugwarriorrc'
+        assert load.get_config_path() == str(
+            tmp_path / '.config/bugwarrior/bugwarriorrc'
         )
 
-    def test_BUGWARRIORRC(self):
+    def test_BUGWARRIORRC(self, create_filepath, tmp_path, monkeypatch):
         """
         If $BUGWARRIORRC is set, it takes precedence over everything else (even
         if the file doesn't exist).
         """
-        rc = os.path.join(self.tempdir, 'my-bugwarriorc')
-        os.environ['BUGWARRIORRC'] = rc
-        self.create('.bugwarriorrc')
-        self.create('.config/bugwarrior/bugwarriorrc')
+        rc = str(tmp_path / 'my-bugwarriorc')
+        monkeypatch.setenv('BUGWARRIORRC', rc)
+        create_filepath('.bugwarriorrc')
+        create_filepath('.config/bugwarrior/bugwarriorrc')
         assert load.get_config_path() == rc
 
-    def test_BUGWARRIORRC_empty(self):
+    def test_BUGWARRIORRC_empty(self, create_filepath, monkeypatch):
         """
         If $BUGWARRIORRC is set but empty, it is not used and the default file
         is used instead.
         """
-        os.environ['BUGWARRIORRC'] = ''
-        rc = self.create('.config/bugwarrior/bugwarriorrc')
+        monkeypatch.setenv('BUGWARRIORRC', '')
+        rc = create_filepath('.config/bugwarrior/bugwarriorrc')
         assert load.get_config_path() == rc
 
 
@@ -116,13 +109,15 @@ class TestBugwarriorConfigParser:
         assert config.getint('general', 'somenone') is None
 
     def test_getint_valueerror(self, config):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match='general.somechar must be an integer or empty.'
+        ):
             config.getint('general', 'somechar')
 
 
-class TestParseFile(LoadTest):
-    def test_toml(self):
-        config_path = self.create('.bugwarrior.toml')
+class TestParseFile:
+    def test_toml(self, create_filepath):
+        config_path = create_filepath('.bugwarrior.toml')
         with open(config_path, 'w') as fout:
             fout.write(
                 textwrap.dedent("""
@@ -133,8 +128,8 @@ class TestParseFile(LoadTest):
 
         load.parse_file(config_path)
 
-    def test_ini(self):
-        config_path = self.create('.bugwarriorrc')
+    def test_ini(self, create_filepath):
+        config_path = create_filepath('.bugwarriorrc')
         with open(config_path, 'w') as fout:
             fout.write(
                 textwrap.dedent("""
@@ -146,8 +141,8 @@ class TestParseFile(LoadTest):
 
         assert config == {'flavor': {'general': {'foo': 'bar'}}, 'services': []}
 
-    def test_toml_invalid(self):
-        config_path = self.create('.bugwarrior.toml')
+    def test_toml_invalid(self, create_filepath):
+        config_path = create_filepath('.bugwarrior.toml')
         with open(config_path, 'w') as fout:
             fout.write(
                 textwrap.dedent("""
@@ -159,8 +154,8 @@ class TestParseFile(LoadTest):
         with pytest.raises(tomllib.TOMLDecodeError):
             load.parse_file(config_path)
 
-    def test_ini_invalid(self):
-        config_path = self.create('.bugwarriorrc')
+    def test_ini_invalid(self, create_filepath):
+        config_path = create_filepath('.bugwarriorrc')
         with open(config_path, 'w') as fout:
             fout.write(
                 textwrap.dedent("""
@@ -172,8 +167,8 @@ class TestParseFile(LoadTest):
         with pytest.raises(configparser.MissingSectionHeaderError):
             load.parse_file(config_path)
 
-    def test_toml_flavors(self):
-        config_path = self.create('.bugwarrior.toml')
+    def test_toml_flavors(self, create_filepath):
+        config_path = create_filepath('.bugwarrior.toml')
 
         with open(config_path, 'w') as fout:
             fout.write('[flavor.myflavor]\ntargets = ["my_gitlab"]')
@@ -183,8 +178,8 @@ class TestParseFile(LoadTest):
             'services': [],
         }
 
-    def test_ini_flavors(self):
-        config_path = self.create('.bugwarriorrc')
+    def test_ini_flavors(self, create_filepath):
+        config_path = create_filepath('.bugwarriorrc')
         with open(config_path, 'w') as fout:
             fout.write(
                 textwrap.dedent("""
@@ -199,12 +194,12 @@ class TestParseFile(LoadTest):
             'services': [],
         }
 
-    def test_ini_options_renamed(self):
+    def test_ini_options_renamed(self, create_filepath):
         """
         Prefixes are removed and log.* are renamed log_* in main section.
         """
 
-        config_path = self.create('.bugwarriorrc')
+        config_path = create_filepath('.bugwarriorrc')
         with open(config_path, 'w') as fout:
             fout.write(
                 textwrap.dedent("""
@@ -225,8 +220,8 @@ class TestParseFile(LoadTest):
         assert 'log_level' in config['flavor']['general']
         assert 'log.level' not in config['flavor']['general']
 
-    def test_ini_missing_prefix(self):
-        config_path = self.create('.bugwarriorrc')
+    def test_ini_missing_prefix(self, create_filepath):
+        config_path = create_filepath('.bugwarriorrc')
         with open(config_path, 'w') as fout:
             fout.write(
                 textwrap.dedent("""
@@ -241,8 +236,8 @@ class TestParseFile(LoadTest):
         with pytest.raises(SystemExit):
             load.parse_file(config_path)
 
-    def test_ini_wrong_prefix(self):
-        config_path = self.create('.bugwarriorrc')
+    def test_ini_wrong_prefix(self, create_filepath):
+        config_path = create_filepath('.bugwarriorrc')
         with open(config_path, 'w') as fout:
             fout.write(
                 textwrap.dedent("""
@@ -258,13 +253,9 @@ class TestParseFile(LoadTest):
             load.parse_file(config_path)
 
 
-class TestLoadConfig(LoadTest):
-    def setUp(self):
-        self.basedir = Path(__file__).parent
-        super().setUp()
-
-    def test_main_section_does_not_exist(self):
-        config_path = self.create(".bugwarriorrc")
+class TestLoadConfig:
+    def test_main_section_does_not_exist(self, create_filepath, caplog):
+        config_path = create_filepath(".bugwarriorrc")
         with open(config_path, 'w') as fout:
             fout.write(
                 textwrap.dedent("""
@@ -277,5 +268,5 @@ class TestLoadConfig(LoadTest):
         with pytest.raises(SystemExit):
             load.load_config("general", False)
 
-        assert len(self.caplog.records) == 1
-        assert "No section: 'general'" in self.caplog.records[0].message
+        assert len(caplog.records) == 1
+        assert "No section: 'general'" in caplog.records[0].message

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -1,9 +1,7 @@
 import importlib
 from importlib.metadata import entry_points
-import os
 from pathlib import Path
 import re
-import unittest
 
 import pydantic
 from pydantic import TypeAdapter
@@ -11,28 +9,25 @@ import pytest
 
 from bugwarrior.config import schema
 
-from ..base import ConfigTest, DumbConfig
+from ..base import DumbConfig, validate
 
 
-class TestExpandedPath(unittest.TestCase):
-    def setUp(self):
-        self.adapter = TypeAdapter(schema.ExpandedPath)
-        self.dir = os.getcwd()
-        os.chdir(os.path.expanduser('~'))
-        self.log = Path('./bugwarrior.log').absolute()
+class TestExpandedPath:
+    adapter = TypeAdapter(schema.ExpandedPath)
 
-    def test_log(self):
-        filename = os.path.join(os.path.expandvars('$HOME'), self.log)
-        assert self.adapter.validate_python(filename) == self.log
+    @pytest.fixture
+    def log(self, monkeypatch):
+        monkeypatch.chdir(Path.home())
+        return Path('./bugwarrior.log').absolute()
 
-    def test_log_userhome(self):
-        assert self.adapter.validate_python('~/bugwarrior.log') == self.log
+    def test_log(self, log):
+        assert self.adapter.validate_python(str(log)) == log
 
-    def test_log_envvar(self):
-        assert self.adapter.validate_python('$HOME/bugwarrior.log') == self.log
+    def test_log_userhome(self, log):
+        assert self.adapter.validate_python('~/bugwarrior.log') == log
 
-    def tearDown(self):
-        os.chdir(self.dir)
+    def test_log_envvar(self, log):
+        assert self.adapter.validate_python('$HOME/bugwarrior.log') == log
 
 
 class TestConfigList:
@@ -50,55 +45,58 @@ class TestConfigList:
         ) == ['work', 'jira', "{{jirastatus|lower|replace(' ','_')}}"]
 
 
-class TestTaskrcPath(ConfigTest):
-    def setUp(self):
-        super().setUp()
-        self.config = {'general': {'targets': []}}
+class TestTaskrcPath:
+    @pytest.fixture
+    def config(self):
+        return {'general': {'targets': []}}
 
-    def test_default_factory_default(self):
-        config = self.validate()
-        assert str(config.main.taskrc) == os.path.join(self.tempdir, '.taskrc')
+    def test_default_factory_default(self, config, config_environment):
+        config = validate(config)
+        assert config.main.taskrc == config_environment.taskrc
 
-    def test_default_factory_env_override(self):
-        override = os.path.join(self.tempdir, 'override_taskrc')
-        with open(override, 'w+') as fout:
-            fout.write('data.location=%s\n' % self.lists_path)
-        os.environ['TASKRC'] = override
+    def test_default_factory_env_override(
+        self, config, config_environment, tmp_path, monkeypatch
+    ):
+        override = tmp_path / 'override_taskrc'
+        override.write_text(f'data.location={config_environment.lists_path}\n')
+        monkeypatch.setenv('TASKRC', str(override))
 
-        config = self.validate()
-        assert str(config.main.taskrc) == override
+        config = validate(config)
+        assert config.main.taskrc == override
 
-    def test_default_factory_xdg_config_home(self):
-        os.remove(self.taskrc)
+    def test_default_factory_xdg_config_home(
+        self, config, config_environment, tmp_path
+    ):
+        config_environment.taskrc.unlink()
 
-        dot_config_task = os.path.join(self.tempdir, '.config', 'task')
-        os.makedirs(dot_config_task)
-        taskrc = os.path.join(dot_config_task, 'taskrc')
-        with open(taskrc, 'w+') as fout:
-            fout.write('data.location=%s\n' % self.lists_path)
+        dot_config_task = tmp_path / '.config' / 'task'
+        dot_config_task.mkdir(parents=True)
+        taskrc = dot_config_task / 'taskrc'
+        taskrc.write_text(f'data.location={config_environment.lists_path}\n')
 
-        config = self.validate()
-        assert str(config.main.taskrc) == taskrc
+        config = validate(config)
+        assert config.main.taskrc == taskrc
 
-    def test_default_factory_dot_config_taskrc(self):
+    def test_default_factory_dot_config_taskrc(
+        self, config, config_environment, tmp_path, monkeypatch
+    ):
         """Taskrc is still found if XDG_CONFIG_HOME is unset."""
-        os.remove(self.taskrc)
+        config_environment.taskrc.unlink()
 
-        dot_config_task = os.path.join(self.tempdir, '.config', 'task')
-        os.makedirs(dot_config_task)
-        taskrc = os.path.join(dot_config_task, 'taskrc')
-        with open(taskrc, 'w+') as fout:
-            fout.write('data.location=%s\n' % self.lists_path)
-        del os.environ['XDG_CONFIG_HOME']
+        dot_config_task = tmp_path / '.config' / 'task'
+        dot_config_task.mkdir(parents=True)
+        taskrc = dot_config_task / 'taskrc'
+        taskrc.write_text(f'data.location={config_environment.lists_path}\n')
+        monkeypatch.delenv('XDG_CONFIG_HOME')
 
-        config = self.validate()
-        assert str(config.main.taskrc) == taskrc
+        config = validate(config)
+        assert config.main.taskrc == taskrc
 
-    def test_no_taskrc_file_found(self):
-        os.remove(self.taskrc)
+    def test_no_taskrc_file_found(self, config, config_environment):
+        config_environment.taskrc.unlink()
 
         with pytest.raises(OSError, match=r"Unable to find taskrc file\."):
-            self.validate()
+            validate(config)
 
 
 class TestUnsupportedOption:
@@ -132,31 +130,32 @@ class TestComputeTemplates:
         assert computed_values['templates'] == {'project': ''}
 
 
-class TestServices(unittest.TestCase):
-    def test_common_configuration_options(self):
+class TestServices:
+    @pytest.mark.parametrize(
+        'entry_point',
+        [pytest.param(e, id=e.name) for e in entry_points(group='bugwarrior.service')],
+    )
+    def test_common_configuration_options(self, entry_point):
         """
         Cheaply check that each service at least references all of the common
         configuration options, if for no other reason than to throw a
         validation error if they are not supported.
         """
-        for e in entry_points(group='bugwarrior.service'):
-            with self.subTest(service=e.name):
-                service_file = importlib.import_module(e.module).__file__
-                with open(service_file, 'r') as f:
-                    service_code = f.read()
-                for option in ['only_if_assigned', 'also_unassigned']:
-                    with self.subTest(option=option):
-                        assert re.search(option, service_code) is not None, (
-                            f'\
-Service should support common configuration option self.config.{option}'
-                        )
+        service_file = importlib.import_module(entry_point.module).__file__
+        with open(service_file, 'r') as f:
+            service_code = f.read()
 
-                # get_priority() makes use of the default_priority option
-                with self.subTest(option='default_priority'):
-                    assert (
-                        re.search('default_priority', service_code)
-                        or re.search('get_priority', service_code)
-                    ) is not None, (
-                        '\
+        for option in ['only_if_assigned', 'also_unassigned']:
+            assert re.search(option, service_code) is not None, (
+                f'\
+Service should support common configuration option self.config.{option}'
+            )
+
+        # get_priority() makes use of the default_priority option
+        assert (
+            re.search('default_priority', service_code)
+            or re.search('get_priority', service_code)
+        ) is not None, (
+            '\
 Service should support self.config.default_priority or use self.get_priority()'
-                    )
+        )

--- a/tests/config/test_validation.py
+++ b/tests/config/test_validation.py
@@ -8,7 +8,7 @@ from bugwarrior import config
 from bugwarrior.config import validation
 from bugwarrior.config.load import format_config, parse_file
 
-from ..base import ConfigTest, DumbConfig, DumbService, register_services
+from ..base import DumbConfig, DumbService, register_services, validate
 
 
 class ValidationConfig(DumbConfig):
@@ -40,168 +40,184 @@ class ValidationService(DumbService):
     CONFIG_SCHEMA = ValidationConfig
 
 
-class TestValidation(ConfigTest):
-    def setUp(self):
-        super().setUp()
-        self.enterContext(register_services({"test": ValidationService}))
-        self.config = {
+class TestValidation:
+    @pytest.fixture(autouse=True)
+    def registered_services(self):
+        with register_services({"test": ValidationService}):
+            yield
+
+    @pytest.fixture
+    def config(self):
+        return {
             "general": {"targets": ["my_service"]},
             "my_service": {"service": "test", "username": "ralph"},
         }
 
-    def test_valid(self):
-        self.validate()
+    def test_valid(self, config):
+        validate(config)
 
-    def test_main_section_required(self):
-        del self.config['general']
+    def test_main_section_required(self, config, caplog):
+        del config['general']
 
+        formatted = format_config(config)
         with pytest.raises(SystemExit):
-            formatted = format_config(self.config)
             validation.validate_config(formatted, 'general', 'configpath')
 
-        assert len(self.caplog.records) == 1
-        assert "No section: 'general'" in self.caplog.records[0].message
+        assert len(caplog.records) == 1
+        assert "No section: 'general'" in caplog.records[0].message
 
-    def test_main_section_missing_targets_option(self):
-        del self.config['general']['targets']
+    def test_main_section_missing_targets_option(self, config, assert_validation_error):
+        del config['general']['targets']
 
-        self.assertValidationError("[general]\ntargets  <- Field required")
+        assert_validation_error(config, "[general]\ntargets  <- Field required")
 
-    def test_target_section_missing(self):
-        del self.config['my_service']
+    def test_target_section_missing(self, config, assert_validation_error):
+        del config['my_service']
 
-        self.assertValidationError(
-            "[general]\ntargets = ['my_service']  <- No [my_service] section found"
+        assert_validation_error(
+            config,
+            "[general]\ntargets = ['my_service']  <- No [my_service] section found",
         )
 
-    def test_service_missing(self):
-        del self.config['my_service']['service']
+    def test_service_missing(self, config, assert_validation_error):
+        del config['my_service']['service']
 
-        self.assertValidationError("No option 'service' in section: 'my_service'")
+        assert_validation_error(config, "No option 'service' in section: 'my_service'")
 
-    def test_extra_field(self):
+    def test_extra_field(self, config, assert_validation_error):
         """Undeclared fields are forbidden."""
-        self.config['my_service']['undeclared_field'] = 'extra'
+        config['my_service']['undeclared_field'] = 'extra'
 
-        self.assertValidationError(
-            '[my_service]\nundeclared_field = extra  <- unrecognized option'
+        assert_validation_error(
+            config, '[my_service]\nundeclared_field = extra  <- unrecognized option'
         )
 
-    def test_root_validator(self):
-        del self.config['my_service']['username']
+    def test_root_validator(self, config, assert_validation_error):
+        del config['my_service']['username']
 
-        self.assertValidationError(
-            '[my_service]  <- Value error, section requires one of:\n    username\n    query'
+        assert_validation_error(
+            config,
+            '[my_service]  <- Value error, section requires one of:\n    username\n    query',
         )
 
-    def test_no_scheme_url_validator_default(self):
-        service_config = self.validate().service_configs[0]
+    def test_no_scheme_url_validator_default(self, config):
+        service_config = validate(config).service_configs[0]
         assert service_config.host == 'example.com'
 
-    def test_no_scheme_url_validator_set(self):
-        self.config['my_service']['host'] = 'example.com'
-        service_config = self.validate().service_configs[0]
+    def test_no_scheme_url_validator_set(self, config):
+        config['my_service']['host'] = 'example.com'
+        service_config = validate(config).service_configs[0]
         assert service_config.host == 'example.com'
 
-    def test_no_scheme_url_validator_scheme(self):
-        self.config['my_service']['host'] = 'https://example.com'
-        self.assertValidationError(
-            "host = https://example.com  <- URL should not include scheme ('https')"
+    def test_no_scheme_url_validator_scheme(self, config, assert_validation_error):
+        config['my_service']['host'] = 'https://example.com'
+        assert_validation_error(
+            config,
+            "host = https://example.com  <- URL should not include scheme ('https')",
         )
 
-    def test_stripped_trailing_slash_url(self):
-        self.config['my_service']['url'] = 'https://example.org/'
-        service_config = self.validate().service_configs[0]
+    def test_stripped_trailing_slash_url(self, config):
+        config['my_service']['url'] = 'https://example.org/'
+        service_config = validate(config).service_configs[0]
         assert service_config.url == 'https://example.org'
 
-    def test_deprecated_filter_merge_requests(self):
-        service_config = self.validate().service_configs[0]
+    def test_deprecated_filter_merge_requests(self, config):
+        service_config = validate(config).service_configs[0]
         assert service_config.include_merge_requests is True
 
-        self.config['my_service']['filter_merge_requests'] = 'true'
-        service_config = self.validate().service_configs[0]
+        config['my_service']['filter_merge_requests'] = 'true'
+        service_config = validate(config).service_configs[0]
         assert service_config.include_merge_requests is False
 
-    def test_deprecated_filter_merge_requests_and_include_merge_requests(self):
-        self.config['my_service']['filter_merge_requests'] = 'true'
-        self.config['my_service']['include_merge_requests'] = 'true'
-        self.assertValidationError(
-            'filter_merge_requests and include_merge_requests are incompatible.'
+    def test_deprecated_filter_merge_requests_and_include_merge_requests(
+        self, config, assert_validation_error
+    ):
+        config['my_service']['filter_merge_requests'] = 'true'
+        config['my_service']['include_merge_requests'] = 'true'
+        assert_validation_error(
+            config, 'filter_merge_requests and include_merge_requests are incompatible.'
         )
 
-    def test_deprecated_project_name(self):
+    def test_deprecated_project_name(self, config):
         """We're just testing that deprecation doesn't break validation."""
-        self.config['my_service']['project_name'] = 'myproject'
-        self.validate()
+        config['my_service']['project_name'] = 'myproject'
+        validate(config)
 
-    def test_flavors(self):
-        self.config['flavor'] = {'myflavor': {'targets': ['my_service']}}
-        self.validate()
+    def test_flavors(self, config):
+        config['flavor'] = {'myflavor': {'targets': ['my_service']}}
+        validate(config)
 
-    def test_quoted_flavor_key_error(self):
+    def test_quoted_flavor_key_error(self, config, assert_validation_error):
         """Using ["flavor.myflavor"] instead of [flavor.myflavor] raises an error."""
-        self.config['flavor.myflavor'] = {'targets': ['my_service']}
-        self.assertValidationError(
-            '["flavor.myflavor"]  <- Did you mean [flavor.myflavor]?'
+        config['flavor.myflavor'] = {'targets': ['my_service']}
+        assert_validation_error(
+            config, '["flavor.myflavor"]  <- Did you mean [flavor.myflavor]?'
         )
 
-    def test_hooks_invalid_option(self):
-        self.config['hooks'] = {'invalid_option': 'value'}
-        self.assertValidationError(
-            '[hooks]\ninvalid_option = value  <- unrecognized option'
+    def test_hooks_invalid_option(self, config, assert_validation_error):
+        config['hooks'] = {'invalid_option': 'value'}
+        assert_validation_error(
+            config, '[hooks]\ninvalid_option = value  <- unrecognized option'
         )
 
-    def test_notifications_invalid_backend(self):
-        self.config['notifications'] = {'backend': 'invalid_backend'}
-        self.assertValidationError(
+    def test_notifications_invalid_backend(self, config, assert_validation_error):
+        config['notifications'] = {'backend': 'invalid_backend'}
+        assert_validation_error(
+            config,
             "[notifications]\nbackend = invalid_backend  <- Input should be "
-            "'gobject', 'growlnotify' or 'applescript'"
+            "'gobject', 'growlnotify' or 'applescript'",
         )
 
-    def test_service_and_hooks_errors_reported_together(self):
-        del self.config['my_service']['service']
-        self.config['hooks'] = {'invalid_option': 'value'}
-        self.assertValidationError("No option 'service' in section: 'my_service'")
-        self.assertValidationError(
-            '[hooks]\ninvalid_option = value  <- unrecognized option'
+    def test_service_and_hooks_errors_reported_together(
+        self, config, assert_validation_error
+    ):
+        del config['my_service']['service']
+        config['hooks'] = {'invalid_option': 'value'}
+        assert_validation_error(config, "No option 'service' in section: 'my_service'")
+        assert_validation_error(
+            config, '[hooks]\ninvalid_option = value  <- unrecognized option'
         )
 
 
-class TestExampleFiles(ConfigTest):
+class TestExampleFiles:
     """
     Validates the shipped example configs against the real services.
 
     Separate from TestValidation so it does not register the fake services.
     """
 
-    def test_load_and_validate_example_files(self):
-        example_dir = Path(__file__).parent
-        config_files = [
-            example_dir / 'example-bugwarrior.toml',
-            example_dir / 'example-bugwarriorrc',
-        ]
-        expected_by_flavor = {
-            'general': {
-                'GithubConfig',
-                'GitlabConfig',
-                'GmailConfig',
-                'JiraConfig',
-                'KanboardConfig',
-                'PhabricatorConfig',
-                'PivotalTrackerConfig',
-                'RedMineConfig',
-                'TracConfig',
-            },
-            'myflavor': {'GitlabConfig', 'JiraConfig', 'GithubConfig'},
-        }
-        for config_path in config_files:
-            for main_section, expected_configs in expected_by_flavor.items():
-                with self.subTest(config=config_path.name, main_section=main_section):
-                    formatted_config = parse_file(str(config_path))
+    @pytest.mark.parametrize(
+        'config_name', ['example-bugwarrior.toml', 'example-bugwarriorrc']
+    )
+    @pytest.mark.parametrize(
+        ('main_section', 'expected_configs'),
+        [
+            (
+                'general',
+                {
+                    'GithubConfig',
+                    'GitlabConfig',
+                    'GmailConfig',
+                    'JiraConfig',
+                    'KanboardConfig',
+                    'PhabricatorConfig',
+                    'PivotalTrackerConfig',
+                    'RedMineConfig',
+                    'TracConfig',
+                },
+            ),
+            ('myflavor', {'GitlabConfig', 'JiraConfig', 'GithubConfig'}),
+        ],
+    )
+    def test_load_and_validate_example_files(
+        self, config_name, main_section, expected_configs
+    ):
+        config_path = Path(__file__).parent / config_name
+        formatted_config = parse_file(str(config_path))
 
-                    config = validation.validate_config(
-                        formatted_config, main_section, str(config_path)
-                    )
-                    assert {
-                        conf.__class__.__name__ for conf in config.service_configs
-                    } == expected_configs
+        config = validation.validate_config(
+            formatted_config, main_section, str(config_path)
+        )
+        assert {
+            conf.__class__.__name__ for conf in config.service_configs
+        } == expected_configs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,63 @@
+import dataclasses
+import pathlib
+
+import pytest
+
+from bugwarrior import config
+
+from .base import validate
+
+
+@dataclasses.dataclass
+class ConfigEnvironment:
+    """Temporary taskwarrior configuration created for each test."""
+
+    taskrc: pathlib.Path
+    lists_path: pathlib.Path
+
+
+@pytest.fixture(autouse=True)
+def config_environment(tmp_path, monkeypatch):
+    """
+    Isolate every test from the user's real taskwarrior environment.
+
+    Creates a temporary taskrc and data location and points HOME and
+    XDG_CONFIG_HOME at the temporary directory. Request this fixture by
+    name to access the generated paths.
+    """
+    lists_path = tmp_path / 'lists'
+    lists_path.mkdir()
+    taskrc = tmp_path / '.taskrc'
+    taskrc.write_text(f'data.location={lists_path}\n')
+
+    monkeypatch.setenv('HOME', str(tmp_path))
+    monkeypatch.setenv('XDG_CONFIG_HOME', str(tmp_path / '.config'))
+    monkeypatch.delenv(config.BUGWARRIORRC, raising=False)
+    monkeypatch.delenv('TASKRC', raising=False)
+    monkeypatch.delenv('XDG_CONFIG_DIRS', raising=False)
+
+    return ConfigEnvironment(taskrc=taskrc, lists_path=lists_path)
+
+
+@pytest.fixture
+def assert_validation_error(caplog):
+    """
+    Return a callable asserting that a config fails validation.
+
+    The callable validates the given config dictionary, expecting a fatal
+    exit with a single log record containing the expected message.
+    """
+
+    def check(config, expected):
+        with pytest.raises(SystemExit):
+            validate(config)
+
+        # Only one message should be logged.
+        assert len(caplog.records) == 1
+
+        assert expected in caplog.records[0].message
+
+        # We may want to use this assertion more than once per test.
+        caplog.clear()
+
+    return check

--- a/tests/services/base.py
+++ b/tests/services/base.py
@@ -1,13 +1,11 @@
 from bugwarrior.config import schema
 
-GENERAL_CONFIG = {'annotation_length': 100, 'description_length': 100}
-
 
 def get_mock_service(
     service_class, service_config=None, *, section='unspecified', general_overrides=None
 ):
     options = {
-        'general': {**GENERAL_CONFIG, 'targets': [section]},
+        'general': {'targets': [section]},
         section: {**(service_config or {}), 'target': section},
     }
     if general_overrides:

--- a/tests/services/base.py
+++ b/tests/services/base.py
@@ -1,56 +1,26 @@
-import abc
-
 from bugwarrior.config import schema
 
-from ..base import ConfigTest
+GENERAL_CONFIG = {'annotation_length': 100, 'description_length': 100}
 
 
-class ServiceTest(ConfigTest):
-    GENERAL_CONFIG = {'annotation_length': 100, 'description_length': 100}
-    SERVICE_CONFIG = {}
+def get_mock_service(
+    service_class,
+    service_config=None,
+    *,
+    section='unspecified',
+    config_overrides=None,
+    general_overrides=None,
+):
+    options = {
+        'general': {**GENERAL_CONFIG, 'targets': [section]},
+        section: {**(service_config or {}), 'target': section},
+    }
+    if config_overrides:
+        options[section].update(config_overrides)
+    if general_overrides:
+        options['general'].update(general_overrides)
 
-    @classmethod
-    def setUpClass(cls):
-        cls.maxDiff = None
+    validated_config = service_class.CONFIG_SCHEMA(**options[section])
+    main_config = schema.MainSectionConfig(**options['general'])
 
-    def get_mock_service(
-        self,
-        service_class,
-        section='unspecified',
-        config_overrides=None,
-        general_overrides=None,
-    ):
-        options = {
-            'general': {**self.GENERAL_CONFIG, 'targets': [section]},
-            section: {**self.SERVICE_CONFIG.copy(), 'target': section},
-        }
-        if config_overrides:
-            options[section].update(config_overrides)
-        if general_overrides:
-            options['general'].update(general_overrides)
-
-        service_config = service_class.CONFIG_SCHEMA(**options[section])
-        main_config = schema.MainSectionConfig(**options['general'])
-
-        return service_class(service_config, main_config)
-
-
-class ServiceIssueTest(ServiceTest, abc.ABC):
-    """Ensures that certain test methods are implemented for each service."""
-
-    @abc.abstractmethod
-    def test_to_taskwarrior(self):
-        """Test Service.to_taskwarrior()."""
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def test_issues(self):
-        """
-        Test Service.issues().
-
-        - When the API is accessed via requests, use the responses library to
-        mock requests.
-        - When the API is accessed via a third party library, substitute a fake
-        implementation class for it.
-        """
-        raise NotImplementedError
+    return service_class(validated_config, main_config)

--- a/tests/services/base.py
+++ b/tests/services/base.py
@@ -4,19 +4,12 @@ GENERAL_CONFIG = {'annotation_length': 100, 'description_length': 100}
 
 
 def get_mock_service(
-    service_class,
-    service_config=None,
-    *,
-    section='unspecified',
-    config_overrides=None,
-    general_overrides=None,
+    service_class, service_config=None, *, section='unspecified', general_overrides=None
 ):
     options = {
         'general': {**GENERAL_CONFIG, 'targets': [section]},
         section: {**(service_config or {}), 'target': section},
     }
-    if config_overrides:
-        options[section].update(config_overrides)
     if general_overrides:
         options['general'].update(general_overrides)
 

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from .base import get_mock_service
+
+
+@pytest.fixture
+def make_service(request):
+    def make(**overrides):
+        return get_mock_service(
+            request.module.SERVICE_CLASS, {**request.module.SERVICE_CONFIG, **overrides}
+        )
+
+    return make
+
+
+@pytest.fixture
+def service(make_service):
+    return make_service()

--- a/tests/services/test_azuredevops.py
+++ b/tests/services/test_azuredevops.py
@@ -155,16 +155,22 @@ class TestAzureDevopsServiceConfig:
 
 class TestAzureDevopsService:
     @pytest.fixture
-    def service(self, record):
-        return self.get_service(record)
+    def make_service(self, record):
+        def make(**overrides):
+            service = get_mock_service(
+                AzureDevopsService, {**SERVICE_CONFIG, **overrides}
+            )
+            service.client = mock.MagicMock()
+            service.client.get_parent_name.return_value = None
+            service.client.get_work_items_from_query.return_value = [1]
+            service.client.get_work_item.return_value = record
+            return service
 
-    def get_service(self, record, **overrides):
-        service = get_mock_service(AzureDevopsService, {**SERVICE_CONFIG, **overrides})
-        service.client = mock.MagicMock()
-        service.client.get_parent_name.return_value = None
-        service.client.get_work_items_from_query.return_value = [1]
-        service.client.get_work_item.return_value = record
-        return service
+        return make
+
+    @pytest.fixture
+    def service(self, make_service):
+        return make_service()
 
     def test_to_taskwarrior(self, service, record):
         issue = service.get_issue_for_record(record)
@@ -220,7 +226,7 @@ class TestAzureDevopsService:
         issue = next(service.issues())
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
-    def test_issues_wiql_filter(self, record):
+    def test_issues_wiql_filter(self, make_service):
         expected = {
             "project": None,
             "priority": "M",
@@ -241,6 +247,6 @@ class TestAzureDevopsService:
             "description": '(bw)Impediment#1 - Example Title .. https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_workitems/edit/1',  # noqa: E501
             "tags": [],
         }
-        service = self.get_service(record, wiql_filter='something')
+        service = make_service(wiql_filter='something')
         issue = next(service.issues())
         assert TaskConstructor(issue).get_taskwarrior_record() == expected

--- a/tests/services/test_azuredevops.py
+++ b/tests/services/test_azuredevops.py
@@ -155,8 +155,10 @@ class TestAzureDevopsService:
     def service(self):
         return self.get_service()
 
-    def get_service(self, **kwargs):
-        service = get_mock_service(AzureDevopsService, self.SERVICE_CONFIG, **kwargs)
+    def get_service(self, **overrides):
+        service = get_mock_service(
+            AzureDevopsService, {**self.SERVICE_CONFIG, **overrides}
+        )
         service.client = mock.MagicMock()
         service.client.get_parent_name.return_value = None
         service.client.get_work_items_from_query.return_value = [1]
@@ -239,6 +241,6 @@ class TestAzureDevopsService:
             "description": '(bw)Impediment#1 - Example Title .. https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_workitems/edit/1',  # noqa: E501
             "tags": [],
         }
-        service = self.get_service(config_overrides={'wiql_filter': 'something'})
+        service = self.get_service(wiql_filter='something')
         issue = next(service.issues())
         assert TaskConstructor(issue).get_taskwarrior_record() == expected

--- a/tests/services/test_azuredevops.py
+++ b/tests/services/test_azuredevops.py
@@ -9,110 +9,112 @@ from bugwarrior.services.azuredevops import AzureDevopsService, striphtml
 from ..base import validate
 from .base import get_mock_service
 
-TEST_ISSUE = {
-    "_links": {
-        "fields": {
-            "href": "https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_apis/wit/fields"  # noqa: E501
-        },
-        "html": {
-            "href": "https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_workitems/edit/1"  # noqa: E501
-        },
-        "self": {
-            "href": "https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_apis/wit/workItems/1"  # noqa: E501
-        },
-        "workItemComments": {
-            "href": "https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_apis/wit/workItems/1/comments"  # noqa: E501
-        },
-        "workItemRevisions": {
-            "href": "https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_apis/wit/workItems/1/revisions"  # noqa: E501
-        },
-        "workItemType": {
-            "href": "https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_apis/wit/workItemTypes/Impediment"  # noqa: E501
-        },
-        "workItemUpdates": {
-            "href": "https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_apis/wit/workItems/1/updates"  # noqa: E501
-        },
-    },
-    "fields": {
-        "Microsoft.VSTS.Common.ClosedBy": {
-            "_links": {
-                "avatar": {
-                    "href": "https://dev.azure.com/test_organization/_apis/GraphProfile/MemberAvatars/msa.MjhmZjA5NGItMDZiNy03MzgwLTk4YjQtODIwNjU4N2QzODJi"  # noqa: E501
-                }
-            },
-            "descriptor": "msa.MjhmZjA5NGItMDZiNy03MzgwLTk4YjQtODIwNjU4N2QzODJi",
-            "displayName": "testuser1",
-            "id": "28ff094b-06b7-6380-98b4-8206587d382b",
-            "imageUrl": "https://dev.azure.com/test_organization/_apis/GraphProfile/MemberAvatars/msa.MjhmZjA5NGItMDZiNy03MzgwLTk4YjQtODIwNjU4N2QzODJi",  # noqa: E501
-            "uniqueName": "testuser1@example.com",
-            "url": "https://spsprodcus3.vssps.visualstudio.com/Aa98ad20f-7b43-48c2-9693-ba2dd8786d34/_apis/Identities/28ff094b-06b7-6380-98b4-8206587d382b",  # noqa: E501
-        },
-        "Microsoft.VSTS.Common.ClosedDate": "2020-07-08T19:55:46.113Z",
-        "Microsoft.VSTS.Common.Priority": 2,
-        "Microsoft.VSTS.Common.StateChangeDate": "2020-07-08T19:55:46.113Z",
-        "System.AreaPath": "test_project",
-        "System.AssignedTo": {
-            "_links": {
-                "avatar": {
-                    "href": "https://dev.azure.com/test_organization/_apis/GraphProfile/MemberAvatars/msa.MjhmZjA5NGItMDZiNy03MzgwLTk4YjQtODIwNjU4N2QzODJi"  # noqa: E501
-                }
-            },
-            "descriptor": "msa.MjhmZjA5NGItMDZiNy03MzgwLTk4YjQtODIwNjU4N2QzODJi",
-            "displayName": "testuser1",
-            "id": "28ff094b-06b7-6380-98b4-8206587d382b",
-            "imageUrl": "https://dev.azure.com/test_organization/_apis/GraphProfile/MemberAvatars/msa.MjhmZjA5NGItMDZiNy03MzgwLTk4YjQtODIwNjU4N2QzODJi",  # noqa: E501
-            "uniqueName": "testuser1@example.com",
-            "url": "https://spsprodcus3.vssps.visualstudio.com/Aa98ad20f-7b43-48c2-9693-ba2dd8786d34/_apis/Identities/28ff094b-06b7-6380-98b4-8206587d382b",  # noqa: E501
-        },
-        "System.ChangedBy": {
-            "_links": {
-                "avatar": {
-                    "href": "https://dev.azure.com/test_organization/_apis/GraphProfile/MemberAvatars/msa.MjhmZjA5NGItMDZiNy03MzgwLTk4YjQtODIwNjU4N2QzODJi"  # noqa: E501
-                }
-            },
-            "descriptor": "msa.MjhmZjA5NGItMDZiNy03MzgwLTk4YjQtODIwNjU4N2QzODJi",
-            "displayName": "testuser1",
-            "id": "28ff094b-06b7-6380-98b4-8206587d382b",
-            "imageUrl": "https://dev.azure.com/test_organization/_apis/GraphProfile/MemberAvatars/msa.MjhmZjA5NGItMDZiNy03MzgwLTk4YjQtODIwNjU4N2QzODJi",  # noqa: E501
-            "uniqueName": "testuser1@example.com",
-            "url": "https://spsprodcus3.vssps.visualstudio.com/Aa98ad20f-7b43-48c2-9693-ba2dd8786d34/_apis/Identities/28ff094b-06b7-6380-98b4-8206587d382b",  # noqa: E501
-        },
-        "System.ChangedDate": "2020-07-08T19:55:46.113Z",
-        "System.CommentCount": 1,
-        "System.CreatedBy": {
-            "_links": {
-                "avatar": {
-                    "href": "https://dev.azure.com/test_organization/_apis/GraphProfile/MemberAvatars/msa.MTU2MzZhMTEtZDA2Ny03ZWE5LTllNzItNWQ5ODhjMTYzMWM0"  # noqa: E501
-                }
-            },
-            "descriptor": "msa.MTU2MzZhMTEtZDA2Ny03ZWE5LTllNzItNWQ5ODhjMTYzMWM0",
-            "displayName": "testuser2",
-            "id": "15636a11-d067-6ea9-9e72-5d988c1631c4",
-            "imageUrl": "https://dev.azure.com/test_organization/_apis/GraphProfile/MemberAvatars/msa.MTU2MzZhMTEtZDA2Ny03ZWE5LTllNzItNWQ5ODhjMTYzMWM0",  # noqa: E501
-            "uniqueName": "testuser2@example.com",
-            "url": "https://spsprodcus3.vssps.visualstudio.com/Aa98ad20f-7b43-48c2-9693-ba2dd8786d34/_apis/Identities/15636a11-d067-6ea9-9e72-5d988c1631c4",  # noqa: E501
-        },
-        "System.CreatedDate": "2020-07-08T17:31:46.493Z",
-        "System.Description": "<h1> This Description has some html in it </h1>",
-        "System.IterationPath": "test_project\\2020.4",
-        "System.Reason": "Impediment removed",
-        "System.State": "Closed",
-        "System.TeamProject": "test_project",
-        "System.Title": "Example Title",
-        "System.WorkItemType": "Impediment",
-    },
-    "id": 1,
-    "rev": 4,
-    "url": "https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_apis/wit/workItems/1",  # noqa: E501
-}
-
-
 SERVICE_CONFIG = {
     "service": "azuredevops",
     "organization": "test_organization",
     "project": "test_project",
     "PAT": "myPAT",
 }
+
+
+@pytest.fixture
+def record():
+    return {
+        "_links": {
+            "fields": {
+                "href": "https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_apis/wit/fields"  # noqa: E501
+            },
+            "html": {
+                "href": "https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_workitems/edit/1"  # noqa: E501
+            },
+            "self": {
+                "href": "https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_apis/wit/workItems/1"  # noqa: E501
+            },
+            "workItemComments": {
+                "href": "https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_apis/wit/workItems/1/comments"  # noqa: E501
+            },
+            "workItemRevisions": {
+                "href": "https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_apis/wit/workItems/1/revisions"  # noqa: E501
+            },
+            "workItemType": {
+                "href": "https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_apis/wit/workItemTypes/Impediment"  # noqa: E501
+            },
+            "workItemUpdates": {
+                "href": "https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_apis/wit/workItems/1/updates"  # noqa: E501
+            },
+        },
+        "fields": {
+            "Microsoft.VSTS.Common.ClosedBy": {
+                "_links": {
+                    "avatar": {
+                        "href": "https://dev.azure.com/test_organization/_apis/GraphProfile/MemberAvatars/msa.MjhmZjA5NGItMDZiNy03MzgwLTk4YjQtODIwNjU4N2QzODJi"  # noqa: E501
+                    }
+                },
+                "descriptor": "msa.MjhmZjA5NGItMDZiNy03MzgwLTk4YjQtODIwNjU4N2QzODJi",
+                "displayName": "testuser1",
+                "id": "28ff094b-06b7-6380-98b4-8206587d382b",
+                "imageUrl": "https://dev.azure.com/test_organization/_apis/GraphProfile/MemberAvatars/msa.MjhmZjA5NGItMDZiNy03MzgwLTk4YjQtODIwNjU4N2QzODJi",  # noqa: E501
+                "uniqueName": "testuser1@example.com",
+                "url": "https://spsprodcus3.vssps.visualstudio.com/Aa98ad20f-7b43-48c2-9693-ba2dd8786d34/_apis/Identities/28ff094b-06b7-6380-98b4-8206587d382b",  # noqa: E501
+            },
+            "Microsoft.VSTS.Common.ClosedDate": "2020-07-08T19:55:46.113Z",
+            "Microsoft.VSTS.Common.Priority": 2,
+            "Microsoft.VSTS.Common.StateChangeDate": "2020-07-08T19:55:46.113Z",
+            "System.AreaPath": "test_project",
+            "System.AssignedTo": {
+                "_links": {
+                    "avatar": {
+                        "href": "https://dev.azure.com/test_organization/_apis/GraphProfile/MemberAvatars/msa.MjhmZjA5NGItMDZiNy03MzgwLTk4YjQtODIwNjU4N2QzODJi"  # noqa: E501
+                    }
+                },
+                "descriptor": "msa.MjhmZjA5NGItMDZiNy03MzgwLTk4YjQtODIwNjU4N2QzODJi",
+                "displayName": "testuser1",
+                "id": "28ff094b-06b7-6380-98b4-8206587d382b",
+                "imageUrl": "https://dev.azure.com/test_organization/_apis/GraphProfile/MemberAvatars/msa.MjhmZjA5NGItMDZiNy03MzgwLTk4YjQtODIwNjU4N2QzODJi",  # noqa: E501
+                "uniqueName": "testuser1@example.com",
+                "url": "https://spsprodcus3.vssps.visualstudio.com/Aa98ad20f-7b43-48c2-9693-ba2dd8786d34/_apis/Identities/28ff094b-06b7-6380-98b4-8206587d382b",  # noqa: E501
+            },
+            "System.ChangedBy": {
+                "_links": {
+                    "avatar": {
+                        "href": "https://dev.azure.com/test_organization/_apis/GraphProfile/MemberAvatars/msa.MjhmZjA5NGItMDZiNy03MzgwLTk4YjQtODIwNjU4N2QzODJi"  # noqa: E501
+                    }
+                },
+                "descriptor": "msa.MjhmZjA5NGItMDZiNy03MzgwLTk4YjQtODIwNjU4N2QzODJi",
+                "displayName": "testuser1",
+                "id": "28ff094b-06b7-6380-98b4-8206587d382b",
+                "imageUrl": "https://dev.azure.com/test_organization/_apis/GraphProfile/MemberAvatars/msa.MjhmZjA5NGItMDZiNy03MzgwLTk4YjQtODIwNjU4N2QzODJi",  # noqa: E501
+                "uniqueName": "testuser1@example.com",
+                "url": "https://spsprodcus3.vssps.visualstudio.com/Aa98ad20f-7b43-48c2-9693-ba2dd8786d34/_apis/Identities/28ff094b-06b7-6380-98b4-8206587d382b",  # noqa: E501
+            },
+            "System.ChangedDate": "2020-07-08T19:55:46.113Z",
+            "System.CommentCount": 1,
+            "System.CreatedBy": {
+                "_links": {
+                    "avatar": {
+                        "href": "https://dev.azure.com/test_organization/_apis/GraphProfile/MemberAvatars/msa.MTU2MzZhMTEtZDA2Ny03ZWE5LTllNzItNWQ5ODhjMTYzMWM0"  # noqa: E501
+                    }
+                },
+                "descriptor": "msa.MTU2MzZhMTEtZDA2Ny03ZWE5LTllNzItNWQ5ODhjMTYzMWM0",
+                "displayName": "testuser2",
+                "id": "15636a11-d067-6ea9-9e72-5d988c1631c4",
+                "imageUrl": "https://dev.azure.com/test_organization/_apis/GraphProfile/MemberAvatars/msa.MTU2MzZhMTEtZDA2Ny03ZWE5LTllNzItNWQ5ODhjMTYzMWM0",  # noqa: E501
+                "uniqueName": "testuser2@example.com",
+                "url": "https://spsprodcus3.vssps.visualstudio.com/Aa98ad20f-7b43-48c2-9693-ba2dd8786d34/_apis/Identities/15636a11-d067-6ea9-9e72-5d988c1631c4",  # noqa: E501
+            },
+            "System.CreatedDate": "2020-07-08T17:31:46.493Z",
+            "System.Description": "<h1> This Description has some html in it </h1>",
+            "System.IterationPath": "test_project\\2020.4",
+            "System.Reason": "Impediment removed",
+            "System.State": "Closed",
+            "System.TeamProject": "test_project",
+            "System.Title": "Example Title",
+            "System.WorkItemType": "Impediment",
+        },
+        "id": 1,
+        "rev": 4,
+        "url": "https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_apis/wit/workItems/1",  # noqa: E501
+    }
 
 
 class TestAzureDevopsServiceConfig:
@@ -153,19 +155,18 @@ class TestAzureDevopsServiceConfig:
 
 class TestAzureDevopsService:
     @pytest.fixture
-    def service(self):
-        return self.get_service()
+    def service(self, record):
+        return self.get_service(record)
 
-    def get_service(self, **overrides):
+    def get_service(self, record, **overrides):
         service = get_mock_service(AzureDevopsService, {**SERVICE_CONFIG, **overrides})
         service.client = mock.MagicMock()
         service.client.get_parent_name.return_value = None
         service.client.get_work_items_from_query.return_value = [1]
-        service.client.get_work_item.return_value = TEST_ISSUE
+        service.client.get_work_item.return_value = record
         return service
 
-    def test_to_taskwarrior(self, service):
-        record = TEST_ISSUE
+    def test_to_taskwarrior(self, service, record):
         issue = service.get_issue_for_record(record)
         extra = {
             "project": None,
@@ -175,13 +176,13 @@ class TestAzureDevopsService:
         issue.extra.update(extra)
 
         expected = {
-            issue.TITLE: TEST_ISSUE["fields"]["System.Title"],
-            issue.DESCRIPTION: striphtml(TEST_ISSUE["fields"]["System.Description"]),
-            issue.ID: TEST_ISSUE["id"],
-            issue.URL: TEST_ISSUE["_links"]["html"]["href"],
-            issue.TYPE: TEST_ISSUE["fields"]["System.WorkItemType"],
-            issue.STATE: TEST_ISSUE["fields"]["System.State"],
-            issue.PRIORITY: TEST_ISSUE["fields"]["Microsoft.VSTS.Common.Priority"],
+            issue.TITLE: record["fields"]["System.Title"],
+            issue.DESCRIPTION: striphtml(record["fields"]["System.Description"]),
+            issue.ID: record["id"],
+            issue.URL: record["_links"]["html"]["href"],
+            issue.TYPE: record["fields"]["System.WorkItemType"],
+            issue.STATE: record["fields"]["System.State"],
+            issue.PRIORITY: record["fields"]["Microsoft.VSTS.Common.Priority"],
             "priority": "M",
             "project": None,
             "annotations": [],
@@ -219,7 +220,7 @@ class TestAzureDevopsService:
         issue = next(service.issues())
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
-    def test_issues_wiql_filter(self):
+    def test_issues_wiql_filter(self, record):
         expected = {
             "project": None,
             "priority": "M",
@@ -240,6 +241,6 @@ class TestAzureDevopsService:
             "description": '(bw)Impediment#1 - Example Title .. https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_workitems/edit/1',  # noqa: E501
             "tags": [],
         }
-        service = self.get_service(wiql_filter='something')
+        service = self.get_service(record, wiql_filter='something')
         issue = next(service.issues())
         assert TaskConstructor(issue).get_taskwarrior_record() == expected

--- a/tests/services/test_azuredevops.py
+++ b/tests/services/test_azuredevops.py
@@ -1,10 +1,13 @@
 from datetime import datetime, timezone
 from unittest import mock
 
+import pytest
+
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.azuredevops import AzureDevopsService, striphtml
 
-from .base import ConfigTest, ServiceIssueTest
+from ..base import validate
+from .base import get_mock_service
 
 TEST_ISSUE = {
     "_links": {
@@ -104,45 +107,43 @@ TEST_ISSUE = {
 }
 
 
-class TestAzureDevopsServiceConfig(ConfigTest):
-    def setUp(self):
-        super().setUp()
-        self.config = {
+class TestAzureDevopsServiceConfig:
+    @pytest.fixture
+    def config(self):
+        return {
             "general": {"targets": ["test_ado"]},
             "test_ado": {"service": "azuredevops"},
         }
 
-    def test_validate_config_required_fields(self):
-        self.config["test_ado"].update(
+    def test_validate_config_required_fields(self, config):
+        config["test_ado"].update(
             {
                 "organization": "test_organization",
                 "project": "test_project",
                 "PAT": "myPAT",
             }
         )
-        self.validate()
+        validate(config)
 
-    def test_validate_config_no_organization(self):
-        self.config["test_ado"].update({"project": "test_project", "PAT": "myPAT"})
+    def test_validate_config_no_organization(self, config, assert_validation_error):
+        config["test_ado"].update({"project": "test_project", "PAT": "myPAT"})
 
-        self.assertValidationError('[test_ado]\norganization  <- Field required')
+        assert_validation_error(config, '[test_ado]\norganization  <- Field required')
 
-    def test_validate_config_no_project(self):
-        self.config["test_ado"].update(
-            {"organization": "http://one.com/", "PAT": "myPAT"}
-        )
+    def test_validate_config_no_project(self, config, assert_validation_error):
+        config["test_ado"].update({"organization": "http://one.com/", "PAT": "myPAT"})
 
-        self.assertValidationError('[test_ado]\nproject  <- Field required')
+        assert_validation_error(config, '[test_ado]\nproject  <- Field required')
 
-    def test_validate_config_no_PAT(self):
-        self.config["test_ado"].update(
+    def test_validate_config_no_PAT(self, config, assert_validation_error):
+        config["test_ado"].update(
             {"organization": "http://one.com/", "project": "test_project"}
         )
 
-        self.assertValidationError('[test_ado]\nPAT  <- Field required')
+        assert_validation_error(config, '[test_ado]\nPAT  <- Field required')
 
 
-class TestAzureDevopsService(ServiceIssueTest):
+class TestAzureDevopsService:
     SERVICE_CONFIG = {
         "service": "azuredevops",
         "organization": "test_organization",
@@ -150,25 +151,21 @@ class TestAzureDevopsService(ServiceIssueTest):
         "PAT": "myPAT",
     }
 
-    @property
+    @pytest.fixture
     def service(self):
         return self.get_service()
 
-    def get_service(self, *args, **kwargs):
-        service = self.get_mock_service(AzureDevopsService, *args, **kwargs)
+    def get_service(self, **kwargs):
+        service = get_mock_service(AzureDevopsService, self.SERVICE_CONFIG, **kwargs)
+        service.client = mock.MagicMock()
         service.client.get_parent_name.return_value = None
         service.client.get_work_items_from_query.return_value = [1]
         service.client.get_work_item.return_value = TEST_ISSUE
         return service
 
-    def get_mock_service(self, *args, **kwargs):
-        service = super().get_mock_service(*args, **kwargs)
-        service.client = mock.MagicMock()
-        return service
-
-    def test_to_taskwarrior(self):
+    def test_to_taskwarrior(self, service):
         record = TEST_ISSUE
-        issue = self.service.get_issue_for_record(record)
+        issue = service.get_issue_for_record(record)
         extra = {
             "project": None,
             "annotations": [],
@@ -197,7 +194,7 @@ class TestAzureDevopsService(ServiceIssueTest):
         actual_output = issue.to_taskwarrior()
         assert actual_output == expected
 
-    def test_issues(self):
+    def test_issues(self, service):
         expected = {
             "project": None,
             "priority": "M",
@@ -218,7 +215,7 @@ class TestAzureDevopsService(ServiceIssueTest):
             "description": '(bw)Impediment#1 - Example Title .. https://dev.azure.com/test_organization/c2957126-cdef-4f9a-bcc8-09323d1b7095/_workitems/edit/1',  # noqa: E501
             "tags": [],
         }
-        issue = next(self.service.issues())
+        issue = next(service.issues())
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     def test_issues_wiql_filter(self):

--- a/tests/services/test_azuredevops.py
+++ b/tests/services/test_azuredevops.py
@@ -117,16 +117,16 @@ def record():
     }
 
 
-class TestAzureDevopsServiceConfig:
+class TestAzureDevopsConfig:
     @pytest.fixture
     def config(self):
         return {
-            "general": {"targets": ["test_ado"]},
-            "test_ado": {"service": "azuredevops"},
+            "general": {"targets": ["myservice"]},
+            "myservice": {"service": "azuredevops"},
         }
 
     def test_validate_config_required_fields(self, config):
-        config["test_ado"].update(
+        config["myservice"].update(
             {
                 "organization": "test_organization",
                 "project": "test_project",
@@ -136,21 +136,21 @@ class TestAzureDevopsServiceConfig:
         validate(config)
 
     def test_validate_config_no_organization(self, config, assert_validation_error):
-        config["test_ado"].update({"project": "test_project", "PAT": "myPAT"})
+        config["myservice"].update({"project": "test_project", "PAT": "myPAT"})
 
-        assert_validation_error(config, '[test_ado]\norganization  <- Field required')
+        assert_validation_error(config, '[myservice]\norganization  <- Field required')
 
     def test_validate_config_no_project(self, config, assert_validation_error):
-        config["test_ado"].update({"organization": "http://one.com/", "PAT": "myPAT"})
+        config["myservice"].update({"organization": "http://one.com/", "PAT": "myPAT"})
 
-        assert_validation_error(config, '[test_ado]\nproject  <- Field required')
+        assert_validation_error(config, '[myservice]\nproject  <- Field required')
 
     def test_validate_config_no_PAT(self, config, assert_validation_error):
-        config["test_ado"].update(
+        config["myservice"].update(
             {"organization": "http://one.com/", "project": "test_project"}
         )
 
-        assert_validation_error(config, '[test_ado]\nPAT  <- Field required')
+        assert_validation_error(config, '[myservice]\nPAT  <- Field required')
 
 
 class TestAzureDevopsService:

--- a/tests/services/test_azuredevops.py
+++ b/tests/services/test_azuredevops.py
@@ -107,6 +107,14 @@ TEST_ISSUE = {
 }
 
 
+SERVICE_CONFIG = {
+    "service": "azuredevops",
+    "organization": "test_organization",
+    "project": "test_project",
+    "PAT": "myPAT",
+}
+
+
 class TestAzureDevopsServiceConfig:
     @pytest.fixture
     def config(self):
@@ -144,21 +152,12 @@ class TestAzureDevopsServiceConfig:
 
 
 class TestAzureDevopsService:
-    SERVICE_CONFIG = {
-        "service": "azuredevops",
-        "organization": "test_organization",
-        "project": "test_project",
-        "PAT": "myPAT",
-    }
-
     @pytest.fixture
     def service(self):
         return self.get_service()
 
     def get_service(self, **overrides):
-        service = get_mock_service(
-            AzureDevopsService, {**self.SERVICE_CONFIG, **overrides}
-        )
+        service = get_mock_service(AzureDevopsService, {**SERVICE_CONFIG, **overrides})
         service.client = mock.MagicMock()
         service.client.get_parent_name.return_value = None
         service.client.get_work_items_from_query.return_value = [1]

--- a/tests/services/test_bitbucket.py
+++ b/tests/services/test_bitbucket.py
@@ -6,15 +6,15 @@ from bugwarrior.services.bitbucket import BitbucketService
 
 from .base import get_mock_service
 
+SERVICE_CONFIG = {
+    'service': 'bitbucket',
+    'username': 'somename',
+    'key': 'something',
+    'secret': 'something else',
+}
+
 
 class TestBitbucketIssue:
-    SERVICE_CONFIG = {
-        'service': 'bitbucket',
-        'username': 'somename',
-        'key': 'something',
-        'secret': 'something else',
-    }
-
     @pytest.fixture
     def service(self):
         with responses.mock:
@@ -22,7 +22,7 @@ class TestBitbucketIssue:
                 'https://bitbucket.org/site/oauth2/access_token',
                 json={'access_token': 'sometoken', 'refresh_token': 'anothertoken'},
             )
-            return get_mock_service(BitbucketService, self.SERVICE_CONFIG)
+            return get_mock_service(BitbucketService, SERVICE_CONFIG)
 
     def test_to_taskwarrior(self, service):
         arbitrary_issue = {'priority': 'trivial', 'id': '100', 'title': 'Some Title'}

--- a/tests/services/test_bitbucket.py
+++ b/tests/services/test_bitbucket.py
@@ -4,7 +4,7 @@ import responses
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.bitbucket import BitbucketService
 
-from .base import get_mock_service
+SERVICE_CLASS = BitbucketService
 
 SERVICE_CONFIG = {
     'service': 'bitbucket',
@@ -30,13 +30,13 @@ def extra():
 
 class TestBitbucketIssue:
     @pytest.fixture
-    def service(self):
+    def service(self, make_service):
         with responses.mock:
             responses.post(
                 'https://bitbucket.org/site/oauth2/access_token',
                 json={'access_token': 'sometoken', 'refresh_token': 'anothertoken'},
             )
-            return get_mock_service(BitbucketService, SERVICE_CONFIG)
+            return make_service()
 
     def test_to_taskwarrior(self, service, record, extra):
         issue = service.get_issue_for_record(record, extra)

--- a/tests/services/test_bitbucket.py
+++ b/tests/services/test_bitbucket.py
@@ -1,12 +1,13 @@
+import pytest
 import responses
 
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.bitbucket import BitbucketService
 
-from .base import ServiceIssueTest
+from .base import get_mock_service
 
 
-class TestBitbucketIssue(ServiceIssueTest):
+class TestBitbucketIssue:
     SERVICE_CONFIG = {
         'service': 'bitbucket',
         'username': 'somename',
@@ -14,17 +15,16 @@ class TestBitbucketIssue(ServiceIssueTest):
         'secret': 'something else',
     }
 
-    @responses.activate
-    def setUp(self):
-        super().setUp()
+    @pytest.fixture
+    def service(self):
+        with responses.mock:
+            responses.post(
+                'https://bitbucket.org/site/oauth2/access_token',
+                json={'access_token': 'sometoken', 'refresh_token': 'anothertoken'},
+            )
+            return get_mock_service(BitbucketService, self.SERVICE_CONFIG)
 
-        responses.post(
-            'https://bitbucket.org/site/oauth2/access_token',
-            json={'access_token': 'sometoken', 'refresh_token': 'anothertoken'},
-        )
-        self.service = self.get_mock_service(BitbucketService)
-
-    def test_to_taskwarrior(self):
+    def test_to_taskwarrior(self, service):
         arbitrary_issue = {'priority': 'trivial', 'id': '100', 'title': 'Some Title'}
         arbitrary_extra = {
             'url': 'http://hello-there.com/',
@@ -32,7 +32,7 @@ class TestBitbucketIssue(ServiceIssueTest):
             'annotations': ['One'],
         }
 
-        issue = self.service.get_issue_for_record(arbitrary_issue, arbitrary_extra)
+        issue = service.get_issue_for_record(arbitrary_issue, arbitrary_extra)
 
         expected_output = {
             'project': arbitrary_extra['project'],
@@ -47,7 +47,7 @@ class TestBitbucketIssue(ServiceIssueTest):
         assert actual_output == expected_output
 
     @responses.activate
-    def test_issues(self):
+    def test_issues(self, service):
         responses.get(
             'https://api.bitbucket.org/2.0/repositories/somename/',
             json={'values': [{'full_name': 'somename/somerepo', 'has_issues': True}]},
@@ -93,7 +93,7 @@ class TestBitbucketIssue(ServiceIssueTest):
             },
         )
 
-        issue, pr = (i for i in self.service.issues())
+        issue, pr = (i for i in service.issues())
 
         expected_issue = {
             'annotations': ['@nobody - Some comment.'],
@@ -121,16 +121,16 @@ class TestBitbucketIssue(ServiceIssueTest):
 
         assert TaskConstructor(pr).get_taskwarrior_record() == expected_pr
 
-    def test_get_owner(self):
+    def test_get_owner(self, service):
         issue = {'title': 'Foobar', 'assignee': {'username': 'tintin'}}
-        assert self.service.get_owner(('foo', issue)) == 'tintin'
+        assert service.get_owner(('foo', issue)) == 'tintin'
 
-    def test_get_owner_none(self):
+    def test_get_owner_none(self, service):
         issue = {'title': 'Foobar', 'assignee': None}
-        assert self.service.get_owner(('foo', issue)) is None
+        assert service.get_owner(('foo', issue)) is None
 
     @responses.activate
-    def test_fetch_issues_pagination(self):
+    def test_fetch_issues_pagination(self, service):
         responses.get(
             'https://api.bitbucket.org/2.0/repositories/somename/somerepo/issues/',
             json={
@@ -158,7 +158,7 @@ class TestBitbucketIssue(ServiceIssueTest):
                 ]
             },
         )
-        issues = list(self.service.fetch_issues('somename/somerepo'))
+        issues = list(service.fetch_issues('somename/somerepo'))
         expected = [
             (
                 'somename/somerepo',

--- a/tests/services/test_bitbucket.py
+++ b/tests/services/test_bitbucket.py
@@ -14,6 +14,20 @@ SERVICE_CONFIG = {
 }
 
 
+@pytest.fixture
+def record():
+    return {'priority': 'trivial', 'id': '100', 'title': 'Some Title'}
+
+
+@pytest.fixture
+def extra():
+    return {
+        'url': 'http://hello-there.com/',
+        'project': 'Something',
+        'annotations': ['One'],
+    }
+
+
 class TestBitbucketIssue:
     @pytest.fixture
     def service(self):
@@ -24,23 +38,16 @@ class TestBitbucketIssue:
             )
             return get_mock_service(BitbucketService, SERVICE_CONFIG)
 
-    def test_to_taskwarrior(self, service):
-        arbitrary_issue = {'priority': 'trivial', 'id': '100', 'title': 'Some Title'}
-        arbitrary_extra = {
-            'url': 'http://hello-there.com/',
-            'project': 'Something',
-            'annotations': ['One'],
-        }
-
-        issue = service.get_issue_for_record(arbitrary_issue, arbitrary_extra)
+    def test_to_taskwarrior(self, service, record, extra):
+        issue = service.get_issue_for_record(record, extra)
 
         expected_output = {
-            'project': arbitrary_extra['project'],
-            'priority': issue.PRIORITY_MAP[arbitrary_issue['priority']],
-            'annotations': arbitrary_extra['annotations'],
-            issue.URL: arbitrary_extra['url'],
-            issue.FOREIGN_ID: arbitrary_issue['id'],
-            issue.TITLE: arbitrary_issue['title'],
+            'project': extra['project'],
+            'priority': issue.PRIORITY_MAP[record['priority']],
+            'annotations': extra['annotations'],
+            issue.URL: extra['url'],
+            issue.FOREIGN_ID: record['id'],
+            issue.TITLE: record['title'],
         }
         actual_output = issue.to_taskwarrior()
 

--- a/tests/services/test_bts.py
+++ b/tests/services/test_bts.py
@@ -1,11 +1,9 @@
 from unittest import mock
 
-import pytest
-
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services import bts
 
-from .base import get_mock_service
+SERVICE_CLASS = bts.BTSService
 
 SERVICE_CONFIG = {'service': 'bts', 'email': 'irl@debian.org', 'packages': 'bugwarrior'}
 
@@ -34,10 +32,6 @@ class FakeBTSLib:
 
 
 class TestBTSService:
-    @pytest.fixture
-    def service(self):
-        return get_mock_service(bts.BTSService, SERVICE_CONFIG)
-
     def test_to_taskwarrior(self, service):
         issue = service.get_issue_for_record(service._record_for_bug(FakeBTSBug))
 

--- a/tests/services/test_bts.py
+++ b/tests/services/test_bts.py
@@ -7,6 +7,8 @@ from bugwarrior.services import bts
 
 from .base import get_mock_service
 
+SERVICE_CONFIG = {'service': 'bts', 'email': 'irl@debian.org', 'packages': 'bugwarrior'}
+
 
 class FakeBTSBug:
     bug_num = 810629
@@ -32,15 +34,9 @@ class FakeBTSLib:
 
 
 class TestBTSService:
-    SERVICE_CONFIG = {
-        'service': 'bts',
-        'email': 'irl@debian.org',
-        'packages': 'bugwarrior',
-    }
-
     @pytest.fixture
     def service(self):
-        return get_mock_service(bts.BTSService, self.SERVICE_CONFIG)
+        return get_mock_service(bts.BTSService, SERVICE_CONFIG)
 
     def test_to_taskwarrior(self, service):
         issue = service.get_issue_for_record(service._record_for_bug(FakeBTSBug))

--- a/tests/services/test_bts.py
+++ b/tests/services/test_bts.py
@@ -77,8 +77,7 @@ class TestBTSService:
             'btsurl': 'https://bugs.debian.org/810629',
             'btssource': '',
             'description': (
-                '(bw)Is#810629 - ITP: bugwarrior -- Pull tickets from github, '
-                'bitbucket, bugzilla, jira, trac, and others into taskwa .. '
+                '(bw)Is#810629 - ITP: bugwarrior -- Pull tickets fro .. '
                 'https://bugs.debian.org/810629'
             ),
             'priority': 'L',

--- a/tests/services/test_bts.py
+++ b/tests/services/test_bts.py
@@ -1,9 +1,11 @@
 from unittest import mock
 
+import pytest
+
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services import bts
 
-from .base import ServiceIssueTest
+from .base import get_mock_service
 
 
 class FakeBTSBug:
@@ -29,21 +31,19 @@ class FakeBTSLib:
             return [FakeBTSBug]
 
 
-class TestBTSService(ServiceIssueTest):
+class TestBTSService:
     SERVICE_CONFIG = {
         'service': 'bts',
         'email': 'irl@debian.org',
         'packages': 'bugwarrior',
     }
 
-    def setUp(self):
-        super().setUp()
-        self.service = self.get_mock_service(bts.BTSService)
+    @pytest.fixture
+    def service(self):
+        return get_mock_service(bts.BTSService, self.SERVICE_CONFIG)
 
-    def test_to_taskwarrior(self):
-        issue = self.service.get_issue_for_record(
-            self.service._record_for_bug(FakeBTSBug)
-        )
+    def test_to_taskwarrior(self, service):
+        issue = service.get_issue_for_record(service._record_for_bug(FakeBTSBug))
 
         expected_output = {
             'priority': issue.PRIORITY_MAP[FakeBTSBug.severity],
@@ -60,9 +60,9 @@ class TestBTSService(ServiceIssueTest):
 
         assert actual_output == expected_output
 
-    def test_issues(self):
+    def test_issues(self, service):
         with mock.patch('bugwarrior.services.bts.debianbts', FakeBTSLib()):
-            issue = next(self.service.issues())
+            issue = next(service.issues())
 
         expected = {
             'annotations': [],

--- a/tests/services/test_bugzilla.py
+++ b/tests/services/test_bugzilla.py
@@ -29,13 +29,16 @@ class FakeBugzillaLib:
         ]
 
 
-class TestBugzillaServiceConfig:
+class TestBugzillaConfig:
     @pytest.fixture
     def config(self):
-        return {'general': {'targets': ['mybz']}, 'mybz': {'service': 'bugzilla'}}
+        return {
+            'general': {'targets': ['myservice']},
+            'myservice': {'service': 'bugzilla'},
+        }
 
     def test_validate_config_username_password(self, config):
-        config['mybz'].update(
+        config['myservice'].update(
             {'base_uri': 'https://one.com/', 'username': 'me', 'password': 'mypas'}
         )
 
@@ -43,7 +46,7 @@ class TestBugzillaServiceConfig:
         validate(config)
 
     def test_validate_config_api_key(self, config):
-        config['mybz'].update(
+        config['myservice'].update(
             {'base_uri': 'https://one.com/', 'username': 'me', 'api_key': '123'}
         )
 
@@ -51,12 +54,12 @@ class TestBugzillaServiceConfig:
         validate(config)
 
     def test_validate_config_api_key_no_username(self, config, assert_validation_error):
-        config['mybz'].update({'base_uri': 'https://one.com/', 'api_key': '123'})
+        config['myservice'].update({'base_uri': 'https://one.com/', 'api_key': '123'})
 
-        assert_validation_error(config, '[mybz]\nusername  <- Field required')
+        assert_validation_error(config, '[myservice]\nusername  <- Field required')
 
     def test_validate_warns_when_scheme_missing_in_uri(self, config, caplog):
-        config['mybz'].update(
+        config['myservice'].update(
             {'base_uri': 'one.com/', 'username': 'me', 'password': 'mypas'}
         )
 

--- a/tests/services/test_bugzilla.py
+++ b/tests/services/test_bugzilla.py
@@ -7,7 +7,8 @@ import pytest
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.bz import BugzillaService
 
-from .base import ConfigTest, ServiceIssueTest
+from ..base import validate
+from .base import get_mock_service
 
 
 class FakeBugzillaLib:
@@ -21,50 +22,46 @@ class FakeBugzillaLib:
         ]
 
 
-class TestBugzillaServiceConfig(ConfigTest):
-    def setUp(self):
-        super().setUp()
-        self.config = {
-            'general': {'targets': ['mybz']},
-            'mybz': {'service': 'bugzilla'},
-        }
+class TestBugzillaServiceConfig:
+    @pytest.fixture
+    def config(self):
+        return {'general': {'targets': ['mybz']}, 'mybz': {'service': 'bugzilla'}}
 
-    def test_validate_config_username_password(self):
-        self.config['mybz'].update(
+    def test_validate_config_username_password(self, config):
+        config['mybz'].update(
             {'base_uri': 'https://one.com/', 'username': 'me', 'password': 'mypas'}
         )
 
         # no error expected
-        self.validate()
+        validate(config)
 
-    def test_validate_config_api_key(self):
-        self.config['mybz'].update(
+    def test_validate_config_api_key(self, config):
+        config['mybz'].update(
             {'base_uri': 'https://one.com/', 'username': 'me', 'api_key': '123'}
         )
 
         # no error expected
-        self.validate()
+        validate(config)
 
-    def test_validate_config_api_key_no_username(self):
-        self.config['mybz'].update({'base_uri': 'https://one.com/', 'api_key': '123'})
+    def test_validate_config_api_key_no_username(self, config, assert_validation_error):
+        config['mybz'].update({'base_uri': 'https://one.com/', 'api_key': '123'})
 
-        self.assertValidationError('[mybz]\nusername  <- Field required')
+        assert_validation_error(config, '[mybz]\nusername  <- Field required')
 
-    def test_validate_warns_when_scheme_missing_in_uri(self):
-        self.config['mybz'].update(
+    def test_validate_warns_when_scheme_missing_in_uri(self, config, caplog):
+        config['mybz'].update(
             {'base_uri': 'one.com/', 'username': 'me', 'password': 'mypas'}
         )
 
-        self.validate()
+        validate(config)
 
-        assert len(self.caplog.records) == 1
+        assert len(caplog.records) == 1
         assert (
-            'bugzilla.base_uri should include the scheme'
-            in self.caplog.records[0].message
+            'bugzilla.base_uri should include the scheme' in caplog.records[0].message
         )
 
 
-class TestBugzillaService(ServiceIssueTest):
+class TestBugzillaService:
     SERVICE_CONFIG = {
         'service': 'bugzilla',
         'base_uri': 'https://one.com/',
@@ -87,34 +84,30 @@ class TestBugzillaService(ServiceIssueTest):
         microsecond=0
     )
 
-    def setUp(self):
-        super().setUp()
+    def make_service(self, **kwargs):
         with mock.patch('bugzilla.Bugzilla'):
-            self.service = self.get_mock_service(BugzillaService)
-
-    def get_mock_service(self, *args, **kwargs):
-        service = super().get_mock_service(*args, **kwargs)
+            service = get_mock_service(BugzillaService, self.SERVICE_CONFIG, **kwargs)
         service.bz = FakeBugzillaLib([self.arbitrary_record])
         service._get_assigned_date = lambda issues: self.arbitrary_datetime.isoformat()
         return service
 
-    def test_api_key_supplied(self):
-        with mock.patch('bugzilla.Bugzilla'):
-            self.service = self.get_mock_service(
-                BugzillaService,
-                config_overrides={
-                    'base_uri': 'https://one.com/',
-                    'username': 'me',
-                    'api_key': '123',
-                },
-            )
+    @pytest.fixture
+    def service(self):
+        return self.make_service()
 
-    def test_to_taskwarrior(self):
+    def test_api_key_supplied(self):
+        self.make_service(
+            config_overrides={
+                'base_uri': 'https://one.com/',
+                'username': 'me',
+                'api_key': '123',
+            }
+        )
+
+    def test_to_taskwarrior(self, service):
         arbitrary_extra = {'url': 'http://path/to/issue/', 'annotations': ['Two']}
 
-        issue = self.service.get_issue_for_record(
-            self.arbitrary_record, arbitrary_extra
-        )
+        issue = service.get_issue_for_record(self.arbitrary_record, arbitrary_extra)
 
         expected_output = {
             'project': self.arbitrary_record['component'],
@@ -131,8 +124,8 @@ class TestBugzillaService(ServiceIssueTest):
 
         assert actual_output == expected_output
 
-    def test_issues(self):
-        issue = next(self.service.issues())
+    def test_issues(self, service):
+        issue = next(service.issues())
 
         expected = {
             'annotations': [],
@@ -154,10 +147,7 @@ class TestBugzillaService(ServiceIssueTest):
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     def test_only_if_assigned(self):
-        with mock.patch('bugzilla.Bugzilla'):
-            self.service = self.get_mock_service(
-                BugzillaService, config_overrides={'only_if_assigned': 'hello'}
-            )
+        service = self.make_service(config_overrides={'only_if_assigned': 'hello'})
 
         assigned_records = [
             {
@@ -181,9 +171,9 @@ class TestBugzillaService(ServiceIssueTest):
                 'assigned_to': 'somebodyelse',
             },
         ]
-        self.service.bz.records.extend(assigned_records)
+        service.bz.records.extend(assigned_records)
 
-        issues = self.service.issues()
+        issues = service.issues()
 
         expected = {
             'annotations': [],
@@ -210,11 +200,9 @@ class TestBugzillaService(ServiceIssueTest):
             next(issues)
 
     def test_also_unassigned(self):
-        with mock.patch('bugzilla.Bugzilla'):
-            self.service = self.get_mock_service(
-                BugzillaService,
-                config_overrides={'only_if_assigned': 'hello', 'also_unassigned': True},
-            )
+        service = self.make_service(
+            config_overrides={'only_if_assigned': 'hello', 'also_unassigned': True}
+        )
 
         assigned_records = [
             {
@@ -238,9 +226,9 @@ class TestBugzillaService(ServiceIssueTest):
                 'assigned_to': 'somebodyelse',
             },
         ]
-        self.service.bz.records.extend(assigned_records)
+        service.bz.records.extend(assigned_records)
 
-        issues = self.service.issues()
+        issues = service.issues()
 
         assert TaskConstructor(next(issues)).get_taskwarrior_record()[
             'bugzillabugid'

--- a/tests/services/test_bugzilla.py
+++ b/tests/services/test_bugzilla.py
@@ -10,6 +10,13 @@ from bugwarrior.services.bz import BugzillaService
 from ..base import validate
 from .base import get_mock_service
 
+SERVICE_CONFIG = {
+    'service': 'bugzilla',
+    'base_uri': 'https://one.com/',
+    'username': 'hello',
+    'password': 'there',
+}
+
 
 class FakeBugzillaLib:
     def __init__(self, records):
@@ -62,13 +69,6 @@ class TestBugzillaServiceConfig:
 
 
 class TestBugzillaService:
-    SERVICE_CONFIG = {
-        'service': 'bugzilla',
-        'base_uri': 'https://one.com/',
-        'username': 'hello',
-        'password': 'there',
-    }
-
     arbitrary_record = {
         'product': 'Product',
         'component': 'Something',
@@ -86,9 +86,7 @@ class TestBugzillaService:
 
     def make_service(self, **overrides):
         with mock.patch('bugzilla.Bugzilla'):
-            service = get_mock_service(
-                BugzillaService, {**self.SERVICE_CONFIG, **overrides}
-            )
+            service = get_mock_service(BugzillaService, {**SERVICE_CONFIG, **overrides})
         service.bz = FakeBugzillaLib([self.arbitrary_record])
         service._get_assigned_date = lambda issues: self.arbitrary_datetime.isoformat()
         return service

--- a/tests/services/test_bugzilla.py
+++ b/tests/services/test_bugzilla.py
@@ -68,8 +68,9 @@ class TestBugzillaServiceConfig:
         )
 
 
-class TestBugzillaService:
-    arbitrary_record = {
+@pytest.fixture
+def record():
+    return {
         'product': 'Product',
         'component': 'Something',
         'priority': 'urgent',
@@ -80,39 +81,46 @@ class TestBugzillaService:
         'assigned_to': None,
     }
 
-    arbitrary_datetime = datetime.datetime.now(tz=datetime.timezone.utc).replace(
-        microsecond=0
-    )
 
-    def make_service(self, **overrides):
+ASSIGNED_DATE = datetime.datetime.now(tz=datetime.timezone.utc).replace(microsecond=0)
+
+
+@pytest.fixture
+def make_service(record):
+    def make(**overrides):
         with mock.patch('bugzilla.Bugzilla'):
             service = get_mock_service(BugzillaService, {**SERVICE_CONFIG, **overrides})
-        service.bz = FakeBugzillaLib([self.arbitrary_record])
-        service._get_assigned_date = lambda issues: self.arbitrary_datetime.isoformat()
+        service.bz = FakeBugzillaLib([record])
+        service._get_assigned_date = lambda issues: ASSIGNED_DATE.isoformat()
         return service
 
-    @pytest.fixture
-    def service(self):
-        return self.make_service()
+    return make
 
-    def test_api_key_supplied(self):
-        self.make_service(base_uri='https://one.com/', username='me', api_key='123')
 
-    def test_to_taskwarrior(self, service):
+@pytest.fixture
+def service(make_service):
+    return make_service()
+
+
+class TestBugzillaService:
+    def test_api_key_supplied(self, make_service):
+        make_service(base_uri='https://one.com/', username='me', api_key='123')
+
+    def test_to_taskwarrior(self, service, record):
         arbitrary_extra = {'url': 'http://path/to/issue/', 'annotations': ['Two']}
 
-        issue = service.get_issue_for_record(self.arbitrary_record, arbitrary_extra)
+        issue = service.get_issue_for_record(record, arbitrary_extra)
 
         expected_output = {
-            'project': self.arbitrary_record['component'],
-            'priority': issue.PRIORITY_MAP[self.arbitrary_record['priority']],
+            'project': record['component'],
+            'priority': issue.PRIORITY_MAP[record['priority']],
             'annotations': arbitrary_extra['annotations'],
-            issue.STATUS: self.arbitrary_record['status'],
+            issue.STATUS: record['status'],
             issue.URL: arbitrary_extra['url'],
-            issue.SUMMARY: self.arbitrary_record['summary'],
-            issue.BUG_ID: self.arbitrary_record['id'],
-            issue.PRODUCT: self.arbitrary_record['product'],
-            issue.COMPONENT: self.arbitrary_record['component'],
+            issue.SUMMARY: record['summary'],
+            issue.BUG_ID: record['id'],
+            issue.PRODUCT: record['product'],
+            issue.COMPONENT: record['component'],
         }
         actual_output = issue.to_taskwarrior()
 
@@ -140,8 +148,8 @@ class TestBugzillaService:
 
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
-    def test_only_if_assigned(self):
-        service = self.make_service(only_if_assigned='hello')
+    def test_only_if_assigned(self, make_service):
+        service = make_service(only_if_assigned='hello')
 
         assigned_records = [
             {
@@ -171,7 +179,7 @@ class TestBugzillaService:
 
         expected = {
             'annotations': [],
-            'bugzillaassignedon': self.arbitrary_datetime,
+            'bugzillaassignedon': ASSIGNED_DATE,
             'bugzillabugid': 1234568,
             'bugzillastatus': 'ASSIGNED',
             'bugzillasummary': 'This is the issue summary',
@@ -193,8 +201,8 @@ class TestBugzillaService:
         with pytest.raises(StopIteration):
             next(issues)
 
-    def test_also_unassigned(self):
-        service = self.make_service(only_if_assigned='hello', also_unassigned=True)
+    def test_also_unassigned(self, make_service):
+        service = make_service(only_if_assigned='hello', also_unassigned=True)
 
         assigned_records = [
             {

--- a/tests/services/test_bugzilla.py
+++ b/tests/services/test_bugzilla.py
@@ -84,9 +84,11 @@ class TestBugzillaService:
         microsecond=0
     )
 
-    def make_service(self, **kwargs):
+    def make_service(self, **overrides):
         with mock.patch('bugzilla.Bugzilla'):
-            service = get_mock_service(BugzillaService, self.SERVICE_CONFIG, **kwargs)
+            service = get_mock_service(
+                BugzillaService, {**self.SERVICE_CONFIG, **overrides}
+            )
         service.bz = FakeBugzillaLib([self.arbitrary_record])
         service._get_assigned_date = lambda issues: self.arbitrary_datetime.isoformat()
         return service
@@ -96,13 +98,7 @@ class TestBugzillaService:
         return self.make_service()
 
     def test_api_key_supplied(self):
-        self.make_service(
-            config_overrides={
-                'base_uri': 'https://one.com/',
-                'username': 'me',
-                'api_key': '123',
-            }
-        )
+        self.make_service(base_uri='https://one.com/', username='me', api_key='123')
 
     def test_to_taskwarrior(self, service):
         arbitrary_extra = {'url': 'http://path/to/issue/', 'annotations': ['Two']}
@@ -147,7 +143,7 @@ class TestBugzillaService:
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     def test_only_if_assigned(self):
-        service = self.make_service(config_overrides={'only_if_assigned': 'hello'})
+        service = self.make_service(only_if_assigned='hello')
 
         assigned_records = [
             {
@@ -200,9 +196,7 @@ class TestBugzillaService:
             next(issues)
 
     def test_also_unassigned(self):
-        service = self.make_service(
-            config_overrides={'only_if_assigned': 'hello', 'also_unassigned': True}
-        )
+        service = self.make_service(only_if_assigned='hello', also_unassigned=True)
 
         assigned_records = [
             {

--- a/tests/services/test_clickup.py
+++ b/tests/services/test_clickup.py
@@ -3,10 +3,10 @@ from datetime import datetime, timezone
 import pytest
 import responses
 
-from bugwarrior.collect import TaskConstructor, get_service_instances
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.clickup import ClickupClient, ClickupService
 
-from ..base import validate
+from ..base import get_validated_service, validate
 from .base import get_mock_service
 
 
@@ -113,6 +113,9 @@ def task_page(task):
     return get
 
 
+SERVICE_CONFIG = {'service': 'clickup', 'team_id': 1234, 'token': 'arbitrary_token'}
+
+
 class TestClickupClient:
     def test_init(self):
         http_client = ClickupClient('12345')
@@ -141,33 +144,23 @@ class TestClickupService:
     def config(self):
         return {
             'general': {'targets': ['myservice']},
-            'myservice': {
-                'service': 'clickup',
-                'token': 'XXXXXX',
-                'also_unassigned': 'true',
-                'team_id': 1234,
-            },
+            'myservice': {**SERVICE_CONFIG, 'also_unassigned': 'true'},
         }
-
-    def get_service(self, config):
-        conf = validate(config)
-        service = get_service_instances(conf)[0]
-        return service
 
     def test_keyring_service(self, config):
         conf = validate(config).service_configs[0]
         assert conf.keyring_service == 'clickup://'
 
     def test_is_assigned(self, config, task):
-        assert self.get_service(config).is_assigned(task)
+        assert get_validated_service(config).is_assigned(task)
 
         config["myservice"]["only_if_assigned"] = "Pedro Manobrista"
 
-        assert self.get_service(config).is_assigned(task)
+        assert get_validated_service(config).is_assigned(task)
 
         config["myservice"]["also_unassigned"] = False
 
-        assert not self.get_service(config).is_assigned(task)
+        assert not get_validated_service(config).is_assigned(task)
 
         task["assignees"] = [
             {
@@ -179,15 +172,13 @@ class TestClickupService:
                 "profilePicture": None,
             }
         ]
-        assert self.get_service(config).is_assigned(task)
+        assert get_validated_service(config).is_assigned(task)
 
 
 class TestClickupIssue:
-    SERVICE_CONFIG = {'service': 'clickup', 'team_id': 1234, 'token': 'arbitrary_token'}
-
     @pytest.fixture
     def service(self):
-        return get_mock_service(ClickupService, self.SERVICE_CONFIG)
+        return get_mock_service(ClickupService, SERVICE_CONFIG)
 
     def test_to_taskwarrior(self, service, task):
         issue = service.get_issue_for_record(task)

--- a/tests/services/test_clickup.py
+++ b/tests/services/test_clickup.py
@@ -7,7 +7,6 @@ from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.clickup import ClickupClient, ClickupService
 
 from ..base import get_validated_service, validate
-from .base import get_mock_service
 
 
 @pytest.fixture
@@ -113,6 +112,8 @@ def task_page(record):
     return get
 
 
+SERVICE_CLASS = ClickupService
+
 SERVICE_CONFIG = {'service': 'clickup', 'team_id': 1234, 'token': 'arbitrary_token'}
 
 
@@ -176,10 +177,6 @@ class TestClickupService:
 
 
 class TestClickupIssue:
-    @pytest.fixture
-    def service(self):
-        return get_mock_service(ClickupService, SERVICE_CONFIG)
-
     def test_to_taskwarrior(self, service, record):
         issue = service.get_issue_for_record(record)
 

--- a/tests/services/test_clickup.py
+++ b/tests/services/test_clickup.py
@@ -11,7 +11,7 @@ from .base import get_mock_service
 
 
 @pytest.fixture
-def task():
+def record():
     return {
         "id": "86adrdd2j",
         "custom_id": None,
@@ -104,11 +104,11 @@ def task():
 
 
 @pytest.fixture
-def task_page(task):
+def task_page(record):
     """Return a one-task API response page, the last one for page_number > 0."""
 
     def get(page_number):
-        return {"tasks": [task], "last_page": page_number > 0}
+        return {"tasks": [record], "last_page": page_number > 0}
 
     return get
 
@@ -125,7 +125,7 @@ class TestClickupClient:
         )
 
     @responses.activate
-    def test_get_repo(self, task, task_page):
+    def test_get_repo(self, record, task_page):
         client = ClickupClient('XXXXXX')
         responses.get(
             "https://api.clickup.com/api/v2/team/1234/task?include_closed=false&page=0",
@@ -136,7 +136,7 @@ class TestClickupClient:
             json=task_page(1),
         )
         result = [item for item in client.get_tasks_for_team(team_id=1234)]
-        assert result == [task, task]
+        assert result == [record, record]
 
 
 class TestClickupService:
@@ -151,18 +151,18 @@ class TestClickupService:
         conf = validate(config).service_configs[0]
         assert conf.keyring_service == 'clickup://'
 
-    def test_is_assigned(self, config, task):
-        assert get_validated_service(config).is_assigned(task)
+    def test_is_assigned(self, config, record):
+        assert get_validated_service(config).is_assigned(record)
 
         config["myservice"]["only_if_assigned"] = "Pedro Manobrista"
 
-        assert get_validated_service(config).is_assigned(task)
+        assert get_validated_service(config).is_assigned(record)
 
         config["myservice"]["also_unassigned"] = False
 
-        assert not get_validated_service(config).is_assigned(task)
+        assert not get_validated_service(config).is_assigned(record)
 
-        task["assignees"] = [
+        record["assignees"] = [
             {
                 "id": 2606423512,
                 "username": "Pedro Manobrista",
@@ -172,7 +172,7 @@ class TestClickupService:
                 "profilePicture": None,
             }
         ]
-        assert get_validated_service(config).is_assigned(task)
+        assert get_validated_service(config).is_assigned(record)
 
 
 class TestClickupIssue:
@@ -180,36 +180,36 @@ class TestClickupIssue:
     def service(self):
         return get_mock_service(ClickupService, SERVICE_CONFIG)
 
-    def test_to_taskwarrior(self, service, task):
-        issue = service.get_issue_for_record(task)
+    def test_to_taskwarrior(self, service, record):
+        issue = service.get_issue_for_record(record)
 
         expected_output = {
             "project": None,
             "priority": 'M',
             "due": None,
             "entry": datetime.fromtimestamp(
-                int(task["date_created"]) // 1e3, tz=timezone.utc
+                int(record["date_created"]) // 1e3, tz=timezone.utc
             ),
-            issue.ID: task["id"],
-            issue.DESCRIPTION: task["description"],
-            issue.STATUS: task["status"]["status"],
+            issue.ID: record["id"],
+            issue.DESCRIPTION: record["description"],
+            issue.STATUS: record["status"]["status"],
             issue.UPDATED_AT: datetime.fromtimestamp(
-                int(task["date_updated"]) // 1e3, tz=timezone.utc
+                int(record["date_updated"]) // 1e3, tz=timezone.utc
             ),
-            issue.CREATOR: task["creator"]["username"],
-            issue.URL: task["url"],
-            issue.LIST_NAME: task["list"]["name"],
-            issue.PROJECT: task["project"]["id"],
-            issue.FOLDER: task["folder"]["id"],
-            issue.SPACE: task["space"]["id"],
-            issue.NAME: task["name"],
+            issue.CREATOR: record["creator"]["username"],
+            issue.URL: record["url"],
+            issue.LIST_NAME: record["list"]["name"],
+            issue.PROJECT: record["project"]["id"],
+            issue.FOLDER: record["folder"]["id"],
+            issue.SPACE: record["space"]["id"],
+            issue.NAME: record["name"],
         }
         actual_output = issue.to_taskwarrior()
 
         assert actual_output == expected_output
 
     @responses.activate
-    def test_issues(self, service, task, task_page):
+    def test_issues(self, service, record, task_page):
         responses.get(
             "https://api.clickup.com/api/v2/team/1234/task?include_closed=false&page=0",
             json=task_page(1),
@@ -223,22 +223,22 @@ class TestClickupIssue:
             "due": None,
             "tags": [],
             "entry": datetime.fromtimestamp(
-                int(task["date_created"]) // 1e3, tz=timezone.utc
+                int(record["date_created"]) // 1e3, tz=timezone.utc
             ),
             "description": "(bw)Is# - My task .. https://app.clickup.com/t/86adrdd2j",
-            issue.ID: task["id"],
-            issue.DESCRIPTION: task["description"],
-            issue.STATUS: task["status"]["status"],
+            issue.ID: record["id"],
+            issue.DESCRIPTION: record["description"],
+            issue.STATUS: record["status"]["status"],
             issue.UPDATED_AT: datetime.fromtimestamp(
-                int(task["date_updated"]) // 1e3, tz=timezone.utc
+                int(record["date_updated"]) // 1e3, tz=timezone.utc
             ),
-            issue.CREATOR: task["creator"]["username"],
-            issue.URL: task["url"],
-            issue.LIST_NAME: task["list"]["name"],
-            issue.PROJECT: task["project"]["id"],
-            issue.FOLDER: task["folder"]["id"],
-            issue.SPACE: task["space"]["id"],
-            issue.NAME: task["name"],
+            issue.CREATOR: record["creator"]["username"],
+            issue.URL: record["url"],
+            issue.LIST_NAME: record["list"]["name"],
+            issue.PROJECT: record["project"]["id"],
+            issue.FOLDER: record["folder"]["id"],
+            issue.SPACE: record["space"]["id"],
+            issue.NAME: record["name"],
         }
 
         assert TaskConstructor(issue).get_taskwarrior_record() == expected_output

--- a/tests/services/test_clickup.py
+++ b/tests/services/test_clickup.py
@@ -1,125 +1,116 @@
 from datetime import datetime, timezone
 
+import pytest
 import responses
 
 from bugwarrior.collect import TaskConstructor, get_service_instances
 from bugwarrior.services.clickup import ClickupClient, ClickupService
 
-from .base import ConfigTest, ServiceIssueTest
+from ..base import validate
+from .base import get_mock_service
 
 
-class TestData:
-    def __init__(self):
-        self.tasks = {
-            "tasks": [
-                {
-                    "id": "86adrdd2j",
-                    "custom_id": None,
-                    "custom_item_id": 0,
-                    "name": "My task",
-                    "text_content": "",
-                    "description": "",
-                    "status": {
-                        "status": "mystatus",
-                        "id": "p901312298283_rBjB6Xxi",
-                        "color": "#b660e0",
-                        "type": "custom",
-                        "orderindex": 4,
-                    },
-                    "orderindex": "1.00000282100000000000000000000000",
-                    "date_created": "1765390998981",
-                    "date_updated": "1765391016301",
-                    "date_closed": None,
-                    "date_done": None,
-                    "archived": False,
-                    "creator": {
-                        "id": 261642312,
-                        "username": "Me",
-                        "color": "#595d66",
-                        "email": "me@example.com",
-                        "profilePicture": None,
-                    },
-                    "assignees": [],
-                    "group_assignees": [],
-                    "watchers": [
-                        {
-                            "id": 261642312,
-                            "username": "Me",
-                            "color": "#595d66",
-                            "initials": "M",
-                            "email": "me@example.com",
-                            "profilePicture": None,
-                        }
-                    ],
-                    "checklists": [],
-                    "tags": [],
-                    "parent": None,
-                    "top_level_parent": None,
-                    "priority": None,
-                    "due_date": None,
-                    "start_date": None,
-                    "points": None,
-                    "time_estimate": None,
-                    "custom_fields": [],
-                    "dependencies": [],
-                    "linked_tasks": [],
-                    "locations": [],
-                    "team_id": "90232846929",
-                    "url": "https://app.clickup.com/t/86adrdd2j",
-                    "sharing": {
-                        "public": False,
-                        "public_share_expires_on": None,
-                        "public_fields": [
-                            "assignees",
-                            "priority",
-                            "due_date",
-                            "content",
-                            "comments",
-                            "attachments",
-                            "customFields",
-                            "subtasks",
-                            "tags",
-                            "checklists",
-                            "coverimage",
-                        ],
-                        "token": None,
-                        "seo_optimized": False,
-                    },
-                    "permission_level": "create",
-                    "list": {"id": "901323335746", "name": "List", "access": True},
-                    "project": {
-                        "id": "901515652835",
-                        "name": "hidden",
-                        "hidden": True,
-                        "access": True,
-                    },
-                    "folder": {
-                        "id": "901315352835",
-                        "name": "hidden",
-                        "hidden": True,
-                        "access": True,
-                    },
-                    "space": {"id": "901312298283"},
-                }
+@pytest.fixture
+def task():
+    return {
+        "id": "86adrdd2j",
+        "custom_id": None,
+        "custom_item_id": 0,
+        "name": "My task",
+        "text_content": "",
+        "description": "",
+        "status": {
+            "status": "mystatus",
+            "id": "p901312298283_rBjB6Xxi",
+            "color": "#b660e0",
+            "type": "custom",
+            "orderindex": 4,
+        },
+        "orderindex": "1.00000282100000000000000000000000",
+        "date_created": "1765390998981",
+        "date_updated": "1765391016301",
+        "date_closed": None,
+        "date_done": None,
+        "archived": False,
+        "creator": {
+            "id": 261642312,
+            "username": "Me",
+            "color": "#595d66",
+            "email": "me@example.com",
+            "profilePicture": None,
+        },
+        "assignees": [],
+        "group_assignees": [],
+        "watchers": [
+            {
+                "id": 261642312,
+                "username": "Me",
+                "color": "#595d66",
+                "initials": "M",
+                "email": "me@example.com",
+                "profilePicture": None,
+            }
+        ],
+        "checklists": [],
+        "tags": [],
+        "parent": None,
+        "top_level_parent": None,
+        "priority": None,
+        "due_date": None,
+        "start_date": None,
+        "points": None,
+        "time_estimate": None,
+        "custom_fields": [],
+        "dependencies": [],
+        "linked_tasks": [],
+        "locations": [],
+        "team_id": "90232846929",
+        "url": "https://app.clickup.com/t/86adrdd2j",
+        "sharing": {
+            "public": False,
+            "public_share_expires_on": None,
+            "public_fields": [
+                "assignees",
+                "priority",
+                "due_date",
+                "content",
+                "comments",
+                "attachments",
+                "customFields",
+                "subtasks",
+                "tags",
+                "checklists",
+                "coverimage",
             ],
-            "last_page": True,
-        }
+            "token": None,
+            "seo_optimized": False,
+        },
+        "permission_level": "create",
+        "list": {"id": "901323335746", "name": "List", "access": True},
+        "project": {
+            "id": "901515652835",
+            "name": "hidden",
+            "hidden": True,
+            "access": True,
+        },
+        "folder": {
+            "id": "901315352835",
+            "name": "hidden",
+            "hidden": True,
+            "access": True,
+        },
+        "space": {"id": "901312298283"},
+    }
 
-    def get_page(self, page_number: int):
-        if page_number == 0:
-            tasks = self.tasks.copy()
-            tasks["last_page"] = False
-            return tasks
-        else:
-            return self.tasks
 
-    def get_task_contents(self):
-        tasks = self.tasks["tasks"]
-        tasks += tasks
-        return tasks
+@pytest.fixture
+def task_page(task):
+    """Return a one-task API response page, the last one for page_number > 0."""
 
-    def get_task(self):
-        return self.get_task_contents()[0]
+    def get(page_number):
+        return {"tasks": [task], "last_page": page_number > 0}
+
+    return get
 
 
 class TestClickupClient:
@@ -131,26 +122,24 @@ class TestClickupClient:
         )
 
     @responses.activate
-    def test_get_repo(self):
+    def test_get_repo(self, task, task_page):
         client = ClickupClient('XXXXXX')
-        data = TestData()
         responses.get(
             "https://api.clickup.com/api/v2/team/1234/task?include_closed=false&page=0",
-            json=data.get_page(0),
+            json=task_page(0),
         )
         responses.get(
             "https://api.clickup.com/api/v2/team/1234/task?include_closed=false&page=1",
-            json=data.get_page(1),
+            json=task_page(1),
         )
         result = [item for item in client.get_tasks_for_team(team_id=1234)]
-        assert data.get_task_contents() == result
+        assert result == [task, task]
 
 
-class TestClickupService(ConfigTest):
-    def setUp(self):
-        super().setUp()
-        self.data = TestData()
-        self.config = {
+class TestClickupService:
+    @pytest.fixture
+    def config(self):
+        return {
             'general': {'targets': ['myservice']},
             'myservice': {
                 'service': 'clickup',
@@ -160,28 +149,25 @@ class TestClickupService(ConfigTest):
             },
         }
 
-    @property
-    def service(self):
-        conf = self.validate()
+    def get_service(self, config):
+        conf = validate(config)
         service = get_service_instances(conf)[0]
         return service
 
-    def test_keyring_service(self):
-        conf = self.validate().service_configs[0]
+    def test_keyring_service(self, config):
+        conf = validate(config).service_configs[0]
         assert conf.keyring_service == 'clickup://'
 
-    def test_is_assigned(self):
-        task = self.data.get_task()
+    def test_is_assigned(self, config, task):
+        assert self.get_service(config).is_assigned(task)
 
-        assert self.service.is_assigned(task)
+        config["myservice"]["only_if_assigned"] = "Pedro Manobrista"
 
-        self.config["myservice"]["only_if_assigned"] = "Pedro Manobrista"
+        assert self.get_service(config).is_assigned(task)
 
-        assert self.service.is_assigned(task)
+        config["myservice"]["also_unassigned"] = False
 
-        self.config["myservice"]["also_unassigned"] = False
-
-        assert not self.service.is_assigned(task)
+        assert not self.get_service(config).is_assigned(task)
 
         task["assignees"] = [
             {
@@ -193,22 +179,19 @@ class TestClickupService(ConfigTest):
                 "profilePicture": None,
             }
         ]
-        assert self.service.is_assigned(task)
+        assert self.get_service(config).is_assigned(task)
 
 
-class TestClickupIssue(ServiceIssueTest):
+class TestClickupIssue:
     SERVICE_CONFIG = {'service': 'clickup', 'team_id': 1234, 'token': 'arbitrary_token'}
 
-    def setUp(self):
-        super().setUp()
-        self.service = self.get_mock_service(ClickupService)
+    @pytest.fixture
+    def service(self):
+        return get_mock_service(ClickupService, self.SERVICE_CONFIG)
 
-        self.data = TestData()
+    def test_to_taskwarrior(self, service, task):
+        issue = service.get_issue_for_record(task)
 
-    def test_to_taskwarrior(self):
-        issue = self.service.get_issue_for_record(self.data.get_task())
-
-        task = self.data.get_task()
         expected_output = {
             "project": None,
             "priority": 'M',
@@ -235,15 +218,14 @@ class TestClickupIssue(ServiceIssueTest):
         assert actual_output == expected_output
 
     @responses.activate
-    def test_issues(self):
+    def test_issues(self, service, task, task_page):
         responses.get(
             "https://api.clickup.com/api/v2/team/1234/task?include_closed=false&page=0",
-            json=self.data.get_page(1),
+            json=task_page(1),
         )
 
-        issue = next(self.service.issues())
+        issue = next(service.issues())
 
-        task = self.data.get_task()
         expected_output = {
             "project": None,
             "priority": 'M',

--- a/tests/services/test_contracts.py
+++ b/tests/services/test_contracts.py
@@ -20,6 +20,39 @@ def module_test_names(module):
     return names
 
 
+@pytest.mark.parametrize('module_name', TEST_MODULES)
+def test_service_config_is_module_level(module_name):
+    """
+    Each service test module must define its base service section as a
+    module-level SERVICE_CONFIG dict.
+    """
+    module = importlib.import_module(f'tests.services.{module_name}')
+
+    assert isinstance(getattr(module, 'SERVICE_CONFIG', None), dict), (
+        f'{module_name} does not define a module-level SERVICE_CONFIG dict'
+    )
+
+
+@pytest.mark.parametrize('module_name', TEST_MODULES)
+def test_fake_data_is_not_class_state(module_name):
+    """
+    Fake API payloads must be module-level fixtures returning fresh objects,
+    not mutable class attributes shared between tests.
+    """
+    module = importlib.import_module(f'tests.services.{module_name}')
+
+    offenders = [
+        f'{cls_name}.{name}'
+        for cls_name, cls in vars(module).items()
+        if isinstance(cls, type) and cls_name.startswith('Test')
+        for name, value in vars(cls).items()
+        if isinstance(value, (dict, list))
+    ]
+    assert not offenders, (
+        f'{module_name} keeps mutable data on test classes: {offenders}'
+    )
+
+
 @pytest.mark.parametrize('required', ['test_to_taskwarrior', 'test_issues'])
 @pytest.mark.parametrize('module_name', TEST_MODULES)
 def test_core_service_methods_are_tested(module_name, required):

--- a/tests/services/test_contracts.py
+++ b/tests/services/test_contracts.py
@@ -1,0 +1,45 @@
+"""Ensure each service's test module exercises the core service methods."""
+
+import importlib
+import pathlib
+
+import pytest
+
+TEST_MODULES = sorted(
+    path.stem
+    for path in pathlib.Path(__file__).parent.glob('test_*.py')
+    if path.stem != 'test_contracts'
+)
+
+#: Modules that predate this contract and are still missing required tests.
+#: Do not add new entries; write the missing tests instead.
+KNOWN_INCOMPLETE = {'test_pagure': {'test_to_taskwarrior', 'test_issues'}}
+
+
+def module_test_names(module):
+    names = {name for name in vars(module) if name.startswith('test_')}
+    for value in vars(module).values():
+        if isinstance(value, type):
+            names.update(name for name in dir(value) if name.startswith('test_'))
+    return names
+
+
+@pytest.mark.parametrize('required', ['test_to_taskwarrior', 'test_issues'])
+@pytest.mark.parametrize('module_name', TEST_MODULES)
+def test_core_service_methods_are_tested(module_name, required):
+    """
+    Each service test module must test to_taskwarrior() and issues().
+
+    - When the API is accessed via requests, use the responses library to
+    mock requests.
+    - When the API is accessed via a third party library, substitute a fake
+    implementation class for it.
+    """
+    if required in KNOWN_INCOMPLETE.get(module_name, set()):
+        pytest.skip(f'{module_name} predates the coverage contract')
+
+    module = importlib.import_module(f'tests.services.{module_name}')
+
+    assert any(name.startswith(required) for name in module_test_names(module)), (
+        f'{module_name} does not define a {required} test'
+    )

--- a/tests/services/test_contracts.py
+++ b/tests/services/test_contracts.py
@@ -11,10 +11,6 @@ TEST_MODULES = sorted(
     if path.stem != 'test_contracts'
 )
 
-#: Modules that predate this contract and are still missing required tests.
-#: Do not add new entries; write the missing tests instead.
-KNOWN_INCOMPLETE = {'test_pagure': {'test_to_taskwarrior', 'test_issues'}}
-
 
 def module_test_names(module):
     names = {name for name in vars(module) if name.startswith('test_')}
@@ -35,9 +31,6 @@ def test_core_service_methods_are_tested(module_name, required):
     - When the API is accessed via a third party library, substitute a fake
     implementation class for it.
     """
-    if required in KNOWN_INCOMPLETE.get(module_name, set()):
-        pytest.skip(f'{module_name} predates the coverage contract')
-
     module = importlib.import_module(f'tests.services.{module_name}')
 
     assert any(name.startswith(required) for name in module_test_names(module)), (

--- a/tests/services/test_deck.py
+++ b/tests/services/test_deck.py
@@ -3,10 +3,10 @@ from unittest import mock
 
 import pytest
 
-from bugwarrior.collect import TaskConstructor, get_service_instances
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.deck import NextcloudDeckClient
 
-from ..base import validate
+from ..base import get_validated_service
 
 
 @pytest.fixture
@@ -63,15 +63,16 @@ def card():
     }
 
 
-class TestNextcloudDeckIssue:
-    SERVICE_CONFIG = {
-        'service': 'deck',
-        'base_uri': 'http://localhost:8080',
-        'username': 'testuser',
-        'password': 'testpassword',
-        'import_labels_as_tags': True,
-    }
+SERVICE_CONFIG = {
+    'service': 'deck',
+    'base_uri': 'http://localhost:8080',
+    'username': 'testuser',
+    'password': 'testpassword',
+    'import_labels_as_tags': True,
+}
 
+
+class TestNextcloudDeckIssue:
     @pytest.fixture
     def config(self):
         return {
@@ -80,18 +81,11 @@ class TestNextcloudDeckIssue:
                 # would otherwise cut the title short
                 'description_length': '45',
             },
-            'deck': {
-                'service': 'deck',
-                'base_uri': 'http://localhost:8080',
-                'username': 'testuser',
-                'password': 'testpassword',
-                'import_labels_as_tags': 'true',
-            },
+            'deck': {**SERVICE_CONFIG},
         }
 
     def make_service(self, config, card):
-        conf = validate(config)
-        service = get_service_instances(conf)[0]
+        service = get_validated_service(config)
         service.client = mock.MagicMock(spec=NextcloudDeckClient)
         service.client.get_boards = mock.MagicMock(
             return_value=[{'id': 5, 'title': 'testboard'}]

--- a/tests/services/test_deck.py
+++ b/tests/services/test_deck.py
@@ -84,27 +84,31 @@ class TestDeckIssue:
             'myservice': {**SERVICE_CONFIG},
         }
 
-    def make_service(self, config, record):
-        service = get_validated_service(config)
-        service.client = mock.MagicMock(spec=NextcloudDeckClient)
-        service.client.get_boards = mock.MagicMock(
-            return_value=[{'id': 5, 'title': 'testboard'}]
-        )
-        service.client.get_stacks = mock.MagicMock(
-            return_value=[{'id': 13, 'title': 'teststack', 'cards': [record]}]
-        )
-        service.client.get_comments = mock.MagicMock(
-            return_value={
-                'ocs': {
-                    'data': [{'actorDisplayName': 'Lena', 'message': 'testcomment'}]
+    @pytest.fixture
+    def make_service(self, record):
+        def make(config):
+            service = get_validated_service(config)
+            service.client = mock.MagicMock(spec=NextcloudDeckClient)
+            service.client.get_boards = mock.MagicMock(
+                return_value=[{'id': 5, 'title': 'testboard'}]
+            )
+            service.client.get_stacks = mock.MagicMock(
+                return_value=[{'id': 13, 'title': 'teststack', 'cards': [record]}]
+            )
+            service.client.get_comments = mock.MagicMock(
+                return_value={
+                    'ocs': {
+                        'data': [{'actorDisplayName': 'Lena', 'message': 'testcomment'}]
+                    }
                 }
-            }
-        )
-        return service
+            )
+            return service
+
+        return make
 
     @pytest.fixture
-    def service(self, config, record):
-        return self.make_service(config, record)
+    def service(self, config, make_service):
+        return make_service(config)
 
     def test_to_taskwarrior(self, service, record):
         issue = service.get_issue_for_record(
@@ -163,12 +167,12 @@ class TestDeckIssue:
 
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
-    def test_get_owner(self, config, record):
+    def test_get_owner(self, config, record, make_service):
         # Regression test: the old get_owner did `issue[issue.ASSIGNEE]`, treating
         # the NextcloudDeckIssue as a dict. Issue has no __getitem__, so this raised
         # TypeError whenever only_if_assigned was configured.
         config['myservice']['only_if_assigned'] = 'rainbow'
-        service = self.make_service(config, record)
+        service = make_service(config)
         issue = service.get_issue_for_record(
             record,
             {
@@ -179,14 +183,14 @@ class TestDeckIssue:
         )
         assert service.get_owner(issue) == 'rainbow'
 
-    def test_filter_boards_include(self, config, record):
+    def test_filter_boards_include(self, config, make_service):
         config['myservice']['include_board_ids'] = '5'
-        service = self.make_service(config, record)
+        service = make_service(config)
         assert service.filter_boards({'title': 'testboard', 'id': 5})
         assert not service.filter_boards({'title': 'testboard', 'id': 6})
 
-    def test_filter_boards_exclude(self, config, record):
+    def test_filter_boards_exclude(self, config, make_service):
         config['myservice']['exclude_board_ids'] = '5'
-        service = self.make_service(config, record)
+        service = make_service(config)
         assert not service.filter_boards({'title': 'testboard', 'id': 5})
         assert service.filter_boards({'title': 'testboard', 'id': 6})

--- a/tests/services/test_deck.py
+++ b/tests/services/test_deck.py
@@ -10,7 +10,7 @@ from ..base import get_validated_service
 
 
 @pytest.fixture
-def card():
+def record():
     return {
         "title": "check that nextcloud deck integration works",
         "description": "some additional description",
@@ -84,14 +84,14 @@ class TestNextcloudDeckIssue:
             'deck': {**SERVICE_CONFIG},
         }
 
-    def make_service(self, config, card):
+    def make_service(self, config, record):
         service = get_validated_service(config)
         service.client = mock.MagicMock(spec=NextcloudDeckClient)
         service.client.get_boards = mock.MagicMock(
             return_value=[{'id': 5, 'title': 'testboard'}]
         )
         service.client.get_stacks = mock.MagicMock(
-            return_value=[{'id': 13, 'title': 'teststack', 'cards': [card]}]
+            return_value=[{'id': 13, 'title': 'teststack', 'cards': [record]}]
         )
         service.client.get_comments = mock.MagicMock(
             return_value={
@@ -103,12 +103,12 @@ class TestNextcloudDeckIssue:
         return service
 
     @pytest.fixture
-    def service(self, config, card):
-        return self.make_service(config, card)
+    def service(self, config, record):
+        return self.make_service(config, record)
 
-    def test_to_taskwarrior(self, service, card):
+    def test_to_taskwarrior(self, service, record):
         issue = service.get_issue_for_record(
-            card,
+            record,
             {
                 'board': {'title': 'testboard', 'id': 5},
                 'stack': {'title': 'teststack', 'id': 13},
@@ -163,14 +163,14 @@ class TestNextcloudDeckIssue:
 
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
-    def test_get_owner(self, config, card):
+    def test_get_owner(self, config, record):
         # Regression test: the old get_owner did `issue[issue.ASSIGNEE]`, treating
         # the NextcloudDeckIssue as a dict. Issue has no __getitem__, so this raised
         # TypeError whenever only_if_assigned was configured.
         config['deck']['only_if_assigned'] = 'rainbow'
-        service = self.make_service(config, card)
+        service = self.make_service(config, record)
         issue = service.get_issue_for_record(
-            card,
+            record,
             {
                 'board': {'title': 'testboard', 'id': 5},
                 'stack': {'title': 'teststack', 'id': 13},
@@ -179,14 +179,14 @@ class TestNextcloudDeckIssue:
         )
         assert service.get_owner(issue) == 'rainbow'
 
-    def test_filter_boards_include(self, config, card):
+    def test_filter_boards_include(self, config, record):
         config['deck']['include_board_ids'] = '5'
-        service = self.make_service(config, card)
+        service = self.make_service(config, record)
         assert service.filter_boards({'title': 'testboard', 'id': 5})
         assert not service.filter_boards({'title': 'testboard', 'id': 6})
 
-    def test_filter_boards_exclude(self, config, card):
+    def test_filter_boards_exclude(self, config, record):
         config['deck']['exclude_board_ids'] = '5'
-        service = self.make_service(config, card)
+        service = self.make_service(config, record)
         assert not service.filter_boards({'title': 'testboard', 'id': 5})
         assert service.filter_boards({'title': 'testboard', 'id': 6})

--- a/tests/services/test_deck.py
+++ b/tests/services/test_deck.py
@@ -72,16 +72,16 @@ SERVICE_CONFIG = {
 }
 
 
-class TestNextcloudDeckIssue:
+class TestDeckIssue:
     @pytest.fixture
     def config(self):
         return {
             'general': {
-                'targets': ['deck'],
+                'targets': ['myservice'],
                 # would otherwise cut the title short
                 'description_length': '45',
             },
-            'deck': {**SERVICE_CONFIG},
+            'myservice': {**SERVICE_CONFIG},
         }
 
     def make_service(self, config, record):
@@ -167,7 +167,7 @@ class TestNextcloudDeckIssue:
         # Regression test: the old get_owner did `issue[issue.ASSIGNEE]`, treating
         # the NextcloudDeckIssue as a dict. Issue has no __getitem__, so this raised
         # TypeError whenever only_if_assigned was configured.
-        config['deck']['only_if_assigned'] = 'rainbow'
+        config['myservice']['only_if_assigned'] = 'rainbow'
         service = self.make_service(config, record)
         issue = service.get_issue_for_record(
             record,
@@ -180,13 +180,13 @@ class TestNextcloudDeckIssue:
         assert service.get_owner(issue) == 'rainbow'
 
     def test_filter_boards_include(self, config, record):
-        config['deck']['include_board_ids'] = '5'
+        config['myservice']['include_board_ids'] = '5'
         service = self.make_service(config, record)
         assert service.filter_boards({'title': 'testboard', 'id': 5})
         assert not service.filter_boards({'title': 'testboard', 'id': 6})
 
     def test_filter_boards_exclude(self, config, record):
-        config['deck']['exclude_board_ids'] = '5'
+        config['myservice']['exclude_board_ids'] = '5'
         service = self.make_service(config, record)
         assert not service.filter_boards({'title': 'testboard', 'id': 5})
         assert service.filter_boards({'title': 'testboard', 'id': 6})

--- a/tests/services/test_deck.py
+++ b/tests/services/test_deck.py
@@ -1,16 +1,17 @@
-import dataclasses
 from datetime import datetime, timezone
 from unittest import mock
+
+import pytest
 
 from bugwarrior.collect import TaskConstructor, get_service_instances
 from bugwarrior.services.deck import NextcloudDeckClient
 
-from .base import ServiceIssueTest
+from ..base import validate
 
 
-@dataclasses.dataclass
-class TestData:
-    arbitrary_card = {
+@pytest.fixture
+def card():
+    return {
         "title": "check that nextcloud deck integration works",
         "description": "some additional description",
         "stackId": 13,
@@ -62,7 +63,7 @@ class TestData:
     }
 
 
-class TestNextcloudDeckIssue(ServiceIssueTest):
+class TestNextcloudDeckIssue:
     SERVICE_CONFIG = {
         'service': 'deck',
         'base_uri': 'http://localhost:8080',
@@ -71,9 +72,9 @@ class TestNextcloudDeckIssue(ServiceIssueTest):
         'import_labels_as_tags': True,
     }
 
-    def setUp(self):
-        super().setUp()
-        self.config = {
+    @pytest.fixture
+    def config(self):
+        return {
             'general': {
                 'targets': ['deck'],
                 # would otherwise cut the title short
@@ -88,20 +89,15 @@ class TestNextcloudDeckIssue(ServiceIssueTest):
             },
         }
 
-        self.data = TestData()
-
-    @property
-    def service(self):
-        conf = self.validate()
+    def make_service(self, config, card):
+        conf = validate(config)
         service = get_service_instances(conf)[0]
         service.client = mock.MagicMock(spec=NextcloudDeckClient)
         service.client.get_boards = mock.MagicMock(
             return_value=[{'id': 5, 'title': 'testboard'}]
         )
         service.client.get_stacks = mock.MagicMock(
-            return_value=[
-                {'id': 13, 'title': 'teststack', 'cards': [self.data.arbitrary_card]}
-            ]
+            return_value=[{'id': 13, 'title': 'teststack', 'cards': [card]}]
         )
         service.client.get_comments = mock.MagicMock(
             return_value={
@@ -112,9 +108,13 @@ class TestNextcloudDeckIssue(ServiceIssueTest):
         )
         return service
 
-    def test_to_taskwarrior(self):
-        issue = self.service.get_issue_for_record(
-            self.data.arbitrary_card,
+    @pytest.fixture
+    def service(self, config, card):
+        return self.make_service(config, card)
+
+    def test_to_taskwarrior(self, service, card):
+        issue = service.get_issue_for_record(
+            card,
             {
                 'board': {'title': 'testboard', 'id': 5},
                 'stack': {'title': 'teststack', 'id': 13},
@@ -144,8 +144,8 @@ class TestNextcloudDeckIssue(ServiceIssueTest):
 
         assert actual == expected
 
-    def test_issues(self):
-        issue = next(self.service.issues())
+    def test_issues(self, service):
+        issue = next(service.issues())
 
         expected = {
             'annotations': ['@Lena - testcomment'],
@@ -169,27 +169,30 @@ class TestNextcloudDeckIssue(ServiceIssueTest):
 
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
-    def test_get_owner(self):
+    def test_get_owner(self, config, card):
         # Regression test: the old get_owner did `issue[issue.ASSIGNEE]`, treating
         # the NextcloudDeckIssue as a dict. Issue has no __getitem__, so this raised
         # TypeError whenever only_if_assigned was configured.
-        self.config['deck']['only_if_assigned'] = 'rainbow'
-        issue = self.service.get_issue_for_record(
-            self.data.arbitrary_card,
+        config['deck']['only_if_assigned'] = 'rainbow'
+        service = self.make_service(config, card)
+        issue = service.get_issue_for_record(
+            card,
             {
                 'board': {'title': 'testboard', 'id': 5},
                 'stack': {'title': 'teststack', 'id': 13},
                 'annotations': [],
             },
         )
-        assert self.service.get_owner(issue) == 'rainbow'
+        assert service.get_owner(issue) == 'rainbow'
 
-    def test_filter_boards_include(self):
-        self.config['deck']['include_board_ids'] = '5'
-        assert self.service.filter_boards({'title': 'testboard', 'id': 5})
-        assert not self.service.filter_boards({'title': 'testboard', 'id': 6})
+    def test_filter_boards_include(self, config, card):
+        config['deck']['include_board_ids'] = '5'
+        service = self.make_service(config, card)
+        assert service.filter_boards({'title': 'testboard', 'id': 5})
+        assert not service.filter_boards({'title': 'testboard', 'id': 6})
 
-    def test_filter_boards_exclude(self):
-        self.config['deck']['exclude_board_ids'] = '5'
-        assert not self.service.filter_boards({'title': 'testboard', 'id': 5})
-        assert self.service.filter_boards({'title': 'testboard', 'id': 6})
+    def test_filter_boards_exclude(self, config, card):
+        config['deck']['exclude_board_ids'] = '5'
+        service = self.make_service(config, card)
+        assert not service.filter_boards({'title': 'testboard', 'id': 5})
+        assert service.filter_boards({'title': 'testboard', 'id': 6})

--- a/tests/services/test_gerrit.py
+++ b/tests/services/test_gerrit.py
@@ -1,14 +1,15 @@
 import json
 
+import pytest
 import responses
 
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.gerrit import GerritService
 
-from .base import ServiceIssueTest
+from .base import get_mock_service
 
 
-class TestGerritIssue(ServiceIssueTest):
+class TestGerritIssue:
     SERVICE_CONFIG = {
         'service': 'gerrit',
         'base_uri': 'https://one.com',
@@ -46,19 +47,21 @@ class TestGerritIssue(ServiceIssueTest):
         'url': 'https://one.com/#/c/1/',
     }
 
-    def setUp(self):
-        super().setUp()
-
-        responses.add(
-            responses.HEAD,
-            self.SERVICE_CONFIG['base_uri'] + '/a/',
-            headers={'www-authenticate': 'digest'},
-        )
+    @pytest.fixture
+    def service(self):
+        # GerritService.__init__ sends a HEAD request to detect the server's
+        # authentication method, so the responses mock must already be active
+        # when the service is constructed, not just during the test.
         with responses.mock:
-            self.service = self.get_mock_service(GerritService)
+            responses.add(
+                responses.HEAD,
+                self.SERVICE_CONFIG['base_uri'] + '/a/',
+                headers={'www-authenticate': 'digest'},
+            )
+            return get_mock_service(GerritService, self.SERVICE_CONFIG)
 
-    def test_to_taskwarrior(self):
-        issue = self.service.get_issue_for_record(self.record, self.extra)
+    def test_to_taskwarrior(self, service):
+        issue = service.get_issue_for_record(self.record, self.extra)
         actual = issue.to_taskwarrior()
         expected = {
             'annotations': [],
@@ -76,10 +79,10 @@ class TestGerritIssue(ServiceIssueTest):
 
         assert actual == expected
 
-    def test_work_in_progress(self):
+    def test_work_in_progress(self, service):
         wip_record = dict(self.record)  # make a copy of the dict
         wip_record['work_in_progress'] = True
-        issue = self.service.get_issue_for_record(wip_record, self.extra)
+        issue = service.get_issue_for_record(wip_record, self.extra)
 
         expected = {
             'annotations': [],
@@ -99,14 +102,14 @@ class TestGerritIssue(ServiceIssueTest):
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     @responses.activate
-    def test_issues(self):
+    def test_issues(self, service):
         responses.get(
             'https://one.com/a/changes/?q=is:open+is:reviewer&o=MESSAGES&o=DETAILED_ACCOUNTS',
             # The response has some ")]}'" garbage prefixed.
             body=")]}'" + json.dumps([self.record]),
         )
 
-        issue = next(self.service.issues())
+        issue = next(service.issues())
 
         expected = {
             'annotations': ['@Iam Author - is is a message'],

--- a/tests/services/test_gerrit.py
+++ b/tests/services/test_gerrit.py
@@ -17,8 +17,9 @@ SERVICE_CONFIG = {
 }
 
 
-class TestGerritIssue:
-    record = {
+@pytest.fixture
+def record():
+    return {
         'project': 'nova',
         '_number': 1,
         'branch': 'master',
@@ -40,13 +41,18 @@ class TestGerritIssue:
         ],
     }
 
-    extra = {
+
+@pytest.fixture
+def extra():
+    return {
         'annotations': [
             # TODO - test annotations?
         ],
         'url': 'https://one.com/#/c/1/',
     }
 
+
+class TestGerritIssue:
     @pytest.fixture
     def service(self):
         # GerritService.__init__ sends a HEAD request to detect the server's
@@ -60,8 +66,8 @@ class TestGerritIssue:
             )
             return get_mock_service(GerritService, SERVICE_CONFIG)
 
-    def test_to_taskwarrior(self, service):
-        issue = service.get_issue_for_record(self.record, self.extra)
+    def test_to_taskwarrior(self, service, record, extra):
+        issue = service.get_issue_for_record(record, extra)
         actual = issue.to_taskwarrior()
         expected = {
             'annotations': [],
@@ -79,10 +85,10 @@ class TestGerritIssue:
 
         assert actual == expected
 
-    def test_work_in_progress(self, service):
-        wip_record = dict(self.record)  # make a copy of the dict
+    def test_work_in_progress(self, service, record, extra):
+        wip_record = dict(record)  # make a copy of the dict
         wip_record['work_in_progress'] = True
-        issue = service.get_issue_for_record(wip_record, self.extra)
+        issue = service.get_issue_for_record(wip_record, extra)
 
         expected = {
             'annotations': [],
@@ -102,11 +108,11 @@ class TestGerritIssue:
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     @responses.activate
-    def test_issues(self, service):
+    def test_issues(self, service, record):
         responses.get(
             'https://one.com/a/changes/?q=is:open+is:reviewer&o=MESSAGES&o=DETAILED_ACCOUNTS',
             # The response has some ")]}'" garbage prefixed.
-            body=")]}'" + json.dumps([self.record]),
+            body=")]}'" + json.dumps([record]),
         )
 
         issue = next(service.issues())

--- a/tests/services/test_gerrit.py
+++ b/tests/services/test_gerrit.py
@@ -8,16 +8,16 @@ from bugwarrior.services.gerrit import GerritService
 
 from .base import get_mock_service
 
+SERVICE_CONFIG = {
+    'service': 'gerrit',
+    'base_uri': 'https://one.com',
+    'username': 'two',
+    'password': 'three',
+    'ignore_user_comments': ['CI Bot'],
+}
+
 
 class TestGerritIssue:
-    SERVICE_CONFIG = {
-        'service': 'gerrit',
-        'base_uri': 'https://one.com',
-        'username': 'two',
-        'password': 'three',
-        'ignore_user_comments': ['CI Bot'],
-    }
-
     record = {
         'project': 'nova',
         '_number': 1,
@@ -55,10 +55,10 @@ class TestGerritIssue:
         with responses.mock:
             responses.add(
                 responses.HEAD,
-                self.SERVICE_CONFIG['base_uri'] + '/a/',
+                SERVICE_CONFIG['base_uri'] + '/a/',
                 headers={'www-authenticate': 'digest'},
             )
-            return get_mock_service(GerritService, self.SERVICE_CONFIG)
+            return get_mock_service(GerritService, SERVICE_CONFIG)
 
     def test_to_taskwarrior(self, service):
         issue = service.get_issue_for_record(self.record, self.extra)

--- a/tests/services/test_gerrit.py
+++ b/tests/services/test_gerrit.py
@@ -6,7 +6,7 @@ import responses
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.gerrit import GerritService
 
-from .base import get_mock_service
+SERVICE_CLASS = GerritService
 
 SERVICE_CONFIG = {
     'service': 'gerrit',
@@ -54,7 +54,7 @@ def extra():
 
 class TestGerritIssue:
     @pytest.fixture
-    def service(self):
+    def service(self, make_service):
         # GerritService.__init__ sends a HEAD request to detect the server's
         # authentication method, so the responses mock must already be active
         # when the service is constructed, not just during the test.
@@ -64,7 +64,7 @@ class TestGerritIssue:
                 SERVICE_CONFIG['base_uri'] + '/a/',
                 headers={'www-authenticate': 'digest'},
             )
-            return get_mock_service(GerritService, SERVICE_CONFIG)
+            return make_service()
 
     def test_to_taskwarrior(self, service, record, extra):
         issue = service.get_issue_for_record(record, extra)

--- a/tests/services/test_gerrit.py
+++ b/tests/services/test_gerrit.py
@@ -86,9 +86,8 @@ class TestGerritIssue:
         assert actual == expected
 
     def test_work_in_progress(self, service, record, extra):
-        wip_record = dict(record)  # make a copy of the dict
-        wip_record['work_in_progress'] = True
-        issue = service.get_issue_for_record(wip_record, extra)
+        record['work_in_progress'] = True
+        issue = service.get_issue_for_record(record, extra)
 
         expected = {
             'annotations': [],

--- a/tests/services/test_gitbug.py
+++ b/tests/services/test_gitbug.py
@@ -1,16 +1,17 @@
-import dataclasses
 from datetime import datetime, timedelta, timezone
 from unittest import mock
+
+import pytest
 
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.gitbug import GitBugClient, GitBugConfig, GitBugService
 
-from .base import ConfigTest, ServiceIssueTest
+from .base import get_mock_service
 
 
-@dataclasses.dataclass
-class TestData:
-    arbitrary_bug = {
+@pytest.fixture
+def bug():
+    return {
         'author': {'name': 'ryneeverett'},
         'comments': {
             'nodes': [
@@ -28,22 +29,18 @@ class TestData:
     }
 
 
-class TestGitBugIssue(ServiceIssueTest):
+class TestGitBugIssue:
     SERVICE_CONFIG = {'service': 'gitbug', 'path': '/dev/null'}
 
-    def setUp(self):
-        super().setUp()
+    @pytest.fixture
+    def service(self, bug):
+        service = get_mock_service(GitBugService, self.SERVICE_CONFIG)
+        service.client = mock.MagicMock(spec=GitBugClient)
+        service.client.get_issues = mock.MagicMock(return_value=[bug])
+        return service
 
-        self.data = TestData()
-
-        self.service = self.get_mock_service(GitBugService)
-        self.service.client = mock.MagicMock(spec=GitBugClient)
-        self.service.client.get_issues = mock.MagicMock(
-            return_value=[self.data.arbitrary_bug]
-        )
-
-    def test_to_taskwarrior(self):
-        issue = self.service.get_issue_for_record(self.data.arbitrary_bug, {})
+    def test_to_taskwarrior(self, service, bug):
+        issue = service.get_issue_for_record(bug, {})
 
         expected = {
             'annotations': [],
@@ -62,8 +59,8 @@ class TestGitBugIssue(ServiceIssueTest):
 
         assert actual == expected
 
-    def test_issues(self):
-        issue = next(self.service.issues())
+    def test_issues(self, service):
+        issue = next(service.issues())
 
         expected = {
             'annotations': [],
@@ -83,13 +80,11 @@ class TestGitBugIssue(ServiceIssueTest):
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
 
-class TestGitBugConfig(ConfigTest):
-    def setUp(self):
-        super().setUp()
-        self.config = GitBugConfig(
-            service="gitbug", path="~/custom-gitbug-repo", target="mygitbug"
-        )
-
-    def test_home_path_expansion(self):
-        expected = self.tempdir + "/custom-gitbug-repo"
-        assert str(self.config.path) == expected
+def test_home_path_expansion(tmp_path):
+    # The path field is an ExpandedPath, so a configured tilde expands to the
+    # user's home, which the autouse config_environment fixture points at
+    # tmp_path.
+    config = GitBugConfig(
+        service="gitbug", path="~/custom-gitbug-repo", target="mygitbug"
+    )
+    assert config.path == tmp_path / "custom-gitbug-repo"

--- a/tests/services/test_gitbug.py
+++ b/tests/services/test_gitbug.py
@@ -6,8 +6,6 @@ import pytest
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.gitbug import GitBugClient, GitBugConfig, GitBugService
 
-from .base import get_mock_service
-
 
 @pytest.fixture
 def record():
@@ -29,13 +27,15 @@ def record():
     }
 
 
+SERVICE_CLASS = GitBugService
+
 SERVICE_CONFIG = {'service': 'gitbug', 'path': '/dev/null'}
 
 
 class TestGitBugIssue:
     @pytest.fixture
-    def service(self, record):
-        service = get_mock_service(GitBugService, SERVICE_CONFIG)
+    def service(self, record, make_service):
+        service = make_service()
         service.client = mock.MagicMock(spec=GitBugClient)
         service.client.get_issues = mock.MagicMock(return_value=[record])
         return service

--- a/tests/services/test_gitbug.py
+++ b/tests/services/test_gitbug.py
@@ -10,7 +10,7 @@ from .base import get_mock_service
 
 
 @pytest.fixture
-def bug():
+def record():
     return {
         'author': {'name': 'ryneeverett'},
         'comments': {
@@ -34,14 +34,14 @@ SERVICE_CONFIG = {'service': 'gitbug', 'path': '/dev/null'}
 
 class TestGitBugIssue:
     @pytest.fixture
-    def service(self, bug):
+    def service(self, record):
         service = get_mock_service(GitBugService, SERVICE_CONFIG)
         service.client = mock.MagicMock(spec=GitBugClient)
-        service.client.get_issues = mock.MagicMock(return_value=[bug])
+        service.client.get_issues = mock.MagicMock(return_value=[record])
         return service
 
-    def test_to_taskwarrior(self, service, bug):
-        issue = service.get_issue_for_record(bug, {})
+    def test_to_taskwarrior(self, service, record):
+        issue = service.get_issue_for_record(record, {})
 
         expected = {
             'annotations': [],

--- a/tests/services/test_gitbug.py
+++ b/tests/services/test_gitbug.py
@@ -29,12 +29,13 @@ def bug():
     }
 
 
-class TestGitBugIssue:
-    SERVICE_CONFIG = {'service': 'gitbug', 'path': '/dev/null'}
+SERVICE_CONFIG = {'service': 'gitbug', 'path': '/dev/null'}
 
+
+class TestGitBugIssue:
     @pytest.fixture
     def service(self, bug):
-        service = get_mock_service(GitBugService, self.SERVICE_CONFIG)
+        service = get_mock_service(GitBugService, SERVICE_CONFIG)
         service.client = mock.MagicMock(spec=GitBugClient)
         service.client.get_issues = mock.MagicMock(return_value=[bug])
         return service

--- a/tests/services/test_github.py
+++ b/tests/services/test_github.py
@@ -306,7 +306,7 @@ class TestGithubService:
         assert issue["body"][:5] == service.body(issue)
 
 
-class TestGithubValidation:
+class TestGithubConfig:
     @pytest.fixture
     def config(self):
         return {'general': {'targets': ['myservice']}, 'myservice': {**SERVICE_CONFIG}}

--- a/tests/services/test_github.py
+++ b/tests/services/test_github.py
@@ -40,7 +40,7 @@ def record():
         'closed_at': CLOSED.isoformat(),
         'updated_at': UPDATED.isoformat(),
         'repo': 'arbitrary_username/arbitrary_repo',
-        'state': 'CLOSED',
+        'state': 'closed',
         'draft': False,
     }
 
@@ -58,29 +58,28 @@ def extra():
 
 class TestGithubIssue:
     def test_draft(self, service, record, extra):
-        draft = dict(record)
-        draft['draft'] = True
-        issue = service.get_issue_for_record(draft, extra)
+        record['draft'] = True
+        issue = service.get_issue_for_record(record, extra)
 
         expected = {
             'annotations': [],
             'description': '(bw)Is#10 - Hallo .. https://github.com/arbitrary_username/arbitrary_repo/pull/1',  # noqa: E501
             'entry': CREATED,
             'end': CLOSED,
-            'githubbody': draft['body'],
+            'githubbody': record['body'],
             'githubcreatedon': CREATED,
             'githubclosedon': CLOSED,
-            'githubdraft': int(draft['draft']),
-            'githubmilestone': draft['milestone']['title'],
-            'githubnamespace': draft['repo'].split('/')[0],
-            'githubnumber': draft['number'],
-            'githubrepo': draft['repo'],
-            'githubtitle': draft['title'],
+            'githubdraft': int(record['draft']),
+            'githubmilestone': record['milestone']['title'],
+            'githubnamespace': record['repo'].split('/')[0],
+            'githubnumber': record['number'],
+            'githubrepo': record['repo'],
+            'githubtitle': record['title'],
             'githubtype': 'issue',
             'githubupdatedat': UPDATED,
-            'githuburl': draft['html_url'],
-            'githubuser': draft['user']['login'],
-            'githubstate': draft['state'],
+            'githuburl': record['html_url'],
+            'githubuser': record['user']['login'],
+            'githubstate': record['state'],
             'priority': 'M',
             'project': extra['project'],
             'tags': [],
@@ -112,7 +111,7 @@ class TestGithubIssue:
             issue.MILESTONE: record['milestone']['title'],
             issue.USER: record['user']['login'],
             issue.NAMESPACE: 'arbitrary_username',
-            issue.STATE: 'CLOSED',
+            issue.STATE: 'closed',
         }
         actual_output = issue.to_taskwarrior()
 
@@ -166,7 +165,7 @@ class TestGithubIssue:
             'githubupdatedat': UPDATED,
             'githuburl': 'https://github.com/arbitrary_username/arbitrary_repo/pull/1',
             'githubuser': 'arbitrary_login',
-            'githubstate': 'CLOSED',
+            'githubstate': 'closed',
             'priority': 'M',
             'project': 'arbitrary_repo',
             'tags': [],
@@ -219,7 +218,7 @@ class TestGithubIssueQuery:
             'githubupdatedat': UPDATED,
             'githuburl': 'https://github.com/arbitrary_username/arbitrary_repo/pull/1',
             'githubuser': 'arbitrary_login',
-            'githubstate': 'CLOSED',
+            'githubstate': 'closed',
             'priority': 'M',
             'project': 'arbitrary_repo',
             'tags': [],

--- a/tests/services/test_github.py
+++ b/tests/services/test_github.py
@@ -42,17 +42,17 @@ ARBITRARY_EXTRA = {
 IGNORABLE = {'user': {'login': 'cibot'}, 'body': 'Ignore this comment.'}
 
 
-class TestGithubIssue:
-    SERVICE_CONFIG = {
-        'service': 'github',
-        'login': 'arbitrary_login',
-        'token': 'arbitrary_token',
-        'username': 'arbitrary_username',
-        'ignore_user_comments': [IGNORABLE['user']['login']],
-    }
+SERVICE_CONFIG = {
+    'service': 'github',
+    'login': 'arbitrary_login',
+    'token': 'arbitrary_token',
+    'username': 'arbitrary_username',
+}
 
+
+class TestGithubIssue:
     def test_draft(self):
-        service = get_mock_service(GithubService, self.SERVICE_CONFIG)
+        service = get_mock_service(GithubService, SERVICE_CONFIG)
         draft = dict(ARBITRARY_ISSUE)
         draft['draft'] = True
         issue = service.get_issue_for_record(draft, ARBITRARY_EXTRA)
@@ -85,7 +85,7 @@ class TestGithubIssue:
 
     def test_to_taskwarrior(self):
         service = get_mock_service(
-            GithubService, {**self.SERVICE_CONFIG, 'import_labels_as_tags': True}
+            GithubService, {**SERVICE_CONFIG, 'import_labels_as_tags': True}
         )
         issue = service.get_issue_for_record(ARBITRARY_ISSUE, ARBITRARY_EXTRA)
 
@@ -144,7 +144,10 @@ class TestGithubIssue:
             ],
         )  # second comment should be ignored and still pass
 
-        service = get_mock_service(GithubService, self.SERVICE_CONFIG)
+        service = get_mock_service(
+            GithubService,
+            {**SERVICE_CONFIG, 'ignore_user_comments': [IGNORABLE['user']['login']]},
+        )
         issue = next(service.issues())
 
         expected = {
@@ -174,20 +177,18 @@ class TestGithubIssue:
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
 
-class TestGithubIssueQuery:
-    SERVICE_CONFIG = {
-        'service': 'github',
-        'login': 'arbitrary_login',
-        'token': 'arbitrary_token',
-        'username': 'arbitrary_username',
-        'query': 'is:open reviewer:octocat',
-        'include_user_repos': 'False',
-        'include_user_issues': 'False',
-    }
+QUERY_SERVICE_CONFIG = {
+    **SERVICE_CONFIG,
+    'query': 'is:open reviewer:octocat',
+    'include_user_repos': 'False',
+    'include_user_issues': 'False',
+}
 
+
+class TestGithubIssueQuery:
     @pytest.fixture
     def service(self):
-        return get_mock_service(GithubService, self.SERVICE_CONFIG)
+        return get_mock_service(GithubService, QUERY_SERVICE_CONFIG)
 
     def test_to_taskwarrior(self):
         pass
@@ -234,18 +235,11 @@ class TestGithubIssueQuery:
 
 
 class TestGithubService:
-    SERVICE_CONFIG = {
-        'service': 'github',
-        'login': 'tintin',
-        'username': 'milou',
-        'token': 't0ps3cr3t',
-    }
-
     def test_token_authorization_header(self):
-        service = get_mock_service(GithubService, self.SERVICE_CONFIG)
+        service = get_mock_service(GithubService, SERVICE_CONFIG)
         service = get_mock_service(
             GithubService,
-            {**self.SERVICE_CONFIG, 'token': '@oracle:eval:echo 1234567890ABCDEF'},
+            {**SERVICE_CONFIG, 'token': '@oracle:eval:echo 1234567890ABCDEF'},
         )
         assert (
             service.client.session.headers['Authorization'] == "token 1234567890ABCDEF"
@@ -253,29 +247,34 @@ class TestGithubService:
 
     def test_default_host(self):
         """Check that if host is not set, we default to github.com"""
-        service = get_mock_service(GithubService, self.SERVICE_CONFIG)
+        service = get_mock_service(GithubService, SERVICE_CONFIG)
         assert "github.com" == service.config.host
 
     def test_overwrite_host(self):
         """Check that if host is set, we use its value as host"""
         service = get_mock_service(
-            GithubService, {**self.SERVICE_CONFIG, 'host': 'github.example.com'}
+            GithubService, {**SERVICE_CONFIG, 'host': 'github.example.com'}
         )
         assert "github.example.com" == service.config.host
 
     def test_keyring_service(self):
         """Checks that the keyring service name"""
-        service_config = GithubConfig(**self.SERVICE_CONFIG, target="myservice")
+        service_config = GithubConfig(**SERVICE_CONFIG, target="myservice")
         keyring_service = service_config.keyring_service
-        assert "github://tintin@github.com/milou" == keyring_service
+        assert (
+            "github://arbitrary_login@github.com/arbitrary_username" == keyring_service
+        )
 
     def test_keyring_service_host(self):
         """Checks that the keyring key depends on the github host."""
         service_config = GithubConfig(
-            **{'host': 'github.example.com'}, **self.SERVICE_CONFIG, target="myservice"
+            **{'host': 'github.example.com'}, **SERVICE_CONFIG, target="myservice"
         )
         keyring_service = service_config.keyring_service
-        assert "github://tintin@github.example.com/milou" == keyring_service
+        assert (
+            "github://arbitrary_login@github.example.com/arbitrary_username"
+            == keyring_service
+        )
 
     def test_get_repository_from_issue_url__issue(self):
         issue = dict(repos_url="https://github.com/foo/bar")
@@ -293,32 +292,25 @@ class TestGithubService:
         assert "foo/bar" == repository
 
     def test_body_no_limit(self):
-        service = get_mock_service(GithubService, self.SERVICE_CONFIG)
+        service = get_mock_service(GithubService, SERVICE_CONFIG)
         issue = dict(body="A very short issue body.  Fixes #42.")
         assert issue["body"] == service.body(issue)
 
     def test_body_newline_style(self):
-        service = get_mock_service(GithubService, self.SERVICE_CONFIG)
+        service = get_mock_service(GithubService, SERVICE_CONFIG)
         issue = dict(body="An\r\nIssue\r\nWith\r\nNewlines")
         assert "An\nIssue\nWith\nNewlines" == service.body(issue)
 
     def test_body_length_limit(self):
-        service = get_mock_service(
-            GithubService, {**self.SERVICE_CONFIG, 'body_length': 5}
-        )
+        service = get_mock_service(GithubService, {**SERVICE_CONFIG, 'body_length': 5})
         issue = dict(body="A very short issue body.  Fixes #42.")
         assert issue["body"][:5] == service.body(issue)
 
 
 class TestGithubValidation:
-    SERVICE_CONFIG = {'service': 'github', 'login': 'tintin', 'token': 't0ps3cr3t'}
-
     @pytest.fixture
     def config(self):
-        return {
-            'general': {'targets': ['myservice']},
-            'myservice': {**self.SERVICE_CONFIG, 'username': 'milou'},
-        }
+        return {'general': {'targets': ['myservice']}, 'myservice': {**SERVICE_CONFIG}}
 
     def test_require_username_or_query(self, config, assert_validation_error):
         config['myservice']['include_user_repos'] = 'false'

--- a/tests/services/test_github.py
+++ b/tests/services/test_github.py
@@ -8,9 +8,10 @@ from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.github import GithubClient, GithubConfig, GithubService
 
 from ..base import validate
-from .base import get_mock_service
 
 IGNORABLE = {'user': {'login': 'cibot'}, 'body': 'Ignore this comment.'}
+
+SERVICE_CLASS = GithubService
 
 SERVICE_CONFIG = {
     'service': 'github',
@@ -51,19 +52,6 @@ def data():
     return SimpleNamespace(
         created=created, closed=closed, updated=updated, record=record, extra=extra
     )
-
-
-@pytest.fixture
-def make_service():
-    def make(**overrides):
-        return get_mock_service(GithubService, {**SERVICE_CONFIG, **overrides})
-
-    return make
-
-
-@pytest.fixture
-def service(make_service):
-    return make_service()
 
 
 class TestGithubIssue:
@@ -185,18 +173,14 @@ class TestGithubIssue:
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
 
-QUERY_SERVICE_CONFIG = {
-    **SERVICE_CONFIG,
-    'query': 'is:open reviewer:octocat',
-    'include_user_repos': 'False',
-    'include_user_issues': 'False',
-}
-
-
 class TestGithubIssueQuery:
     @pytest.fixture
-    def service(self):
-        return get_mock_service(GithubService, QUERY_SERVICE_CONFIG)
+    def service(self, make_service):
+        return make_service(
+            query='is:open reviewer:octocat',
+            include_user_repos='False',
+            include_user_issues='False',
+        )
 
     def test_to_taskwarrior(self):
         pass

--- a/tests/services/test_github.py
+++ b/tests/services/test_github.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
 import pytest
 import responses
@@ -9,38 +10,7 @@ from bugwarrior.services.github import GithubClient, GithubConfig, GithubService
 from ..base import validate
 from .base import get_mock_service
 
-ARBITRARY_CREATED = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(
-    microsecond=0
-)
-ARBITRARY_CLOSED = (datetime.now(timezone.utc) - timedelta(minutes=30)).replace(
-    microsecond=0
-)
-ARBITRARY_UPDATED = datetime.now(timezone.utc).replace(microsecond=0)
-ARBITRARY_ISSUE = {
-    'title': 'Hallo',
-    'html_url': 'https://github.com/arbitrary_username/arbitrary_repo/pull/1',
-    'url': 'https://api.github.com/repos/arbitrary_username/arbitrary_repo/issues/1',
-    'number': 10,
-    'body': 'Something',
-    'user': {'login': 'arbitrary_login'},
-    'milestone': {'title': 'alpha'},
-    'labels': [{'name': 'bugfix'}],
-    'created_at': ARBITRARY_CREATED.isoformat(),
-    'closed_at': ARBITRARY_CLOSED.isoformat(),
-    'updated_at': ARBITRARY_UPDATED.isoformat(),
-    'repo': 'arbitrary_username/arbitrary_repo',
-    'state': 'closed',
-    'draft': False,
-}
-ARBITRARY_EXTRA = {
-    'project': 'one',
-    'type': 'issue',
-    'annotations': [],
-    'body': 'Something',
-    'namespace': 'arbitrary_username',
-}
 IGNORABLE = {'user': {'login': 'cibot'}, 'body': 'Ignore this comment.'}
-
 
 SERVICE_CONFIG = {
     'service': 'github',
@@ -50,21 +20,54 @@ SERVICE_CONFIG = {
 }
 
 
+@pytest.fixture
+def data():
+    created = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(microsecond=0)
+    closed = (datetime.now(timezone.utc) - timedelta(minutes=30)).replace(microsecond=0)
+    updated = datetime.now(timezone.utc).replace(microsecond=0)
+    record = {
+        'title': 'Hallo',
+        'html_url': 'https://github.com/arbitrary_username/arbitrary_repo/pull/1',
+        'url': 'https://api.github.com/repos/arbitrary_username/arbitrary_repo/issues/1',
+        'number': 10,
+        'body': 'Something',
+        'user': {'login': 'arbitrary_login'},
+        'milestone': {'title': 'alpha'},
+        'labels': [{'name': 'bugfix'}],
+        'created_at': created.isoformat(),
+        'closed_at': closed.isoformat(),
+        'updated_at': updated.isoformat(),
+        'repo': 'arbitrary_username/arbitrary_repo',
+        'state': 'closed',
+        'draft': False,
+    }
+    extra = {
+        'project': 'one',
+        'type': 'issue',
+        'annotations': [],
+        'body': 'Something',
+        'namespace': 'arbitrary_username',
+    }
+    return SimpleNamespace(
+        created=created, closed=closed, updated=updated, record=record, extra=extra
+    )
+
+
 class TestGithubIssue:
-    def test_draft(self):
+    def test_draft(self, data):
         service = get_mock_service(GithubService, SERVICE_CONFIG)
-        draft = dict(ARBITRARY_ISSUE)
+        draft = dict(data.record)
         draft['draft'] = True
-        issue = service.get_issue_for_record(draft, ARBITRARY_EXTRA)
+        issue = service.get_issue_for_record(draft, data.extra)
 
         expected = {
             'annotations': [],
             'description': '(bw)Is#10 - Hallo .. https://github.com/arbitrary_username/arbitrary_repo/pull/1',  # noqa: E501
-            'entry': ARBITRARY_CREATED,
-            'end': ARBITRARY_CLOSED,
+            'entry': data.created,
+            'end': data.closed,
             'githubbody': draft['body'],
-            'githubcreatedon': ARBITRARY_CREATED,
-            'githubclosedon': ARBITRARY_CLOSED,
+            'githubcreatedon': data.created,
+            'githubclosedon': data.closed,
             'githubdraft': int(draft['draft']),
             'githubmilestone': draft['milestone']['title'],
             'githubnamespace': draft['repo'].split('/')[0],
@@ -72,42 +75,42 @@ class TestGithubIssue:
             'githubrepo': draft['repo'],
             'githubtitle': draft['title'],
             'githubtype': 'issue',
-            'githubupdatedat': ARBITRARY_UPDATED,
+            'githubupdatedat': data.updated,
             'githuburl': draft['html_url'],
             'githubuser': draft['user']['login'],
             'githubstate': draft['state'],
             'priority': 'M',
-            'project': ARBITRARY_EXTRA['project'],
+            'project': data.extra['project'],
             'tags': [],
         }
 
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
-    def test_to_taskwarrior(self):
+    def test_to_taskwarrior(self, data):
         service = get_mock_service(
             GithubService, {**SERVICE_CONFIG, 'import_labels_as_tags': True}
         )
-        issue = service.get_issue_for_record(ARBITRARY_ISSUE, ARBITRARY_EXTRA)
+        issue = service.get_issue_for_record(data.record, data.extra)
 
         expected_output = {
-            'project': ARBITRARY_EXTRA['project'],
+            'project': data.extra['project'],
             'priority': service.config.default_priority,
             'annotations': [],
             'tags': ['bugfix'],
-            'entry': ARBITRARY_CREATED,
-            'end': ARBITRARY_CLOSED,
-            issue.URL: ARBITRARY_ISSUE['html_url'],
-            issue.REPO: ARBITRARY_ISSUE['repo'],
-            issue.DRAFT: ARBITRARY_ISSUE['draft'],
-            issue.TYPE: ARBITRARY_EXTRA['type'],
-            issue.TITLE: ARBITRARY_ISSUE['title'],
-            issue.NUMBER: ARBITRARY_ISSUE['number'],
-            issue.UPDATED_AT: ARBITRARY_UPDATED,
-            issue.CREATED_AT: ARBITRARY_CREATED,
-            issue.CLOSED_AT: ARBITRARY_CLOSED,
-            issue.BODY: ARBITRARY_EXTRA['body'],
-            issue.MILESTONE: ARBITRARY_ISSUE['milestone']['title'],
-            issue.USER: ARBITRARY_ISSUE['user']['login'],
+            'entry': data.created,
+            'end': data.closed,
+            issue.URL: data.record['html_url'],
+            issue.REPO: data.record['repo'],
+            issue.DRAFT: data.record['draft'],
+            issue.TYPE: data.extra['type'],
+            issue.TITLE: data.record['title'],
+            issue.NUMBER: data.record['number'],
+            issue.UPDATED_AT: data.updated,
+            issue.CREATED_AT: data.created,
+            issue.CLOSED_AT: data.closed,
+            issue.BODY: data.extra['body'],
+            issue.MILESTONE: data.record['milestone']['title'],
+            issue.USER: data.record['user']['login'],
             issue.NAMESPACE: 'arbitrary_username',
             issue.STATE: 'closed',
         }
@@ -116,7 +119,7 @@ class TestGithubIssue:
         assert actual_output == expected_output
 
     @responses.activate
-    def test_issues(self):
+    def test_issues(self, data):
         responses.get(
             'https://api.github.com/user/repos?per_page=100',
             json=[{'name': 'some_repo', 'owner': {'login': 'some_username'}}],
@@ -129,12 +132,10 @@ class TestGithubIssue:
 
         responses.get(
             'https://api.github.com/repos/arbitrary_username/arbitrary_repo/issues?per_page=100',
-            json=[ARBITRARY_ISSUE],
+            json=[data.record],
         )
 
-        responses.get(
-            'https://api.github.com/issues?per_page=100', json=[ARBITRARY_ISSUE]
-        )
+        responses.get('https://api.github.com/issues?per_page=100', json=[data.record])
 
         responses.get(
             'https://api.github.com/repos/arbitrary_username/arbitrary_repo/issues/10/comments?per_page=100',  # noqa: E501
@@ -153,11 +154,11 @@ class TestGithubIssue:
         expected = {
             'annotations': ['@arbitrary_login - Arbitrary comment.'],
             'description': '(bw)Is#10 - Hallo .. https://github.com/arbitrary_username/arbitrary_repo/pull/1',  # noqa: E501
-            'entry': ARBITRARY_CREATED,
-            'end': ARBITRARY_CLOSED,
+            'entry': data.created,
+            'end': data.closed,
             'githubbody': 'Something',
-            'githubcreatedon': ARBITRARY_CREATED,
-            'githubclosedon': ARBITRARY_CLOSED,
+            'githubcreatedon': data.created,
+            'githubclosedon': data.closed,
             'githubdraft': 0,
             'githubmilestone': 'alpha',
             'githubnamespace': 'arbitrary_username',
@@ -165,7 +166,7 @@ class TestGithubIssue:
             'githubrepo': 'arbitrary_username/arbitrary_repo',
             'githubtitle': 'Hallo',
             'githubtype': 'issue',
-            'githubupdatedat': ARBITRARY_UPDATED,
+            'githubupdatedat': data.updated,
             'githuburl': 'https://github.com/arbitrary_username/arbitrary_repo/pull/1',
             'githubuser': 'arbitrary_login',
             'githubstate': 'closed',
@@ -194,10 +195,10 @@ class TestGithubIssueQuery:
         pass
 
     @responses.activate
-    def test_issues(self, service):
+    def test_issues(self, service, data):
         responses.get(
             'https://api.github.com/search/issues?q=is%3Aopen+reviewer%3Aoctocat&per_page=100',
-            json={'items': [ARBITRARY_ISSUE]},
+            json={'items': [data.record]},
         )
 
         responses.get(
@@ -210,11 +211,11 @@ class TestGithubIssueQuery:
         expected = {
             'annotations': ['@arbitrary_login - Arbitrary comment.'],
             'description': '(bw)Is#10 - Hallo .. https://github.com/arbitrary_username/arbitrary_repo/pull/1',  # noqa: E501
-            'entry': ARBITRARY_CREATED,
-            'end': ARBITRARY_CLOSED,
+            'entry': data.created,
+            'end': data.closed,
             'githubbody': 'Something',
-            'githubcreatedon': ARBITRARY_CREATED,
-            'githubclosedon': ARBITRARY_CLOSED,
+            'githubcreatedon': data.created,
+            'githubclosedon': data.closed,
             'githubdraft': 0,
             'githubmilestone': 'alpha',
             'githubnamespace': 'arbitrary_username',
@@ -222,7 +223,7 @@ class TestGithubIssueQuery:
             'githubrepo': 'arbitrary_username/arbitrary_repo',
             'githubtitle': 'Hallo',
             'githubtype': 'issue',
-            'githubupdatedat': ARBITRARY_UPDATED,
+            'githubupdatedat': data.updated,
             'githuburl': 'https://github.com/arbitrary_username/arbitrary_repo/pull/1',
             'githubuser': 'arbitrary_login',
             'githubstate': 'closed',

--- a/tests/services/test_github.py
+++ b/tests/services/test_github.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta, timezone
-from types import SimpleNamespace
 
 import pytest
 import responses
@@ -21,12 +20,14 @@ SERVICE_CONFIG = {
 }
 
 
+CREATED = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(microsecond=0)
+CLOSED = (datetime.now(timezone.utc) - timedelta(minutes=30)).replace(microsecond=0)
+UPDATED = datetime.now(timezone.utc).replace(microsecond=0)
+
+
 @pytest.fixture
-def data():
-    created = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(microsecond=0)
-    closed = (datetime.now(timezone.utc) - timedelta(minutes=30)).replace(microsecond=0)
-    updated = datetime.now(timezone.utc).replace(microsecond=0)
-    record = {
+def record():
+    return {
         'title': 'Hallo',
         'html_url': 'https://github.com/arbitrary_username/arbitrary_repo/pull/1',
         'url': 'https://api.github.com/repos/arbitrary_username/arbitrary_repo/issues/1',
@@ -35,39 +36,40 @@ def data():
         'user': {'login': 'arbitrary_login'},
         'milestone': {'title': 'alpha'},
         'labels': [{'name': 'bugfix'}],
-        'created_at': created.isoformat(),
-        'closed_at': closed.isoformat(),
-        'updated_at': updated.isoformat(),
+        'created_at': CREATED.isoformat(),
+        'closed_at': CLOSED.isoformat(),
+        'updated_at': UPDATED.isoformat(),
         'repo': 'arbitrary_username/arbitrary_repo',
-        'state': 'closed',
+        'state': 'CLOSED',
         'draft': False,
     }
-    extra = {
+
+
+@pytest.fixture
+def extra():
+    return {
         'project': 'one',
         'type': 'issue',
         'annotations': [],
         'body': 'Something',
         'namespace': 'arbitrary_username',
     }
-    return SimpleNamespace(
-        created=created, closed=closed, updated=updated, record=record, extra=extra
-    )
 
 
 class TestGithubIssue:
-    def test_draft(self, service, data):
-        draft = dict(data.record)
+    def test_draft(self, service, record, extra):
+        draft = dict(record)
         draft['draft'] = True
-        issue = service.get_issue_for_record(draft, data.extra)
+        issue = service.get_issue_for_record(draft, extra)
 
         expected = {
             'annotations': [],
             'description': '(bw)Is#10 - Hallo .. https://github.com/arbitrary_username/arbitrary_repo/pull/1',  # noqa: E501
-            'entry': data.created,
-            'end': data.closed,
+            'entry': CREATED,
+            'end': CLOSED,
             'githubbody': draft['body'],
-            'githubcreatedon': data.created,
-            'githubclosedon': data.closed,
+            'githubcreatedon': CREATED,
+            'githubclosedon': CLOSED,
             'githubdraft': int(draft['draft']),
             'githubmilestone': draft['milestone']['title'],
             'githubnamespace': draft['repo'].split('/')[0],
@@ -75,49 +77,49 @@ class TestGithubIssue:
             'githubrepo': draft['repo'],
             'githubtitle': draft['title'],
             'githubtype': 'issue',
-            'githubupdatedat': data.updated,
+            'githubupdatedat': UPDATED,
             'githuburl': draft['html_url'],
             'githubuser': draft['user']['login'],
             'githubstate': draft['state'],
             'priority': 'M',
-            'project': data.extra['project'],
+            'project': extra['project'],
             'tags': [],
         }
 
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
-    def test_to_taskwarrior(self, make_service, data):
+    def test_to_taskwarrior(self, make_service, record, extra):
         service = make_service(import_labels_as_tags=True)
-        issue = service.get_issue_for_record(data.record, data.extra)
+        issue = service.get_issue_for_record(record, extra)
 
         expected_output = {
-            'project': data.extra['project'],
+            'project': extra['project'],
             'priority': service.config.default_priority,
             'annotations': [],
             'tags': ['bugfix'],
-            'entry': data.created,
-            'end': data.closed,
-            issue.URL: data.record['html_url'],
-            issue.REPO: data.record['repo'],
-            issue.DRAFT: data.record['draft'],
-            issue.TYPE: data.extra['type'],
-            issue.TITLE: data.record['title'],
-            issue.NUMBER: data.record['number'],
-            issue.UPDATED_AT: data.updated,
-            issue.CREATED_AT: data.created,
-            issue.CLOSED_AT: data.closed,
-            issue.BODY: data.extra['body'],
-            issue.MILESTONE: data.record['milestone']['title'],
-            issue.USER: data.record['user']['login'],
+            'entry': CREATED,
+            'end': CLOSED,
+            issue.URL: record['html_url'],
+            issue.REPO: record['repo'],
+            issue.DRAFT: record['draft'],
+            issue.TYPE: extra['type'],
+            issue.TITLE: record['title'],
+            issue.NUMBER: record['number'],
+            issue.UPDATED_AT: UPDATED,
+            issue.CREATED_AT: CREATED,
+            issue.CLOSED_AT: CLOSED,
+            issue.BODY: extra['body'],
+            issue.MILESTONE: record['milestone']['title'],
+            issue.USER: record['user']['login'],
             issue.NAMESPACE: 'arbitrary_username',
-            issue.STATE: 'closed',
+            issue.STATE: 'CLOSED',
         }
         actual_output = issue.to_taskwarrior()
 
         assert actual_output == expected_output
 
     @responses.activate
-    def test_issues(self, make_service, data):
+    def test_issues(self, make_service, record):
         responses.get(
             'https://api.github.com/user/repos?per_page=100',
             json=[{'name': 'some_repo', 'owner': {'login': 'some_username'}}],
@@ -130,10 +132,10 @@ class TestGithubIssue:
 
         responses.get(
             'https://api.github.com/repos/arbitrary_username/arbitrary_repo/issues?per_page=100',
-            json=[data.record],
+            json=[record],
         )
 
-        responses.get('https://api.github.com/issues?per_page=100', json=[data.record])
+        responses.get('https://api.github.com/issues?per_page=100', json=[record])
 
         responses.get(
             'https://api.github.com/repos/arbitrary_username/arbitrary_repo/issues/10/comments?per_page=100',  # noqa: E501
@@ -149,11 +151,11 @@ class TestGithubIssue:
         expected = {
             'annotations': ['@arbitrary_login - Arbitrary comment.'],
             'description': '(bw)Is#10 - Hallo .. https://github.com/arbitrary_username/arbitrary_repo/pull/1',  # noqa: E501
-            'entry': data.created,
-            'end': data.closed,
+            'entry': CREATED,
+            'end': CLOSED,
             'githubbody': 'Something',
-            'githubcreatedon': data.created,
-            'githubclosedon': data.closed,
+            'githubcreatedon': CREATED,
+            'githubclosedon': CLOSED,
             'githubdraft': 0,
             'githubmilestone': 'alpha',
             'githubnamespace': 'arbitrary_username',
@@ -161,10 +163,10 @@ class TestGithubIssue:
             'githubrepo': 'arbitrary_username/arbitrary_repo',
             'githubtitle': 'Hallo',
             'githubtype': 'issue',
-            'githubupdatedat': data.updated,
+            'githubupdatedat': UPDATED,
             'githuburl': 'https://github.com/arbitrary_username/arbitrary_repo/pull/1',
             'githubuser': 'arbitrary_login',
-            'githubstate': 'closed',
+            'githubstate': 'CLOSED',
             'priority': 'M',
             'project': 'arbitrary_repo',
             'tags': [],
@@ -186,10 +188,10 @@ class TestGithubIssueQuery:
         pass
 
     @responses.activate
-    def test_issues(self, service, data):
+    def test_issues(self, service, record):
         responses.get(
             'https://api.github.com/search/issues?q=is%3Aopen+reviewer%3Aoctocat&per_page=100',
-            json={'items': [data.record]},
+            json={'items': [record]},
         )
 
         responses.get(
@@ -202,11 +204,11 @@ class TestGithubIssueQuery:
         expected = {
             'annotations': ['@arbitrary_login - Arbitrary comment.'],
             'description': '(bw)Is#10 - Hallo .. https://github.com/arbitrary_username/arbitrary_repo/pull/1',  # noqa: E501
-            'entry': data.created,
-            'end': data.closed,
+            'entry': CREATED,
+            'end': CLOSED,
             'githubbody': 'Something',
-            'githubcreatedon': data.created,
-            'githubclosedon': data.closed,
+            'githubcreatedon': CREATED,
+            'githubclosedon': CLOSED,
             'githubdraft': 0,
             'githubmilestone': 'alpha',
             'githubnamespace': 'arbitrary_username',
@@ -214,10 +216,10 @@ class TestGithubIssueQuery:
             'githubrepo': 'arbitrary_username/arbitrary_repo',
             'githubtitle': 'Hallo',
             'githubtype': 'issue',
-            'githubupdatedat': data.updated,
+            'githubupdatedat': UPDATED,
             'githuburl': 'https://github.com/arbitrary_username/arbitrary_repo/pull/1',
             'githubuser': 'arbitrary_login',
-            'githubstate': 'closed',
+            'githubstate': 'CLOSED',
             'priority': 'M',
             'project': 'arbitrary_repo',
             'tags': [],

--- a/tests/services/test_github.py
+++ b/tests/services/test_github.py
@@ -53,9 +53,21 @@ def data():
     )
 
 
+@pytest.fixture
+def make_service():
+    def make(**overrides):
+        return get_mock_service(GithubService, {**SERVICE_CONFIG, **overrides})
+
+    return make
+
+
+@pytest.fixture
+def service(make_service):
+    return make_service()
+
+
 class TestGithubIssue:
-    def test_draft(self, data):
-        service = get_mock_service(GithubService, SERVICE_CONFIG)
+    def test_draft(self, service, data):
         draft = dict(data.record)
         draft['draft'] = True
         issue = service.get_issue_for_record(draft, data.extra)
@@ -86,10 +98,8 @@ class TestGithubIssue:
 
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
-    def test_to_taskwarrior(self, data):
-        service = get_mock_service(
-            GithubService, {**SERVICE_CONFIG, 'import_labels_as_tags': True}
-        )
+    def test_to_taskwarrior(self, make_service, data):
+        service = make_service(import_labels_as_tags=True)
         issue = service.get_issue_for_record(data.record, data.extra)
 
         expected_output = {
@@ -119,7 +129,7 @@ class TestGithubIssue:
         assert actual_output == expected_output
 
     @responses.activate
-    def test_issues(self, data):
+    def test_issues(self, make_service, data):
         responses.get(
             'https://api.github.com/user/repos?per_page=100',
             json=[{'name': 'some_repo', 'owner': {'login': 'some_username'}}],
@@ -145,10 +155,7 @@ class TestGithubIssue:
             ],
         )  # second comment should be ignored and still pass
 
-        service = get_mock_service(
-            GithubService,
-            {**SERVICE_CONFIG, 'ignore_user_comments': [IGNORABLE['user']['login']]},
-        )
+        service = make_service(ignore_user_comments=[IGNORABLE['user']['login']])
         issue = next(service.issues())
 
         expected = {
@@ -236,26 +243,19 @@ class TestGithubIssueQuery:
 
 
 class TestGithubService:
-    def test_token_authorization_header(self):
-        service = get_mock_service(GithubService, SERVICE_CONFIG)
-        service = get_mock_service(
-            GithubService,
-            {**SERVICE_CONFIG, 'token': '@oracle:eval:echo 1234567890ABCDEF'},
-        )
+    def test_token_authorization_header(self, make_service):
+        service = make_service(token='@oracle:eval:echo 1234567890ABCDEF')
         assert (
             service.client.session.headers['Authorization'] == "token 1234567890ABCDEF"
         )
 
-    def test_default_host(self):
+    def test_default_host(self, service):
         """Check that if host is not set, we default to github.com"""
-        service = get_mock_service(GithubService, SERVICE_CONFIG)
         assert "github.com" == service.config.host
 
-    def test_overwrite_host(self):
+    def test_overwrite_host(self, make_service):
         """Check that if host is set, we use its value as host"""
-        service = get_mock_service(
-            GithubService, {**SERVICE_CONFIG, 'host': 'github.example.com'}
-        )
+        service = make_service(host='github.example.com')
         assert "github.example.com" == service.config.host
 
     def test_keyring_service(self):
@@ -292,18 +292,16 @@ class TestGithubService:
         repository = GithubService.get_repository_from_issue(issue)
         assert "foo/bar" == repository
 
-    def test_body_no_limit(self):
-        service = get_mock_service(GithubService, SERVICE_CONFIG)
+    def test_body_no_limit(self, service):
         issue = dict(body="A very short issue body.  Fixes #42.")
         assert issue["body"] == service.body(issue)
 
-    def test_body_newline_style(self):
-        service = get_mock_service(GithubService, SERVICE_CONFIG)
+    def test_body_newline_style(self, service):
         issue = dict(body="An\r\nIssue\r\nWith\r\nNewlines")
         assert "An\nIssue\nWith\nNewlines" == service.body(issue)
 
-    def test_body_length_limit(self):
-        service = get_mock_service(GithubService, {**SERVICE_CONFIG, 'body_length': 5})
+    def test_body_length_limit(self, make_service):
+        service = make_service(body_length=5)
         issue = dict(body="A very short issue body.  Fixes #42.")
         assert issue["body"][:5] == service.body(issue)
 

--- a/tests/services/test_github.py
+++ b/tests/services/test_github.py
@@ -85,9 +85,7 @@ class TestGithubIssue:
 
     def test_to_taskwarrior(self):
         service = get_mock_service(
-            GithubService,
-            self.SERVICE_CONFIG,
-            config_overrides={'import_labels_as_tags': True},
+            GithubService, {**self.SERVICE_CONFIG, 'import_labels_as_tags': True}
         )
         issue = service.get_issue_for_record(ARBITRARY_ISSUE, ARBITRARY_EXTRA)
 
@@ -247,8 +245,7 @@ class TestGithubService:
         service = get_mock_service(GithubService, self.SERVICE_CONFIG)
         service = get_mock_service(
             GithubService,
-            self.SERVICE_CONFIG,
-            config_overrides={'token': '@oracle:eval:echo 1234567890ABCDEF'},
+            {**self.SERVICE_CONFIG, 'token': '@oracle:eval:echo 1234567890ABCDEF'},
         )
         assert (
             service.client.session.headers['Authorization'] == "token 1234567890ABCDEF"
@@ -262,9 +259,7 @@ class TestGithubService:
     def test_overwrite_host(self):
         """Check that if host is set, we use its value as host"""
         service = get_mock_service(
-            GithubService,
-            self.SERVICE_CONFIG,
-            config_overrides={'host': 'github.example.com'},
+            GithubService, {**self.SERVICE_CONFIG, 'host': 'github.example.com'}
         )
         assert "github.example.com" == service.config.host
 
@@ -309,7 +304,7 @@ class TestGithubService:
 
     def test_body_length_limit(self):
         service = get_mock_service(
-            GithubService, self.SERVICE_CONFIG, config_overrides={'body_length': 5}
+            GithubService, {**self.SERVICE_CONFIG, 'body_length': 5}
         )
         issue = dict(body="A very short issue body.  Fixes #42.")
         assert issue["body"][:5] == service.body(issue)

--- a/tests/services/test_github.py
+++ b/tests/services/test_github.py
@@ -1,11 +1,13 @@
 from datetime import datetime, timedelta, timezone
 
+import pytest
 import responses
 
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.github import GithubClient, GithubConfig, GithubService
 
-from .base import ConfigTest, ServiceIssueTest, ServiceTest
+from ..base import validate
+from .base import get_mock_service
 
 ARBITRARY_CREATED = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(
     microsecond=0
@@ -40,7 +42,7 @@ ARBITRARY_EXTRA = {
 IGNORABLE = {'user': {'login': 'cibot'}, 'body': 'Ignore this comment.'}
 
 
-class TestGithubIssue(ServiceIssueTest):
+class TestGithubIssue:
     SERVICE_CONFIG = {
         'service': 'github',
         'login': 'arbitrary_login',
@@ -50,7 +52,7 @@ class TestGithubIssue(ServiceIssueTest):
     }
 
     def test_draft(self):
-        service = self.get_mock_service(GithubService)
+        service = get_mock_service(GithubService, self.SERVICE_CONFIG)
         draft = dict(ARBITRARY_ISSUE)
         draft['draft'] = True
         issue = service.get_issue_for_record(draft, ARBITRARY_EXTRA)
@@ -82,8 +84,10 @@ class TestGithubIssue(ServiceIssueTest):
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     def test_to_taskwarrior(self):
-        service = self.get_mock_service(
-            GithubService, config_overrides={'import_labels_as_tags': True}
+        service = get_mock_service(
+            GithubService,
+            self.SERVICE_CONFIG,
+            config_overrides={'import_labels_as_tags': True},
         )
         issue = service.get_issue_for_record(ARBITRARY_ISSUE, ARBITRARY_EXTRA)
 
@@ -142,7 +146,7 @@ class TestGithubIssue(ServiceIssueTest):
             ],
         )  # second comment should be ignored and still pass
 
-        service = self.get_mock_service(GithubService)
+        service = get_mock_service(GithubService, self.SERVICE_CONFIG)
         issue = next(service.issues())
 
         expected = {
@@ -172,7 +176,7 @@ class TestGithubIssue(ServiceIssueTest):
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
 
-class TestGithubIssueQuery(ServiceIssueTest):
+class TestGithubIssueQuery:
     SERVICE_CONFIG = {
         'service': 'github',
         'login': 'arbitrary_login',
@@ -183,15 +187,15 @@ class TestGithubIssueQuery(ServiceIssueTest):
         'include_user_issues': 'False',
     }
 
-    def setUp(self):
-        super().setUp()
-        self.service = self.get_mock_service(GithubService)
+    @pytest.fixture
+    def service(self):
+        return get_mock_service(GithubService, self.SERVICE_CONFIG)
 
     def test_to_taskwarrior(self):
         pass
 
     @responses.activate
-    def test_issues(self):
+    def test_issues(self, service):
         responses.get(
             'https://api.github.com/search/issues?q=is%3Aopen+reviewer%3Aoctocat&per_page=100',
             json={'items': [ARBITRARY_ISSUE]},
@@ -202,7 +206,7 @@ class TestGithubIssueQuery(ServiceIssueTest):
             json=[{'user': {'login': 'arbitrary_login'}, 'body': 'Arbitrary comment.'}],
         )
 
-        issue = list(self.service.issues())[0]
+        issue = list(service.issues())[0]
 
         expected = {
             'annotations': ['@arbitrary_login - Arbitrary comment.'],
@@ -231,7 +235,7 @@ class TestGithubIssueQuery(ServiceIssueTest):
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
 
-class TestGithubService(ServiceTest):
+class TestGithubService:
     SERVICE_CONFIG = {
         'service': 'github',
         'login': 'tintin',
@@ -240,9 +244,10 @@ class TestGithubService(ServiceTest):
     }
 
     def test_token_authorization_header(self):
-        service = self.get_mock_service(GithubService)
-        service = self.get_mock_service(
+        service = get_mock_service(GithubService, self.SERVICE_CONFIG)
+        service = get_mock_service(
             GithubService,
+            self.SERVICE_CONFIG,
             config_overrides={'token': '@oracle:eval:echo 1234567890ABCDEF'},
         )
         assert (
@@ -251,13 +256,15 @@ class TestGithubService(ServiceTest):
 
     def test_default_host(self):
         """Check that if host is not set, we default to github.com"""
-        service = self.get_mock_service(GithubService)
+        service = get_mock_service(GithubService, self.SERVICE_CONFIG)
         assert "github.com" == service.config.host
 
     def test_overwrite_host(self):
         """Check that if host is set, we use its value as host"""
-        service = self.get_mock_service(
-            GithubService, config_overrides={'host': 'github.example.com'}
+        service = get_mock_service(
+            GithubService,
+            self.SERVICE_CONFIG,
+            config_overrides={'host': 'github.example.com'},
         )
         assert "github.example.com" == service.config.host
 
@@ -291,70 +298,74 @@ class TestGithubService(ServiceTest):
         assert "foo/bar" == repository
 
     def test_body_no_limit(self):
-        service = self.get_mock_service(GithubService)
+        service = get_mock_service(GithubService, self.SERVICE_CONFIG)
         issue = dict(body="A very short issue body.  Fixes #42.")
         assert issue["body"] == service.body(issue)
 
     def test_body_newline_style(self):
-        service = self.get_mock_service(GithubService)
+        service = get_mock_service(GithubService, self.SERVICE_CONFIG)
         issue = dict(body="An\r\nIssue\r\nWith\r\nNewlines")
         assert "An\nIssue\nWith\nNewlines" == service.body(issue)
 
     def test_body_length_limit(self):
-        service = self.get_mock_service(
-            GithubService, config_overrides={'body_length': 5}
+        service = get_mock_service(
+            GithubService, self.SERVICE_CONFIG, config_overrides={'body_length': 5}
         )
         issue = dict(body="A very short issue body.  Fixes #42.")
         assert issue["body"][:5] == service.body(issue)
 
 
-class TestGithubValidation(ConfigTest):
+class TestGithubValidation:
     SERVICE_CONFIG = {'service': 'github', 'login': 'tintin', 'token': 't0ps3cr3t'}
 
-    def setUp(self):
-        super().setUp()
-        self.config = {
+    @pytest.fixture
+    def config(self):
+        return {
             'general': {'targets': ['myservice']},
             'myservice': {**self.SERVICE_CONFIG, 'username': 'milou'},
         }
 
-    def test_require_username_or_query(self):
-        self.config['myservice']['include_user_repos'] = 'false'
-        self.config['myservice'].pop('username')
-        self.assertValidationError('section requires one of')
+    def test_require_username_or_query(self, config, assert_validation_error):
+        config['myservice']['include_user_repos'] = 'false'
+        config['myservice'].pop('username')
+        assert_validation_error(config, 'section requires one of')
 
-    def test_require_username_or_query_with_query(self):
-        self.config['myservice']['include_user_repos'] = 'false'
-        self.config['myservice'].pop('username')
-        self.config['myservice']['query'] = 'is:open reviewer:octocat'
-        self.validate()
+    def test_require_username_or_query_with_query(self, config):
+        config['myservice']['include_user_repos'] = 'false'
+        config['myservice'].pop('username')
+        config['myservice']['query'] = 'is:open reviewer:octocat'
+        validate(config)
 
-    def test_require_username_if_include_user_repos(self):
-        self.config['myservice'].pop('username')
-        self.config['myservice']['query'] = 'is:open'
-        self.assertValidationError('username required when include_user_repos is True')
+    def test_require_username_if_include_user_repos(
+        self, config, assert_validation_error
+    ):
+        config['myservice'].pop('username')
+        config['myservice']['query'] = 'is:open'
+        assert_validation_error(
+            config, 'username required when include_user_repos is True'
+        )
 
-    def test_require_username_if_include_user_repos_disabled(self):
-        self.config['myservice'].pop('username')
-        self.config['myservice']['query'] = 'is:open'
-        self.config['myservice']['include_user_repos'] = 'false'
-        self.validate()
+    def test_require_username_if_include_user_repos_disabled(self, config):
+        config['myservice'].pop('username')
+        config['myservice']['query'] = 'is:open'
+        config['myservice']['include_user_repos'] = 'false'
+        validate(config)
 
-    def test_issue_urls_consistent_with_host(self):
-        self.config['myservice']['issue_urls'] = (
+    def test_issue_urls_consistent_with_host(self, config, assert_validation_error):
+        config['myservice']['issue_urls'] = (
             'https://github.example.com/foo/bar/issues/1'
         )
-        self.assertValidationError('inconsistent with host')
+        assert_validation_error(config, 'inconsistent with host')
 
-    def test_issue_urls_invalid_path(self):
-        self.config['myservice']['issue_urls'] = 'https://github.com/foo/bar/invalid/1'
-        self.assertValidationError('is not a valid issue path')
+    def test_issue_urls_invalid_path(self, config, assert_validation_error):
+        config['myservice']['issue_urls'] = 'https://github.com/foo/bar/invalid/1'
+        assert_validation_error(config, 'is not a valid issue path')
 
-    def test_issue_urls_valid(self):
-        self.config['myservice']['issue_urls'] = (
+    def test_issue_urls_valid(self, config):
+        config['myservice']['issue_urls'] = (
             'https://github.com/foo/bar/issues/1, https://github.com/foo/bar/pull/2'
         )
-        self.validate()
+        validate(config)
 
 
 class TestGithubClient:

--- a/tests/services/test_gitlab.py
+++ b/tests/services/test_gitlab.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime, timedelta, timezone
-from unittest import TestCase
+from types import SimpleNamespace
 
 import pytest
 import responses
@@ -7,145 +7,95 @@ import responses
 from bugwarrior.collect import TaskConstructor, get_service_instances
 from bugwarrior.services.gitlab import GitlabClient, GitlabService
 
-from .base import ConfigTest, ServiceIssueTest
+from ..base import validate
+from .base import get_mock_service
 
 
-class TestData:
-    def __init__(self):
-        self.arbitrary_created = (
-            datetime.now(timezone.utc) - timedelta(hours=1)
-        ).replace(microsecond=0)
-        self.arbitrary_updated = datetime.now(timezone.utc).replace(microsecond=0)
-        self.arbitrary_duedate = datetime.combine(
-            date.today(), datetime.min.time(), tzinfo=timezone.utc
-        )
-        self.arbitrary_issue = {
-            "id": 42,
-            "iid": 3,
-            "project_id": 8,
-            "title": "Add user settings",
+@pytest.fixture
+def data():
+    arbitrary_created = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(
+        microsecond=0
+    )
+    arbitrary_updated = datetime.now(timezone.utc).replace(microsecond=0)
+    arbitrary_duedate = datetime.combine(
+        date.today(), datetime.min.time(), tzinfo=timezone.utc
+    )
+    arbitrary_issue = {
+        "id": 42,
+        "iid": 3,
+        "project_id": 8,
+        "title": "Add user settings",
+        "description": "",
+        "labels": ["feature"],
+        "milestone": {
+            "id": 1,
+            "title": "v1.0",
             "description": "",
-            "labels": ["feature"],
-            "milestone": {
-                "id": 1,
-                "title": "v1.0",
-                "description": "",
-                "due_date": self.arbitrary_duedate.date().isoformat(),
-                "state": "closed",
-                "updated_at": "2012-07-04T13:42:48Z",
-                "created_at": "2012-07-04T13:42:48Z",
-            },
-            "assignee": {
+            "due_date": arbitrary_duedate.date().isoformat(),
+            "state": "closed",
+            "updated_at": "2012-07-04T13:42:48Z",
+            "created_at": "2012-07-04T13:42:48Z",
+        },
+        "assignee": {
+            "id": 2,
+            "username": "jack_smith",
+            "email": "jack@example.com",
+            "name": "Jack Smith",
+            "state": "active",
+            "created_at": "2012-05-23T08:01:01Z",
+        },
+        'assignees': [
+            {
                 "id": 2,
                 "username": "jack_smith",
                 "email": "jack@example.com",
                 "name": "Jack Smith",
                 "state": "active",
                 "created_at": "2012-05-23T08:01:01Z",
-            },
-            'assignees': [
-                {
-                    "id": 2,
-                    "username": "jack_smith",
-                    "email": "jack@example.com",
-                    "name": "Jack Smith",
-                    "state": "active",
-                    "created_at": "2012-05-23T08:01:01Z",
-                }
-            ],
-            "author": {
-                "id": 1,
-                "username": "john_smith",
-                "email": "john@example.com",
-                "name": "John Smith",
-                "state": "active",
-                "created_at": "2012-05-23T08:00:58Z",
-            },
-            "state": "opened",
-            "updated_at": self.arbitrary_updated.isoformat(),
-            "created_at": self.arbitrary_created.isoformat(),
-            "weight": 3,
-            "work_in_progress": True,
-        }
-        self.arbitrary_extra = {
-            'issue_url': 'https://my-git.org/arbitrary_username/project/issues/3',
-            'project': 'project',
-            'namespace': 'arbitrary_namespace',
-            'type': 'issue',
-            'annotations': [],
-            'description': '',
-        }
-        self.arbitrary_todo = {
-            "id": 42,
-            "project": {
-                "id": 2,
-                "name": "project",
-                "name_with_namespace": "arbitrary_namespace / project",
-                "path": "project",
-                "path_with_namespace": "arbitrary_namespace/project",
-            },
-            "author": {
-                "id": 1,
-                "username": "john_smith",
-                "email": "john@example.com",
-                "name": "John Smith",
-                "state": "active",
-                "created_at": "2012-05-23T08:00:58Z",
-            },
-            "action_name": "marked",
-            "target_type": "Issue",
-            "target": {
-                "id": 42,
-                "iid": 3,
-                "project_id": 8,
-                "title": "Add user settings",
-                "description": "",
-                "labels": ["feature"],
-                "milestone": {
-                    "id": 1,
-                    "title": "v1.0",
-                    "description": "",
-                    "due_date": self.arbitrary_duedate.date().isoformat(),
-                    "state": "closed",
-                    "updated_at": "2012-07-04T13:42:48Z",
-                    "created_at": "2012-07-04T13:42:48Z",
-                },
-                "assignee": {
-                    "id": 2,
-                    "username": "jack_smith",
-                    "email": "jack@example.com",
-                    "name": "Jack Smith",
-                    "state": "active",
-                    "created_at": "2012-05-23T08:01:01Z",
-                },
-                "author": {
-                    "id": 1,
-                    "username": "john_smith",
-                    "email": "john@example.com",
-                    "name": "John Smith",
-                    "state": "active",
-                    "created_at": "2012-05-23T08:00:58Z",
-                },
-                "state": "opened",
-                "updated_at": self.arbitrary_updated.isoformat(),
-                "created_at": self.arbitrary_created.isoformat(),
-                "weight": 3,
-                "work_in_progress": True,
-            },
-            "target_url": "https://my-git.org/arbitrary_username/project/issues/3",
-            "body": "Add user settings",
-            "state": "pending",
-            "created_at": self.arbitrary_created.isoformat(),
-            "updated_at": self.arbitrary_updated.isoformat(),
-        }
-        self.arbitrary_todo_extra = {
-            'issue_url': 'https://my-git.org/arbitrary_username/project/issues/3',
-            'project': 'project',
-            'namespace': 'arbitrary_namespace',
-            'type': 'todo',
-            'annotations': [],
-        }
-        self.arbitrary_mr = {
+            }
+        ],
+        "author": {
+            "id": 1,
+            "username": "john_smith",
+            "email": "john@example.com",
+            "name": "John Smith",
+            "state": "active",
+            "created_at": "2012-05-23T08:00:58Z",
+        },
+        "state": "opened",
+        "updated_at": arbitrary_updated.isoformat(),
+        "created_at": arbitrary_created.isoformat(),
+        "weight": 3,
+        "work_in_progress": True,
+    }
+    arbitrary_extra = {
+        'issue_url': 'https://my-git.org/arbitrary_username/project/issues/3',
+        'project': 'project',
+        'namespace': 'arbitrary_namespace',
+        'type': 'issue',
+        'annotations': [],
+        'description': '',
+    }
+    arbitrary_todo = {
+        "id": 42,
+        "project": {
+            "id": 2,
+            "name": "project",
+            "name_with_namespace": "arbitrary_namespace / project",
+            "path": "project",
+            "path_with_namespace": "arbitrary_namespace/project",
+        },
+        "author": {
+            "id": 1,
+            "username": "john_smith",
+            "email": "john@example.com",
+            "name": "John Smith",
+            "state": "active",
+            "created_at": "2012-05-23T08:00:58Z",
+        },
+        "action_name": "marked",
+        "target_type": "Issue",
+        "target": {
             "id": 42,
             "iid": 3,
             "project_id": 8,
@@ -156,7 +106,7 @@ class TestData:
                 "id": 1,
                 "title": "v1.0",
                 "description": "",
-                "due_date": self.arbitrary_duedate.date().isoformat(),
+                "due_date": arbitrary_duedate.date().isoformat(),
                 "state": "closed",
                 "updated_at": "2012-07-04T13:42:48Z",
                 "created_at": "2012-07-04T13:42:48Z",
@@ -178,128 +128,191 @@ class TestData:
                 "created_at": "2012-05-23T08:00:58Z",
             },
             "state": "opened",
-            "updated_at": self.arbitrary_updated.isoformat(),
-            "created_at": self.arbitrary_created.isoformat(),
+            "updated_at": arbitrary_updated.isoformat(),
+            "created_at": arbitrary_created.isoformat(),
             "weight": 3,
             "work_in_progress": True,
-        }
-        self.arbitrary_mr_extra = {
-            'issue_url': 'https://my-git.org/arbitrary_username/project/merge_requests/3',
-            'project': 'project',
-            'namespace': 'arbitrary_namespace',
-            'type': 'merge_request',
-            'annotations': [],
+        },
+        "target_url": "https://my-git.org/arbitrary_username/project/issues/3",
+        "body": "Add user settings",
+        "state": "pending",
+        "created_at": arbitrary_created.isoformat(),
+        "updated_at": arbitrary_updated.isoformat(),
+    }
+    arbitrary_todo_extra = {
+        'issue_url': 'https://my-git.org/arbitrary_username/project/issues/3',
+        'project': 'project',
+        'namespace': 'arbitrary_namespace',
+        'type': 'todo',
+        'annotations': [],
+    }
+    arbitrary_mr = {
+        "id": 42,
+        "iid": 3,
+        "project_id": 8,
+        "title": "Add user settings",
+        "description": "",
+        "labels": ["feature"],
+        "milestone": {
+            "id": 1,
+            "title": "v1.0",
             "description": "",
-        }
-        self.arbitrary_project = {
-            "id": 8,
-            "description": "This is the description of an arbitrary project",
-            "name": "Arbitrary Project",
-            "name_with_namespace": "Arbitrary Namespace / Arbitrary Project",
-            "path": "arbitrary_project",
-            "path_with_namespace": "arbitrary_namespace/arbitrary_project",
-            "created_at": self.arbitrary_created.isoformat(),
-            "default_branch": "main",
-            "tag_list": [],
-            "topics": [],
-            "ssh_url_to_repo": "git@my-git.org:arbitrary_namespace/arbitrary_project.git",
-            "http_url_to_repo": "https://my-git.org/arbitrary_namespace/arbitrary_project.git",
-            "web_url": "https://my-git.org/arbitrary_namespace/arbitrary_project",
-            "readme_url": "https://my-git.org/arbitrary_namespace/arbitrary_project/-/blob/main/README.md",
+            "due_date": arbitrary_duedate.date().isoformat(),
+            "state": "closed",
+            "updated_at": "2012-07-04T13:42:48Z",
+            "created_at": "2012-07-04T13:42:48Z",
+        },
+        "assignee": {
+            "id": 2,
+            "username": "jack_smith",
+            "email": "jack@example.com",
+            "name": "Jack Smith",
+            "state": "active",
+            "created_at": "2012-05-23T08:01:01Z",
+        },
+        "author": {
+            "id": 1,
+            "username": "john_smith",
+            "email": "john@example.com",
+            "name": "John Smith",
+            "state": "active",
+            "created_at": "2012-05-23T08:00:58Z",
+        },
+        "state": "opened",
+        "updated_at": arbitrary_updated.isoformat(),
+        "created_at": arbitrary_created.isoformat(),
+        "weight": 3,
+        "work_in_progress": True,
+    }
+    arbitrary_mr_extra = {
+        'issue_url': 'https://my-git.org/arbitrary_username/project/merge_requests/3',
+        'project': 'project',
+        'namespace': 'arbitrary_namespace',
+        'type': 'merge_request',
+        'annotations': [],
+        "description": "",
+    }
+    arbitrary_project = {
+        "id": 8,
+        "description": "This is the description of an arbitrary project",
+        "name": "Arbitrary Project",
+        "name_with_namespace": "Arbitrary Namespace / Arbitrary Project",
+        "path": "arbitrary_project",
+        "path_with_namespace": "arbitrary_namespace/arbitrary_project",
+        "created_at": arbitrary_created.isoformat(),
+        "default_branch": "main",
+        "tag_list": [],
+        "topics": [],
+        "ssh_url_to_repo": "git@my-git.org:arbitrary_namespace/arbitrary_project.git",
+        "http_url_to_repo": "https://my-git.org/arbitrary_namespace/arbitrary_project.git",
+        "web_url": "https://my-git.org/arbitrary_namespace/arbitrary_project",
+        "readme_url": "https://my-git.org/arbitrary_namespace/arbitrary_project/-/blob/main/README.md",
+        "avatar_url": None,
+        "forks_count": 7,
+        "star_count": 11,
+        "last_activity_at": arbitrary_updated.isoformat(),
+        "namespace": {
+            "id": 2,
+            "name": "Arbitrary Namespace",
+            "path": "arbitrary_namespace",
+            "kind": "group",
+            "full_path": "arbitrary_namespace",
+            "parent_id": None,
             "avatar_url": None,
-            "forks_count": 7,
-            "star_count": 11,
-            "last_activity_at": self.arbitrary_updated.isoformat(),
-            "namespace": {
-                "id": 2,
-                "name": "Arbitrary Namespace",
-                "path": "arbitrary_namespace",
-                "kind": "group",
-                "full_path": "arbitrary_namespace",
-                "parent_id": None,
-                "avatar_url": None,
-                "web_url": "https://my-git.org/groups/arbitrary_namespace",
-            },
-            "container_registry_image_prefix": (
-                "my-git.org:5555/arbitrary_namespace/arbitrary_project"
-            ),
-            "_links": {
-                "self": "https://my-git.org/api/v4/projects/8",
-                "issues": "https://my-git.org/api/v4/projects/8/issues",
-                "merge_requests": "https://my-git.org/api/v4/projects/8/merge_requests",
-                "repo_branches": "https://my-git.org/api/v4/projects/8/repository/branches",
-                "labels": "https://my-git.org/api/v4/projects/8/labels",
-                "events": "https://my-git.org/api/v4/projects/8/events",
-                "members": "https://my-git.org/api/v4/projects/8/members",
-            },
-            "packages_enabled": None,
-            "empty_repo": False,
-            "archived": False,
-            "visibility": "private",
-            "resolve_outdated_diff_discussions": False,
-            "issues_enabled": True,
-            "merge_requests_enabled": True,
-            "wiki_enabled": True,
-            "jobs_enabled": True,
-            "snippets_enabled": False,
-            "container_registry_enabled": True,
-            "service_desk_enabled": False,
-            "service_desk_address": None,
-            "can_create_merge_request_in": True,
-            "issues_access_level": "enabled",
-            "repository_access_level": "enabled",
-            "merge_requests_access_level": "enabled",
-            "forking_access_level": "enabled",
-            "wiki_access_level": "enabled",
-            "builds_access_level": "private",
-            "snippets_access_level": "disabled",
-            "pages_access_level": "public",
-            "operations_access_level": "enabled",
-            "analytics_access_level": "enabled",
-            "container_registry_access_level": "enabled",
-            "emails_disabled": False,
-            "shared_runners_enabled": True,
-            "lfs_enabled": True,
-            "creator_id": 22,
-            "import_status": "finished",
-            "import_error": None,
-            "open_issues_count": 22,
-            "runners_token": None,
-            "ci_default_git_depth": None,
-            "ci_forward_deployment_enabled": False,
-            "ci_job_token_scope_enabled": False,
-            "public_jobs": True,
-            "build_git_strategy": "fetch",
-            "build_timeout": 3600,
-            "auto_cancel_pending_pipelines": "enabled",
-            "build_coverage_regex": "^TOTAL.+?()$",
-            "ci_config_path": "",
-            "shared_with_groups": [],
-            "only_allow_merge_if_pipeline_succeeds": True,
-            "allow_merge_on_skipped_pipeline": False,
-            "restrict_user_defined_variables": False,
-            "request_access_enabled": True,
-            "only_allow_merge_if_all_discussions_are_resolved": True,
-            "remove_source_branch_after_merge": True,
-            "printing_merge_request_link_enabled": True,
-            "merge_method": "ff",
-            "squash_option": "default_off",
-            "suggestion_commit_message": "",
-            "merge_commit_template": None,
-            "squash_commit_template": None,
-            "auto_devops_enabled": False,
-            "auto_devops_deploy_strategy": "continuous",
-            "autoclose_referenced_issues": True,
-            "repository_storage": "default",
-            "keep_latest_artifact": False,
-            "permissions": {"project_access": None, "group_access": None},
-        }
+            "web_url": "https://my-git.org/groups/arbitrary_namespace",
+        },
+        "container_registry_image_prefix": (
+            "my-git.org:5555/arbitrary_namespace/arbitrary_project"
+        ),
+        "_links": {
+            "self": "https://my-git.org/api/v4/projects/8",
+            "issues": "https://my-git.org/api/v4/projects/8/issues",
+            "merge_requests": "https://my-git.org/api/v4/projects/8/merge_requests",
+            "repo_branches": "https://my-git.org/api/v4/projects/8/repository/branches",
+            "labels": "https://my-git.org/api/v4/projects/8/labels",
+            "events": "https://my-git.org/api/v4/projects/8/events",
+            "members": "https://my-git.org/api/v4/projects/8/members",
+        },
+        "packages_enabled": None,
+        "empty_repo": False,
+        "archived": False,
+        "visibility": "private",
+        "resolve_outdated_diff_discussions": False,
+        "issues_enabled": True,
+        "merge_requests_enabled": True,
+        "wiki_enabled": True,
+        "jobs_enabled": True,
+        "snippets_enabled": False,
+        "container_registry_enabled": True,
+        "service_desk_enabled": False,
+        "service_desk_address": None,
+        "can_create_merge_request_in": True,
+        "issues_access_level": "enabled",
+        "repository_access_level": "enabled",
+        "merge_requests_access_level": "enabled",
+        "forking_access_level": "enabled",
+        "wiki_access_level": "enabled",
+        "builds_access_level": "private",
+        "snippets_access_level": "disabled",
+        "pages_access_level": "public",
+        "operations_access_level": "enabled",
+        "analytics_access_level": "enabled",
+        "container_registry_access_level": "enabled",
+        "emails_disabled": False,
+        "shared_runners_enabled": True,
+        "lfs_enabled": True,
+        "creator_id": 22,
+        "import_status": "finished",
+        "import_error": None,
+        "open_issues_count": 22,
+        "runners_token": None,
+        "ci_default_git_depth": None,
+        "ci_forward_deployment_enabled": False,
+        "ci_job_token_scope_enabled": False,
+        "public_jobs": True,
+        "build_git_strategy": "fetch",
+        "build_timeout": 3600,
+        "auto_cancel_pending_pipelines": "enabled",
+        "build_coverage_regex": "^TOTAL.+?()$",
+        "ci_config_path": "",
+        "shared_with_groups": [],
+        "only_allow_merge_if_pipeline_succeeds": True,
+        "allow_merge_on_skipped_pipeline": False,
+        "restrict_user_defined_variables": False,
+        "request_access_enabled": True,
+        "only_allow_merge_if_all_discussions_are_resolved": True,
+        "remove_source_branch_after_merge": True,
+        "printing_merge_request_link_enabled": True,
+        "merge_method": "ff",
+        "squash_option": "default_off",
+        "suggestion_commit_message": "",
+        "merge_commit_template": None,
+        "squash_commit_template": None,
+        "auto_devops_enabled": False,
+        "auto_devops_deploy_strategy": "continuous",
+        "autoclose_referenced_issues": True,
+        "repository_storage": "default",
+        "keep_latest_artifact": False,
+        "permissions": {"project_access": None, "group_access": None},
+    }
+    return SimpleNamespace(
+        arbitrary_created=arbitrary_created,
+        arbitrary_updated=arbitrary_updated,
+        arbitrary_duedate=arbitrary_duedate,
+        arbitrary_issue=arbitrary_issue,
+        arbitrary_extra=arbitrary_extra,
+        arbitrary_todo=arbitrary_todo,
+        arbitrary_todo_extra=arbitrary_todo_extra,
+        arbitrary_mr=arbitrary_mr,
+        arbitrary_mr_extra=arbitrary_mr_extra,
+        arbitrary_project=arbitrary_project,
+    )
 
 
-class TestGitlabClient(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.client = GitlabClient(
+class TestGitlabClient:
+    @pytest.fixture
+    def client(self):
+        return GitlabClient(
             'my-git.org',
             'XXXXXX',
             only_if_assigned='',
@@ -307,7 +320,6 @@ class TestGitlabClient(TestCase):
             use_https=True,
             verify_ssl=True,
         )
-        self.data = TestData()
 
     def test_init(self):
         http_client = GitlabClient(
@@ -352,23 +364,23 @@ class TestGitlabClient(TestCase):
         assert expected_base_url == http_client._base_url()
 
     @responses.activate
-    def test_get_repo(self):
+    def test_get_repo(self, client, data):
         responses.get(
-            'https://my-git.org/api/v4/projects/8', json=self.data.arbitrary_project
+            'https://my-git.org/api/v4/projects/8', json=data.arbitrary_project
         )
-        result = self.client.get_repo_cached(repo_id=8)
-        assert result == self.data.arbitrary_project
+        result = client.get_repo_cached(repo_id=8)
+        assert result == data.arbitrary_project
 
     @responses.activate
-    def test_get_repos(self):
+    def test_get_repos(self, client, data):
         responses.get(
             'https://my-git.org/api/v4/projects?simple=True&archived=False&page=1&per_page=100',
-            json=[self.data.arbitrary_project],
+            json=[data.arbitrary_project],
         )
         responses.get(
             'https://my-git.org/api/v4/projects'
             + '?simple=True&archived=False&membership=True&page=1&per_page=100',
-            json=[self.data.arbitrary_project],
+            json=[data.arbitrary_project],
         )
         responses.get(
             'https://my-git.org/api/v4/projects'
@@ -378,11 +390,11 @@ class TestGitlabClient(TestCase):
         responses.get(
             'https://my-git.org/api/v4/projects/'
             + 'arbitrary_namespace%2Farbitrary_project?simple=true',
-            json=self.data.arbitrary_project,
+            json=data.arbitrary_project,
         )
         responses.get(
             'https://my-git.org/api/v4/projects/8?simple=true',
-            json=self.data.arbitrary_project,
+            json=data.arbitrary_project,
         )
         responses.get(
             'https://my-git.org/api/v4/projects/non_existing?simple=true', json=[]
@@ -390,7 +402,7 @@ class TestGitlabClient(TestCase):
         responses.get(
             'https://my-git.org/api/v4/projects'
             + '?simple=True&membership=True&owned=False&page=1&per_page=100',
-            json=[self.data.arbitrary_project],
+            json=[data.arbitrary_project],
         )
         responses.get(
             'https://my-git.org/api/v4/projects'
@@ -398,111 +410,108 @@ class TestGitlabClient(TestCase):
             json=[],
         )
 
-        result = self.client.get_repos(
+        result = client.get_repos(
             include_repos=[], only_membership=False, only_owned=False
         )
-        assert result == [self.data.arbitrary_project]
+        assert result == [data.arbitrary_project]
 
-        result = self.client.get_repos(
+        result = client.get_repos(
             include_repos=[], only_membership=True, only_owned=False
         )
-        assert result == [self.data.arbitrary_project]
+        assert result == [data.arbitrary_project]
 
-        result = self.client.get_repos(
+        result = client.get_repos(
             include_repos=[], only_membership=True, only_owned=True
         )
         assert result == []
 
-        result = self.client.get_repos(
+        result = client.get_repos(
             include_repos=['arbitrary_namespace/arbitrary_project'],
             only_membership=False,
             only_owned=False,
         )
-        assert result == [self.data.arbitrary_project]
+        assert result == [data.arbitrary_project]
 
-        result = self.client.get_repos(
+        result = client.get_repos(
             include_repos=['id:8'], only_membership=False, only_owned=False
         )
-        assert result == [self.data.arbitrary_project]
+        assert result == [data.arbitrary_project]
 
-        result = self.client.get_repos(
+        # A repo that cannot be fetched is skipped rather than included.
+        result = client.get_repos(
             include_repos=['non_existing'], only_membership=False, only_owned=False
         )
-        pytest.raises(OSError)
+        assert result == []
 
     @responses.activate
-    def test_get_notes(self):
+    def test_get_notes(self, client, data):
         responses.get(
             'https://my-git.org/api/v4/projects/8/issues/3/notes?page=1&per_page=100',
             json=[{'author': {'username': 'john_smith'}, 'body': 'Some comment.'}],
         )
         expected = [{'author': {'username': 'john_smith'}, 'body': 'Some comment.'}]
-        result = self.client.get_notes(
-            self.data.arbitrary_issue['project_id'],
-            'issues',
-            self.data.arbitrary_issue['iid'],
+        result = client.get_notes(
+            data.arbitrary_issue['project_id'], 'issues', data.arbitrary_issue['iid']
         )
         assert result == expected
 
     @responses.activate
-    def test_get_repo_issues(self):
+    def test_get_repo_issues(self, client, data):
         responses.get(
             'https://my-git.org/api/v4/projects/8/issues?state=opened&page=1&per_page=100',
-            json=[self.data.arbitrary_issue],
+            json=[data.arbitrary_issue],
         )
-        assert self.client.get_repo_issues(self.data.arbitrary_issue['project_id']) == {
-            self.data.arbitrary_issue['id']: (
-                self.data.arbitrary_issue['project_id'],
-                self.data.arbitrary_issue,
+        assert client.get_repo_issues(data.arbitrary_issue['project_id']) == {
+            data.arbitrary_issue['id']: (
+                data.arbitrary_issue['project_id'],
+                data.arbitrary_issue,
             )
         }
 
     @responses.activate
-    def test_get_repo_merge_requests(self):
+    def test_get_repo_merge_requests(self, client, data):
         responses.get(
             'https://my-git.org/api/v4/projects/8/merge_requests?state=opened&page=1&per_page=100',
-            json=[self.data.arbitrary_mr],
+            json=[data.arbitrary_mr],
         )
-        assert self.client.get_repo_merge_requests(
-            self.data.arbitrary_issue['project_id']
-        ) == {
-            self.data.arbitrary_mr['id']: (
-                self.data.arbitrary_issue['project_id'],
-                self.data.arbitrary_mr,
+        assert client.get_repo_merge_requests(data.arbitrary_issue['project_id']) == {
+            data.arbitrary_mr['id']: (
+                data.arbitrary_issue['project_id'],
+                data.arbitrary_mr,
             )
         }
 
     @responses.activate
-    def test_get_issues_from_query(self):
+    def test_get_issues_from_query(self, client, data):
         responses.get(
             'https://my-git.org/api/v4/'
             + 'issues?assignee_id=2&state=opened&scope=all&page=1&per_page=100',
-            json=[self.data.arbitrary_issue],
+            json=[data.arbitrary_issue],
         )
-        assert self.client.get_issues_from_query(
+        assert client.get_issues_from_query(
             'issues?assignee_id=2&state=opened&scope=all'
         ) == {
-            self.data.arbitrary_issue['id']: (
-                self.data.arbitrary_issue['project_id'],
-                self.data.arbitrary_issue,
+            data.arbitrary_issue['id']: (
+                data.arbitrary_issue['project_id'],
+                data.arbitrary_issue,
             )
         }
 
     @responses.activate
-    def test_get_todos(self):
+    def test_get_todos(self, client, data):
         responses.get(
             'https://my-git.org/api/v4/todos?state=pending&page=1&per_page=100',
-            json=[self.data.arbitrary_todo],
+            json=[data.arbitrary_todo],
         )
-        assert self.client.get_todos('todos?state=pending') == [
-            (self.data.arbitrary_todo['project'], self.data.arbitrary_todo)
+        assert client.get_todos('todos?state=pending') == [
+            (data.arbitrary_todo['project'], data.arbitrary_todo)
         ]
 
 
-class TestGitlabService(ConfigTest):
-    def setUp(self):
-        super().setUp()
-        self.config = {
+class TestGitlabService:
+    @pytest.fixture
+    def config(self):
+        return {
             'general': {'targets': ['myservice']},
             'myservice': {
                 'service': 'gitlab',
@@ -514,135 +523,141 @@ class TestGitlabService(ConfigTest):
             },
         }
 
-    @property
-    def service(self):
-        conf = self.validate()
+    def get_service(self, config):
+        conf = validate(config)
         service = get_service_instances(conf)[0]
         service.gitlab_client.repo_cache = {
             1: {'id': 1, 'path_with_namespace': 'arbitrary_namespace/arbitrary_project'}
         }
         return service
 
-    def test_keyring_service_default_host(self):
-        conf = self.validate()
+    def test_keyring_service_default_host(self, config):
+        conf = validate(config)
         conf = conf.service_configs[0]
         assert conf.keyring_service == 'gitlab://foobar@gitlab.com'
 
-    def test_keyring_service_custom_host(self):
-        self.config['myservice']['host'] = 'my-git.org'
-        conf = self.validate()
+    def test_keyring_service_custom_host(self, config):
+        config['myservice']['host'] = 'my-git.org'
+        conf = validate(config)
         conf = conf.service_configs[0]
         assert conf.keyring_service == 'gitlab://foobar@my-git.org'
 
-    def test_filter_gitlab_dot_com(self):
-        self.config['myservice'].update({'host': 'gitlab.com', 'owned': 'false'})
-        self.assertValidationError(
+    def test_filter_gitlab_dot_com(self, config, assert_validation_error):
+        config['myservice'].update({'host': 'gitlab.com', 'owned': 'false'})
+        assert_validation_error(
+            config,
             'You must set at least one of the '
             'configuration options to filter '
-            'repositories'
+            'repositories',
         )
 
-        self.config['myservice'].update(
+        config['myservice'].update(
             {
                 'issue_query': 'arbitrary_query',
                 'merge_request_query': 'arbitrary_query',
                 'todo_query': 'arbitrary_query',
             }
         )
-        self.validate()
+        validate(config)
 
-        self.config['myservice']['issue_query'] = ''
-        self.assertValidationError(
+        config['myservice']['issue_query'] = ''
+        assert_validation_error(
+            config,
             'You must set at least one of the '
             'configuration options to filter '
-            'repositories'
+            'repositories',
         )
 
-    def test_add_default_namespace_to_included_repos(self):
-        self.config['myservice']['include_repos'] = 'baz, banana/tree'
-        assert self.service.config.include_repos == ['foobar/baz', 'banana/tree']
+    def test_add_default_namespace_to_included_repos(self, config):
+        config['myservice']['include_repos'] = 'baz, banana/tree'
+        service = self.get_service(config)
+        assert service.config.include_repos == ['foobar/baz', 'banana/tree']
 
-    def test_add_default_namespace_to_excluded_repos(self):
-        self.config['myservice']['exclude_repos'] = 'baz, banana/tree'
-        assert self.service.config.exclude_repos == ['foobar/baz', 'banana/tree']
+    def test_add_default_namespace_to_excluded_repos(self, config):
+        config['myservice']['exclude_repos'] = 'baz, banana/tree'
+        service = self.get_service(config)
+        assert service.config.exclude_repos == ['foobar/baz', 'banana/tree']
 
-    def test_filter_repos_default(self):
+    def test_filter_repos_default(self, config):
         repo = {'path_with_namespace': 'foobar/baz', 'id': 1234}
-        assert self.service.filter_repos(repo)
+        assert self.get_service(config).filter_repos(repo)
 
-    def test_filter_repos_exclude(self):
-        self.config['myservice']['exclude_repos'] = 'foobar/baz'
+    def test_filter_repos_exclude(self, config):
+        config['myservice']['exclude_repos'] = 'foobar/baz'
         repo = {'path_with_namespace': 'foobar/baz', 'id': 1234}
-        assert not self.service.filter_repos(repo)
+        assert not self.get_service(config).filter_repos(repo)
 
-    def test_filter_repos_exclude_id(self):
-        self.config['myservice']['exclude_repos'] = 'id:1234'
+    def test_filter_repos_exclude_id(self, config):
+        config['myservice']['exclude_repos'] = 'id:1234'
         repo = {'path_with_namespace': 'foobar/baz', 'id': 1234}
-        assert not self.service.filter_repos(repo)
+        assert not self.get_service(config).filter_repos(repo)
 
-    def test_filter_repos_include(self):
-        self.config['myservice']['include_repos'] = 'foobar/baz'
+    def test_filter_repos_include(self, config):
+        config['myservice']['include_repos'] = 'foobar/baz'
         repo = {'path_with_namespace': 'foobar/baz', 'id': 1234}
-        assert self.service.filter_repos(repo)
+        assert self.get_service(config).filter_repos(repo)
 
-    def test_filter_repos_include_id(self):
-        self.config['myservice']['include_repos'] = 'id:1234'
+    def test_filter_repos_include_id(self, config):
+        config['myservice']['include_repos'] = 'id:1234'
         repo = {'path_with_namespace': 'foobar/baz', 'id': 1234}
-        assert self.service.filter_repos(repo)
+        assert self.get_service(config).filter_repos(repo)
 
-    def test_include_only_if_assigned(self):
-        self.config['myservice']['only_if_assigned'] = 'jack_smith'
-        data = TestData()
-        assert self.service.include((1, data.arbitrary_issue))
-        self.config['myservice']['only_if_assigned'] = 'smack_jith'
-        assert not self.service.include((1, data.arbitrary_issue))
+    def test_include_only_if_assigned(self, config, data):
+        config['myservice']['only_if_assigned'] = 'jack_smith'
+        assert self.get_service(config).include((1, data.arbitrary_issue))
+        config['myservice']['only_if_assigned'] = 'smack_jith'
+        assert not self.get_service(config).include((1, data.arbitrary_issue))
 
-    def test_default_priorities(self):
-        self.config['myservice'].update(
+    def test_default_priorities(self, config):
+        config['myservice'].update(
             {
                 'default_issue_priority': 'L',
                 'default_mr_priority': 'M',
                 'default_todo_priority': 'H',
             }
         )
-        assert 'L' == self.service.config.default_issue_priority
-        assert 'M' == self.service.config.default_mr_priority
-        assert 'H' == self.service.config.default_todo_priority
+        service = self.get_service(config)
+        assert 'L' == service.config.default_issue_priority
+        assert 'M' == service.config.default_mr_priority
+        assert 'H' == service.config.default_todo_priority
 
-    def test_default_priorities_fallback(self):
-        self.config['myservice']['default_priority'] = 'H'
-        assert 'H' == self.service.config.default_issue_priority
-        assert 'H' == self.service.config.default_mr_priority
-        assert 'H' == self.service.config.default_todo_priority
+    def test_default_priorities_fallback(self, config):
+        config['myservice']['default_priority'] = 'H'
+        service = self.get_service(config)
+        assert 'H' == service.config.default_issue_priority
+        assert 'H' == service.config.default_mr_priority
+        assert 'H' == service.config.default_todo_priority
 
-    def test_body_zero_limit(self):
-        self.config['myservice']['body_length'] = 0
+    def test_body_zero_limit(self, config):
+        config['myservice']['body_length'] = 0
         issue = dict(description="A very short issue body.  Fixes #42.")
-        assert "" == self.service.description(issue)
+        assert "" == self.get_service(config).description(issue)
 
-    def test_body_short_limit(self):
+    def test_body_short_limit(self, config):
         size_limit = 5
-        self.config['myservice']['body_length'] = size_limit
+        config['myservice']['body_length'] = size_limit
         issue = dict(description="A very short issue body.  Fixes #42.")
-        assert issue["description"][:size_limit] == self.service.description(issue)
+        assert issue["description"][:size_limit] == self.get_service(
+            config
+        ).description(issue)
 
-    def test_body_no_limit(self):
+    def test_body_no_limit(self, config):
         issue = dict(description="A very short issue body.  Fixes #42.")
-        assert issue["description"] == self.service.description(issue)
+        assert issue["description"] == self.get_service(config).description(issue)
 
-    def test_undefined_owned_warning(self):
-        self.config['myservice'].pop('owned')
-        self.config['myservice']['membership'] = 'true'
-        self.validate()
-        assert len(self.caplog.records) == 1
+    def test_undefined_owned_warning(self, config, caplog):
+        config['myservice'].pop('owned')
+        config['myservice']['membership'] = 'true'
+        validate(config)
+        assert len(caplog.records) == 1
         assert (
             "WARNING: Gitlab's 'owned' configuration field should be set "
             "explicitly. In a future release, this will be an error."
-            in self.caplog.records[0].message
+            in caplog.records[0].message
         )
 
 
-class TestGitlabIssue(ServiceIssueTest):
+class TestGitlabIssue:
     SERVICE_CONFIG = {
         'service': 'gitlab',
         'host': 'my-git.org',
@@ -650,35 +665,31 @@ class TestGitlabIssue(ServiceIssueTest):
         'token': 'arbitrary_token',
     }
 
-    def setUp(self):
-        super().setUp()
-        self.service = self.get_mock_service(GitlabService)
+    @pytest.fixture
+    def service(self):
+        return get_mock_service(GitlabService, self.SERVICE_CONFIG)
 
-        self.data = TestData()
-
-    def test_to_taskwarrior(self):
-        issue = self.service.get_issue_for_record(
-            self.data.arbitrary_issue, self.data.arbitrary_extra
-        )
+    def test_to_taskwarrior(self, service, data):
+        issue = service.get_issue_for_record(data.arbitrary_issue, data.arbitrary_extra)
 
         expected_output = {
-            'project': self.data.arbitrary_extra['project'],
-            'priority': self.service.config.default_priority,
+            'project': data.arbitrary_extra['project'],
+            'priority': service.config.default_priority,
             'annotations': [],
             'tags': [],
-            'due': self.data.arbitrary_duedate.replace(microsecond=0),
-            'entry': self.data.arbitrary_created.replace(microsecond=0),
-            issue.URL: self.data.arbitrary_extra['issue_url'],
+            'due': data.arbitrary_duedate.replace(microsecond=0),
+            'entry': data.arbitrary_created.replace(microsecond=0),
+            issue.URL: data.arbitrary_extra['issue_url'],
             issue.REPO: 'project',
-            issue.STATE: self.data.arbitrary_issue['state'],
-            issue.TYPE: self.data.arbitrary_extra['type'],
-            issue.TITLE: self.data.arbitrary_issue['title'],
-            issue.NUMBER: str(self.data.arbitrary_issue['iid']),
-            issue.UPDATED_AT: self.data.arbitrary_updated.replace(microsecond=0),
-            issue.CREATED_AT: self.data.arbitrary_created.replace(microsecond=0),
-            issue.DUEDATE: self.data.arbitrary_duedate,
-            issue.DESCRIPTION: self.data.arbitrary_issue['description'],
-            issue.MILESTONE: self.data.arbitrary_issue['milestone']['title'],
+            issue.STATE: data.arbitrary_issue['state'],
+            issue.TYPE: data.arbitrary_extra['type'],
+            issue.TITLE: data.arbitrary_issue['title'],
+            issue.NUMBER: str(data.arbitrary_issue['iid']),
+            issue.UPDATED_AT: data.arbitrary_updated.replace(microsecond=0),
+            issue.CREATED_AT: data.arbitrary_created.replace(microsecond=0),
+            issue.DUEDATE: data.arbitrary_duedate,
+            issue.DESCRIPTION: data.arbitrary_issue['description'],
+            issue.MILESTONE: data.arbitrary_issue['milestone']['title'],
             issue.UPVOTES: 0,
             issue.DOWNVOTES: 0,
             issue.WORK_IN_PROGRESS: 1,
@@ -691,30 +702,30 @@ class TestGitlabIssue(ServiceIssueTest):
 
         assert actual_output == expected_output
 
-    def test_custom_issue_priority(self):
+    def test_custom_issue_priority(self, data):
         overrides = {'default_issue_priority': 'L'}
-        service = self.get_mock_service(GitlabService, config_overrides=overrides)
-        issue = service.get_issue_for_record(
-            self.data.arbitrary_issue, self.data.arbitrary_extra
+        service = get_mock_service(
+            GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
         )
+        issue = service.get_issue_for_record(data.arbitrary_issue, data.arbitrary_extra)
         expected_output = {
-            'project': self.data.arbitrary_extra['project'],
+            'project': data.arbitrary_extra['project'],
             'priority': 'L',
             'annotations': [],
             'tags': [],
-            'due': self.data.arbitrary_duedate.replace(microsecond=0),
-            'entry': self.data.arbitrary_created.replace(microsecond=0),
-            issue.URL: self.data.arbitrary_extra['issue_url'],
+            'due': data.arbitrary_duedate.replace(microsecond=0),
+            'entry': data.arbitrary_created.replace(microsecond=0),
+            issue.URL: data.arbitrary_extra['issue_url'],
             issue.REPO: 'project',
-            issue.STATE: self.data.arbitrary_issue['state'],
-            issue.TYPE: self.data.arbitrary_extra['type'],
-            issue.TITLE: self.data.arbitrary_issue['title'],
-            issue.NUMBER: str(self.data.arbitrary_issue['iid']),
-            issue.UPDATED_AT: self.data.arbitrary_updated.replace(microsecond=0),
-            issue.CREATED_AT: self.data.arbitrary_created.replace(microsecond=0),
-            issue.DUEDATE: self.data.arbitrary_duedate,
-            issue.DESCRIPTION: self.data.arbitrary_issue['description'],
-            issue.MILESTONE: self.data.arbitrary_issue['milestone']['title'],
+            issue.STATE: data.arbitrary_issue['state'],
+            issue.TYPE: data.arbitrary_extra['type'],
+            issue.TITLE: data.arbitrary_issue['title'],
+            issue.NUMBER: str(data.arbitrary_issue['iid']),
+            issue.UPDATED_AT: data.arbitrary_updated.replace(microsecond=0),
+            issue.CREATED_AT: data.arbitrary_created.replace(microsecond=0),
+            issue.DUEDATE: data.arbitrary_duedate,
+            issue.DESCRIPTION: data.arbitrary_issue['description'],
+            issue.MILESTONE: data.arbitrary_issue['milestone']['title'],
             issue.UPVOTES: 0,
             issue.DOWNVOTES: 0,
             issue.WORK_IN_PROGRESS: 1,
@@ -727,34 +738,36 @@ class TestGitlabIssue(ServiceIssueTest):
 
         assert actual_output == expected_output
 
-    def test_custom_todo_priority(self):
+    def test_custom_todo_priority(self, data):
         overrides = {'default_todo_priority': 'H'}
-        service = self.get_mock_service(GitlabService, config_overrides=overrides)
+        service = get_mock_service(
+            GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
+        )
         service.import_labels_as_tags = True
         issue = service.get_issue_for_record(
-            self.data.arbitrary_todo, self.data.arbitrary_todo_extra
+            data.arbitrary_todo, data.arbitrary_todo_extra
         )
         expected_output = {
-            'project': self.data.arbitrary_todo_extra['project'],
+            'project': data.arbitrary_todo_extra['project'],
             'priority': overrides['default_todo_priority'],
             'annotations': [],
             'tags': [],
             'due': None,  # currently not parsed for ToDos
-            'entry': self.data.arbitrary_created.replace(microsecond=0),
-            issue.URL: self.data.arbitrary_todo_extra['issue_url'],
+            'entry': data.arbitrary_created.replace(microsecond=0),
+            issue.URL: data.arbitrary_todo_extra['issue_url'],
             issue.REPO: 'project',
-            issue.STATE: self.data.arbitrary_todo['state'],
-            issue.TYPE: self.data.arbitrary_todo_extra['type'],
+            issue.STATE: data.arbitrary_todo['state'],
+            issue.TYPE: data.arbitrary_todo_extra['type'],
             issue.TITLE: 'Todo from %s for %s'
             % (
-                self.data.arbitrary_todo['author']['name'],
-                self.data.arbitrary_todo['project']['path'],
+                data.arbitrary_todo['author']['name'],
+                data.arbitrary_todo['project']['path'],
             ),
-            issue.NUMBER: str(self.data.arbitrary_todo['id']),
-            issue.UPDATED_AT: self.data.arbitrary_updated.replace(microsecond=0),
-            issue.CREATED_AT: self.data.arbitrary_created.replace(microsecond=0),
+            issue.NUMBER: str(data.arbitrary_todo['id']),
+            issue.UPDATED_AT: data.arbitrary_updated.replace(microsecond=0),
+            issue.CREATED_AT: data.arbitrary_created.replace(microsecond=0),
             issue.DUEDATE: None,  # Currently not parsed for ToDos
-            issue.DESCRIPTION: self.data.arbitrary_todo['body'],
+            issue.DESCRIPTION: data.arbitrary_todo['body'],
             issue.MILESTONE: None,
             issue.UPVOTES: 0,
             issue.DOWNVOTES: 0,
@@ -768,30 +781,30 @@ class TestGitlabIssue(ServiceIssueTest):
 
         assert actual_output == expected_output
 
-    def test_custom_mr_priority(self):
+    def test_custom_mr_priority(self, data):
         overrides = {'default_mr_priority': '', 'import_labels_as_tags': True}
-        service = self.get_mock_service(GitlabService, config_overrides=overrides)
-        issue = service.get_issue_for_record(
-            self.data.arbitrary_mr, self.data.arbitrary_mr_extra
+        service = get_mock_service(
+            GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
         )
+        issue = service.get_issue_for_record(data.arbitrary_mr, data.arbitrary_mr_extra)
         expected_output = {
-            'project': self.data.arbitrary_mr_extra['project'],
+            'project': data.arbitrary_mr_extra['project'],
             'priority': overrides['default_mr_priority'],
             'annotations': [],
             'tags': ['feature'],
-            'due': self.data.arbitrary_duedate.replace(microsecond=0),
-            'entry': self.data.arbitrary_created.replace(microsecond=0),
-            issue.URL: self.data.arbitrary_mr_extra['issue_url'],
+            'due': data.arbitrary_duedate.replace(microsecond=0),
+            'entry': data.arbitrary_created.replace(microsecond=0),
+            issue.URL: data.arbitrary_mr_extra['issue_url'],
             issue.REPO: 'project',
-            issue.STATE: self.data.arbitrary_mr['state'],
-            issue.TYPE: self.data.arbitrary_mr_extra['type'],
-            issue.TITLE: self.data.arbitrary_mr['title'],
-            issue.NUMBER: str(self.data.arbitrary_mr['iid']),
-            issue.UPDATED_AT: self.data.arbitrary_updated.replace(microsecond=0),
-            issue.CREATED_AT: self.data.arbitrary_created.replace(microsecond=0),
-            issue.DUEDATE: self.data.arbitrary_duedate,
-            issue.DESCRIPTION: self.data.arbitrary_mr['description'],
-            issue.MILESTONE: self.data.arbitrary_issue['milestone']['title'],
+            issue.STATE: data.arbitrary_mr['state'],
+            issue.TYPE: data.arbitrary_mr_extra['type'],
+            issue.TITLE: data.arbitrary_mr['title'],
+            issue.NUMBER: str(data.arbitrary_mr['iid']),
+            issue.UPDATED_AT: data.arbitrary_updated.replace(microsecond=0),
+            issue.CREATED_AT: data.arbitrary_created.replace(microsecond=0),
+            issue.DUEDATE: data.arbitrary_duedate,
+            issue.DESCRIPTION: data.arbitrary_mr['description'],
+            issue.MILESTONE: data.arbitrary_issue['milestone']['title'],
             issue.UPVOTES: 0,
             issue.DOWNVOTES: 0,
             issue.WORK_IN_PROGRESS: 1,
@@ -804,30 +817,28 @@ class TestGitlabIssue(ServiceIssueTest):
 
         assert actual_output == expected_output
 
-    def test_work_in_progress(self):
-        self.data.arbitrary_issue['work_in_progress'] = False
-        issue = self.service.get_issue_for_record(
-            self.data.arbitrary_issue, self.data.arbitrary_extra
-        )
+    def test_work_in_progress(self, service, data):
+        data.arbitrary_issue['work_in_progress'] = False
+        issue = service.get_issue_for_record(data.arbitrary_issue, data.arbitrary_extra)
 
         expected_output = {
-            'project': self.data.arbitrary_extra['project'],
-            'priority': self.service.config.default_priority,
+            'project': data.arbitrary_extra['project'],
+            'priority': service.config.default_priority,
             'annotations': [],
             'tags': [],
-            'due': self.data.arbitrary_duedate.replace(microsecond=0),
-            'entry': self.data.arbitrary_created.replace(microsecond=0),
-            issue.URL: self.data.arbitrary_extra['issue_url'],
+            'due': data.arbitrary_duedate.replace(microsecond=0),
+            'entry': data.arbitrary_created.replace(microsecond=0),
+            issue.URL: data.arbitrary_extra['issue_url'],
             issue.REPO: 'project',
-            issue.STATE: self.data.arbitrary_issue['state'],
-            issue.TYPE: self.data.arbitrary_extra['type'],
-            issue.TITLE: self.data.arbitrary_issue['title'],
-            issue.NUMBER: str(self.data.arbitrary_issue['iid']),
-            issue.UPDATED_AT: self.data.arbitrary_updated.replace(microsecond=0),
-            issue.CREATED_AT: self.data.arbitrary_created.replace(microsecond=0),
-            issue.DUEDATE: self.data.arbitrary_duedate,
-            issue.DESCRIPTION: self.data.arbitrary_issue['description'],
-            issue.MILESTONE: self.data.arbitrary_issue['milestone']['title'],
+            issue.STATE: data.arbitrary_issue['state'],
+            issue.TYPE: data.arbitrary_extra['type'],
+            issue.TITLE: data.arbitrary_issue['title'],
+            issue.NUMBER: str(data.arbitrary_issue['iid']),
+            issue.UPDATED_AT: data.arbitrary_updated.replace(microsecond=0),
+            issue.CREATED_AT: data.arbitrary_created.replace(microsecond=0),
+            issue.DUEDATE: data.arbitrary_duedate,
+            issue.DESCRIPTION: data.arbitrary_issue['description'],
+            issue.MILESTONE: data.arbitrary_issue['milestone']['title'],
             issue.UPVOTES: 0,
             issue.DOWNVOTES: 0,
             issue.WORK_IN_PROGRESS: 0,
@@ -841,12 +852,14 @@ class TestGitlabIssue(ServiceIssueTest):
         assert actual_output == expected_output
 
     @responses.activate
-    def test_issues_from_query(self):
+    def test_issues_from_query(self, data):
         overrides = {'issue_query': 'issues?state=opened'}
-        service = self.get_mock_service(GitlabService, config_overrides=overrides)
+        service = get_mock_service(
+            GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
+        )
         responses.get(
             'https://my-git.org/api/v4/issues?state=opened&per_page=100&page=1',
-            json=[self.data.arbitrary_issue],
+            json=[data.arbitrary_issue],
         )
         responses.get(
             'https://my-git.org/api/v4/projects/8',
@@ -866,11 +879,11 @@ class TestGitlabIssue(ServiceIssueTest):
         expected = {
             'annotations': ['@john_smith - Some comment.'],
             'description': '(bw)Is#3 - Add user settings .. example.com/issues/3',
-            'due': self.data.arbitrary_duedate,
-            'entry': self.data.arbitrary_created,
+            'due': data.arbitrary_duedate,
+            'entry': data.arbitrary_created,
             'gitlabassignee': 'jack_smith',
             'gitlabauthor': 'john_smith',
-            'gitlabcreatedon': self.data.arbitrary_created,
+            'gitlabcreatedon': data.arbitrary_created,
             'gitlabdescription': '',
             'gitlabdownvotes': 0,
             'gitlabmilestone': 'v1.0',
@@ -880,8 +893,8 @@ class TestGitlabIssue(ServiceIssueTest):
             'gitlabstate': 'opened',
             'gitlabtitle': 'Add user settings',
             'gitlabtype': 'issue',
-            'gitlabupdatedat': self.data.arbitrary_updated,
-            'gitlabduedate': self.data.arbitrary_duedate,
+            'gitlabupdatedat': data.arbitrary_updated,
+            'gitlabduedate': data.arbitrary_duedate,
             'gitlabupvotes': 0,
             'gitlaburl': 'example.com/issues/3',
             'gitlabwip': 1,
@@ -893,17 +906,19 @@ class TestGitlabIssue(ServiceIssueTest):
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     @responses.activate
-    def test_mrs_from_query(self):
+    def test_mrs_from_query(self, data):
         overrides = {
             'include_issues': 'false',
             'include_todos': 'false',
             'include_merge_requests': 'true',
             'merge_request_query': 'merge_requests?state=opened',
         }
-        service = self.get_mock_service(GitlabService, config_overrides=overrides)
+        service = get_mock_service(
+            GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
+        )
         responses.get(
             'https://my-git.org/api/v4/merge_requests?state=opened&per_page=100&page=1',
-            json=[self.data.arbitrary_mr],
+            json=[data.arbitrary_mr],
         )
         responses.get(
             'https://my-git.org/api/v4/projects/8',
@@ -924,11 +939,11 @@ class TestGitlabIssue(ServiceIssueTest):
         expected = {
             'annotations': ['@john_smith - Some comment.'],
             'description': '(bw)MR#3 - Add user settings .. example.com/merge_requests/3',
-            'due': self.data.arbitrary_duedate,
-            'entry': self.data.arbitrary_created,
+            'due': data.arbitrary_duedate,
+            'entry': data.arbitrary_created,
             'gitlabassignee': 'jack_smith',
             'gitlabauthor': 'john_smith',
-            'gitlabcreatedon': self.data.arbitrary_created,
+            'gitlabcreatedon': data.arbitrary_created,
             'gitlabdescription': '',
             'gitlabdownvotes': 0,
             'gitlabmilestone': 'v1.0',
@@ -938,8 +953,8 @@ class TestGitlabIssue(ServiceIssueTest):
             'gitlabstate': 'opened',
             'gitlabtitle': 'Add user settings',
             'gitlabtype': 'merge_request',
-            'gitlabupdatedat': self.data.arbitrary_updated,
-            'gitlabduedate': self.data.arbitrary_duedate,
+            'gitlabupdatedat': data.arbitrary_updated,
+            'gitlabduedate': data.arbitrary_duedate,
             'gitlabupvotes': 0,
             'gitlaburl': 'example.com/merge_requests/3',
             'gitlabwip': 1,
@@ -951,17 +966,19 @@ class TestGitlabIssue(ServiceIssueTest):
         assert TaskConstructor(mr).get_taskwarrior_record() == expected
 
     @responses.activate
-    def test_todos_from_query(self):
+    def test_todos_from_query(self, data):
         overrides = {
             'include_issues': 'false',
             'include_merge_requests': 'false',
             'include_todos': 'true',
             'todo_query': 'todos?state=pending',
         }
-        service = self.get_mock_service(GitlabService, config_overrides=overrides)
+        service = get_mock_service(
+            GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
+        )
         responses.get(
             'https://my-git.org/api/v4/todos?state=pending&per_page=100&page=1',
-            json=[self.data.arbitrary_todo],
+            json=[data.arbitrary_todo],
         )
         responses.get(
             'https://my-git.org/api/v4/projects/2',
@@ -989,10 +1006,10 @@ class TestGitlabIssue(ServiceIssueTest):
             'description': '(bw)# - Todo from John Smith for project .. '
             'https://my-git.org/arbitrary_username/project/issues/3',
             'due': None,
-            'entry': self.data.arbitrary_created,
+            'entry': data.arbitrary_created,
             'gitlabassignee': None,
             'gitlabauthor': 'john_smith',
-            'gitlabcreatedon': self.data.arbitrary_created,
+            'gitlabcreatedon': data.arbitrary_created,
             'gitlabdescription': 'Add user settings',
             'gitlabdownvotes': 0,
             'gitlabmilestone': None,
@@ -1002,7 +1019,7 @@ class TestGitlabIssue(ServiceIssueTest):
             'gitlabstate': 'pending',
             'gitlabtitle': 'Todo from John Smith for project',
             'gitlabtype': 'todo',
-            'gitlabupdatedat': self.data.arbitrary_updated,
+            'gitlabupdatedat': data.arbitrary_updated,
             'gitlabduedate': None,
             'gitlabupvotes': 0,
             'gitlaburl': 'https://my-git.org/arbitrary_username/project/issues/3',
@@ -1021,12 +1038,14 @@ class TestGitlabIssue(ServiceIssueTest):
             'include_repos': 'arbitrary_namespace/project',
             'include_all_todos': 'false',
         }
-        service = self.get_mock_service(GitlabService, config_overrides=overrides)
+        service = get_mock_service(
+            GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
+        )
         todo = next(service.issues())
         assert TaskConstructor(todo).get_taskwarrior_record() == expected
 
     @responses.activate
-    def test_issues(self):
+    def test_issues(self, service, data):
         responses.get(
             'https://my-git.org/api/v4/projects?simple=True&archived=False&per_page=100&page=1',
             json=[
@@ -1042,7 +1061,7 @@ class TestGitlabIssue(ServiceIssueTest):
 
         responses.get(
             'https://my-git.org/api/v4/projects/8/issues?state=opened&per_page=100&page=1',
-            json=[self.data.arbitrary_issue],
+            json=[data.arbitrary_issue],
         )
 
         responses.get(
@@ -1050,16 +1069,16 @@ class TestGitlabIssue(ServiceIssueTest):
             json=[{'author': {'username': 'john_smith'}, 'body': 'Some comment.'}],
         )
 
-        issue = next(self.service.issues())
+        issue = next(service.issues())
 
         expected = {
             'annotations': ['@john_smith - Some comment.'],
             'description': '(bw)Is#3 - Add user settings .. example.com/issues/3',
-            'due': self.data.arbitrary_duedate,
-            'entry': self.data.arbitrary_created,
+            'due': data.arbitrary_duedate,
+            'entry': data.arbitrary_created,
             'gitlabassignee': 'jack_smith',
             'gitlabauthor': 'john_smith',
-            'gitlabcreatedon': self.data.arbitrary_created,
+            'gitlabcreatedon': data.arbitrary_created,
             'gitlabdescription': '',
             'gitlabdownvotes': 0,
             'gitlabmilestone': 'v1.0',
@@ -1069,8 +1088,8 @@ class TestGitlabIssue(ServiceIssueTest):
             'gitlabstate': 'opened',
             'gitlabtitle': 'Add user settings',
             'gitlabtype': 'issue',
-            'gitlabupdatedat': self.data.arbitrary_updated,
-            'gitlabduedate': self.data.arbitrary_duedate,
+            'gitlabupdatedat': data.arbitrary_updated,
+            'gitlabduedate': data.arbitrary_duedate,
             'gitlabupvotes': 0,
             'gitlaburl': 'example.com/issues/3',
             'gitlabwip': 1,
@@ -1101,7 +1120,9 @@ class TestGitlabIssue(ServiceIssueTest):
         overrides = {'only_if_assigned': 'jack_smith'}
 
         # Should not raise an error
-        service = self.get_mock_service(GitlabService, config_overrides=overrides)
+        service = get_mock_service(
+            GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
+        )
 
         # Verify service was created successfully
         assert service is not None
@@ -1118,7 +1139,9 @@ class TestGitlabIssue(ServiceIssueTest):
 
         # Should exit with 1
         with pytest.raises(SystemExit) as cm:
-            self.get_mock_service(GitlabService, config_overrides=overrides)
+            get_mock_service(
+                GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
+            )
         assert cm.value.code == 1
 
     @responses.activate
@@ -1147,5 +1170,7 @@ class TestGitlabIssue(ServiceIssueTest):
 
         # Should exit with 1
         with pytest.raises(SystemExit) as cm:
-            self.get_mock_service(GitlabService, config_overrides=overrides)
+            get_mock_service(
+                GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
+            )
         assert cm.value.code == 1

--- a/tests/services/test_gitlab.py
+++ b/tests/services/test_gitlab.py
@@ -8,7 +8,6 @@ from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.gitlab import GitlabClient, GitlabService
 
 from ..base import get_validated_service, validate
-from .base import get_mock_service
 
 
 @pytest.fixture
@@ -304,6 +303,8 @@ def data():
         project=project,
     )
 
+
+SERVICE_CLASS = GitlabService
 
 SERVICE_CONFIG = {
     'service': 'gitlab',
@@ -642,19 +643,6 @@ class TestGitlabService:
             "explicitly. In a future release, this will be an error."
             in caplog.records[0].message
         )
-
-
-@pytest.fixture
-def make_service():
-    def make(**overrides):
-        return get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
-
-    return make
-
-
-@pytest.fixture
-def service(make_service):
-    return make_service()
 
 
 class TestGitlabIssue:

--- a/tests/services/test_gitlab.py
+++ b/tests/services/test_gitlab.py
@@ -13,14 +13,10 @@ from .base import get_mock_service
 
 @pytest.fixture
 def data():
-    arbitrary_created = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(
-        microsecond=0
-    )
-    arbitrary_updated = datetime.now(timezone.utc).replace(microsecond=0)
-    arbitrary_duedate = datetime.combine(
-        date.today(), datetime.min.time(), tzinfo=timezone.utc
-    )
-    arbitrary_issue = {
+    created = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(microsecond=0)
+    updated = datetime.now(timezone.utc).replace(microsecond=0)
+    duedate = datetime.combine(date.today(), datetime.min.time(), tzinfo=timezone.utc)
+    issue = {
         "id": 42,
         "iid": 3,
         "project_id": 8,
@@ -31,7 +27,7 @@ def data():
             "id": 1,
             "title": "v1.0",
             "description": "",
-            "due_date": arbitrary_duedate.date().isoformat(),
+            "due_date": duedate.date().isoformat(),
             "state": "closed",
             "updated_at": "2012-07-04T13:42:48Z",
             "created_at": "2012-07-04T13:42:48Z",
@@ -63,12 +59,12 @@ def data():
             "created_at": "2012-05-23T08:00:58Z",
         },
         "state": "opened",
-        "updated_at": arbitrary_updated.isoformat(),
-        "created_at": arbitrary_created.isoformat(),
+        "updated_at": updated.isoformat(),
+        "created_at": created.isoformat(),
         "weight": 3,
         "work_in_progress": True,
     }
-    arbitrary_extra = {
+    extra = {
         'issue_url': 'https://my-git.org/arbitrary_username/project/issues/3',
         'project': 'project',
         'namespace': 'arbitrary_namespace',
@@ -76,7 +72,7 @@ def data():
         'annotations': [],
         'description': '',
     }
-    arbitrary_todo = {
+    todo = {
         "id": 42,
         "project": {
             "id": 2,
@@ -106,7 +102,7 @@ def data():
                 "id": 1,
                 "title": "v1.0",
                 "description": "",
-                "due_date": arbitrary_duedate.date().isoformat(),
+                "due_date": duedate.date().isoformat(),
                 "state": "closed",
                 "updated_at": "2012-07-04T13:42:48Z",
                 "created_at": "2012-07-04T13:42:48Z",
@@ -128,25 +124,25 @@ def data():
                 "created_at": "2012-05-23T08:00:58Z",
             },
             "state": "opened",
-            "updated_at": arbitrary_updated.isoformat(),
-            "created_at": arbitrary_created.isoformat(),
+            "updated_at": updated.isoformat(),
+            "created_at": created.isoformat(),
             "weight": 3,
             "work_in_progress": True,
         },
         "target_url": "https://my-git.org/arbitrary_username/project/issues/3",
         "body": "Add user settings",
         "state": "pending",
-        "created_at": arbitrary_created.isoformat(),
-        "updated_at": arbitrary_updated.isoformat(),
+        "created_at": created.isoformat(),
+        "updated_at": updated.isoformat(),
     }
-    arbitrary_todo_extra = {
+    todo_extra = {
         'issue_url': 'https://my-git.org/arbitrary_username/project/issues/3',
         'project': 'project',
         'namespace': 'arbitrary_namespace',
         'type': 'todo',
         'annotations': [],
     }
-    arbitrary_mr = {
+    mr = {
         "id": 42,
         "iid": 3,
         "project_id": 8,
@@ -157,7 +153,7 @@ def data():
             "id": 1,
             "title": "v1.0",
             "description": "",
-            "due_date": arbitrary_duedate.date().isoformat(),
+            "due_date": duedate.date().isoformat(),
             "state": "closed",
             "updated_at": "2012-07-04T13:42:48Z",
             "created_at": "2012-07-04T13:42:48Z",
@@ -179,12 +175,12 @@ def data():
             "created_at": "2012-05-23T08:00:58Z",
         },
         "state": "opened",
-        "updated_at": arbitrary_updated.isoformat(),
-        "created_at": arbitrary_created.isoformat(),
+        "updated_at": updated.isoformat(),
+        "created_at": created.isoformat(),
         "weight": 3,
         "work_in_progress": True,
     }
-    arbitrary_mr_extra = {
+    mr_extra = {
         'issue_url': 'https://my-git.org/arbitrary_username/project/merge_requests/3',
         'project': 'project',
         'namespace': 'arbitrary_namespace',
@@ -192,14 +188,14 @@ def data():
         'annotations': [],
         "description": "",
     }
-    arbitrary_project = {
+    project = {
         "id": 8,
         "description": "This is the description of an arbitrary project",
         "name": "Arbitrary Project",
         "name_with_namespace": "Arbitrary Namespace / Arbitrary Project",
         "path": "arbitrary_project",
         "path_with_namespace": "arbitrary_namespace/arbitrary_project",
-        "created_at": arbitrary_created.isoformat(),
+        "created_at": created.isoformat(),
         "default_branch": "main",
         "tag_list": [],
         "topics": [],
@@ -210,7 +206,7 @@ def data():
         "avatar_url": None,
         "forks_count": 7,
         "star_count": 11,
-        "last_activity_at": arbitrary_updated.isoformat(),
+        "last_activity_at": updated.isoformat(),
         "namespace": {
             "id": 2,
             "name": "Arbitrary Namespace",
@@ -296,16 +292,16 @@ def data():
         "permissions": {"project_access": None, "group_access": None},
     }
     return SimpleNamespace(
-        arbitrary_created=arbitrary_created,
-        arbitrary_updated=arbitrary_updated,
-        arbitrary_duedate=arbitrary_duedate,
-        arbitrary_issue=arbitrary_issue,
-        arbitrary_extra=arbitrary_extra,
-        arbitrary_todo=arbitrary_todo,
-        arbitrary_todo_extra=arbitrary_todo_extra,
-        arbitrary_mr=arbitrary_mr,
-        arbitrary_mr_extra=arbitrary_mr_extra,
-        arbitrary_project=arbitrary_project,
+        created=created,
+        updated=updated,
+        duedate=duedate,
+        issue=issue,
+        extra=extra,
+        todo=todo,
+        todo_extra=todo_extra,
+        mr=mr,
+        mr_extra=mr_extra,
+        project=project,
     )
 
 
@@ -373,22 +369,20 @@ class TestGitlabClient:
 
     @responses.activate
     def test_get_repo(self, client, data):
-        responses.get(
-            'https://my-git.org/api/v4/projects/8', json=data.arbitrary_project
-        )
+        responses.get('https://my-git.org/api/v4/projects/8', json=data.project)
         result = client.get_repo_cached(repo_id=8)
-        assert result == data.arbitrary_project
+        assert result == data.project
 
     @responses.activate
     def test_get_repos(self, client, data):
         responses.get(
             'https://my-git.org/api/v4/projects?simple=True&archived=False&page=1&per_page=100',
-            json=[data.arbitrary_project],
+            json=[data.project],
         )
         responses.get(
             'https://my-git.org/api/v4/projects'
             + '?simple=True&archived=False&membership=True&page=1&per_page=100',
-            json=[data.arbitrary_project],
+            json=[data.project],
         )
         responses.get(
             'https://my-git.org/api/v4/projects'
@@ -398,11 +392,10 @@ class TestGitlabClient:
         responses.get(
             'https://my-git.org/api/v4/projects/'
             + 'arbitrary_namespace%2Farbitrary_project?simple=true',
-            json=data.arbitrary_project,
+            json=data.project,
         )
         responses.get(
-            'https://my-git.org/api/v4/projects/8?simple=true',
-            json=data.arbitrary_project,
+            'https://my-git.org/api/v4/projects/8?simple=true', json=data.project
         )
         responses.get(
             'https://my-git.org/api/v4/projects/non_existing?simple=true', json=[]
@@ -410,7 +403,7 @@ class TestGitlabClient:
         responses.get(
             'https://my-git.org/api/v4/projects'
             + '?simple=True&membership=True&owned=False&page=1&per_page=100',
-            json=[data.arbitrary_project],
+            json=[data.project],
         )
         responses.get(
             'https://my-git.org/api/v4/projects'
@@ -421,12 +414,12 @@ class TestGitlabClient:
         result = client.get_repos(
             include_repos=[], only_membership=False, only_owned=False
         )
-        assert result == [data.arbitrary_project]
+        assert result == [data.project]
 
         result = client.get_repos(
             include_repos=[], only_membership=True, only_owned=False
         )
-        assert result == [data.arbitrary_project]
+        assert result == [data.project]
 
         result = client.get_repos(
             include_repos=[], only_membership=True, only_owned=True
@@ -438,12 +431,12 @@ class TestGitlabClient:
             only_membership=False,
             only_owned=False,
         )
-        assert result == [data.arbitrary_project]
+        assert result == [data.project]
 
         result = client.get_repos(
             include_repos=['id:8'], only_membership=False, only_owned=False
         )
-        assert result == [data.arbitrary_project]
+        assert result == [data.project]
 
         # A repo that cannot be fetched is skipped rather than included.
         result = client.get_repos(
@@ -458,35 +451,27 @@ class TestGitlabClient:
             json=[{'author': {'username': 'john_smith'}, 'body': 'Some comment.'}],
         )
         expected = [{'author': {'username': 'john_smith'}, 'body': 'Some comment.'}]
-        result = client.get_notes(
-            data.arbitrary_issue['project_id'], 'issues', data.arbitrary_issue['iid']
-        )
+        result = client.get_notes(data.issue['project_id'], 'issues', data.issue['iid'])
         assert result == expected
 
     @responses.activate
     def test_get_repo_issues(self, client, data):
         responses.get(
             'https://my-git.org/api/v4/projects/8/issues?state=opened&page=1&per_page=100',
-            json=[data.arbitrary_issue],
+            json=[data.issue],
         )
-        assert client.get_repo_issues(data.arbitrary_issue['project_id']) == {
-            data.arbitrary_issue['id']: (
-                data.arbitrary_issue['project_id'],
-                data.arbitrary_issue,
-            )
+        assert client.get_repo_issues(data.issue['project_id']) == {
+            data.issue['id']: (data.issue['project_id'], data.issue)
         }
 
     @responses.activate
     def test_get_repo_merge_requests(self, client, data):
         responses.get(
             'https://my-git.org/api/v4/projects/8/merge_requests?state=opened&page=1&per_page=100',
-            json=[data.arbitrary_mr],
+            json=[data.mr],
         )
-        assert client.get_repo_merge_requests(data.arbitrary_issue['project_id']) == {
-            data.arbitrary_mr['id']: (
-                data.arbitrary_issue['project_id'],
-                data.arbitrary_mr,
-            )
+        assert client.get_repo_merge_requests(data.issue['project_id']) == {
+            data.mr['id']: (data.issue['project_id'], data.mr)
         }
 
     @responses.activate
@@ -494,25 +479,20 @@ class TestGitlabClient:
         responses.get(
             'https://my-git.org/api/v4/'
             + 'issues?assignee_id=2&state=opened&scope=all&page=1&per_page=100',
-            json=[data.arbitrary_issue],
+            json=[data.issue],
         )
         assert client.get_issues_from_query(
             'issues?assignee_id=2&state=opened&scope=all'
-        ) == {
-            data.arbitrary_issue['id']: (
-                data.arbitrary_issue['project_id'],
-                data.arbitrary_issue,
-            )
-        }
+        ) == {data.issue['id']: (data.issue['project_id'], data.issue)}
 
     @responses.activate
     def test_get_todos(self, client, data):
         responses.get(
             'https://my-git.org/api/v4/todos?state=pending&page=1&per_page=100',
-            json=[data.arbitrary_todo],
+            json=[data.todo],
         )
         assert client.get_todos('todos?state=pending') == [
-            (data.arbitrary_todo['project'], data.arbitrary_todo)
+            (data.todo['project'], data.todo)
         ]
 
 
@@ -611,9 +591,9 @@ class TestGitlabService:
 
     def test_include_only_if_assigned(self, config, data):
         config['myservice']['only_if_assigned'] = 'jack_smith'
-        assert self.get_service(config).include((1, data.arbitrary_issue))
+        assert self.get_service(config).include((1, data.issue))
         config['myservice']['only_if_assigned'] = 'smack_jith'
-        assert not self.get_service(config).include((1, data.arbitrary_issue))
+        assert not self.get_service(config).include((1, data.issue))
 
     def test_default_priorities(self, config):
         config['myservice'].update(
@@ -670,26 +650,26 @@ class TestGitlabIssue:
         return get_mock_service(GitlabService, SERVICE_CONFIG)
 
     def test_to_taskwarrior(self, service, data):
-        issue = service.get_issue_for_record(data.arbitrary_issue, data.arbitrary_extra)
+        issue = service.get_issue_for_record(data.issue, data.extra)
 
         expected_output = {
-            'project': data.arbitrary_extra['project'],
+            'project': data.extra['project'],
             'priority': service.config.default_priority,
             'annotations': [],
             'tags': [],
-            'due': data.arbitrary_duedate.replace(microsecond=0),
-            'entry': data.arbitrary_created.replace(microsecond=0),
-            issue.URL: data.arbitrary_extra['issue_url'],
+            'due': data.duedate.replace(microsecond=0),
+            'entry': data.created.replace(microsecond=0),
+            issue.URL: data.extra['issue_url'],
             issue.REPO: 'project',
-            issue.STATE: data.arbitrary_issue['state'],
-            issue.TYPE: data.arbitrary_extra['type'],
-            issue.TITLE: data.arbitrary_issue['title'],
-            issue.NUMBER: str(data.arbitrary_issue['iid']),
-            issue.UPDATED_AT: data.arbitrary_updated.replace(microsecond=0),
-            issue.CREATED_AT: data.arbitrary_created.replace(microsecond=0),
-            issue.DUEDATE: data.arbitrary_duedate,
-            issue.DESCRIPTION: data.arbitrary_issue['description'],
-            issue.MILESTONE: data.arbitrary_issue['milestone']['title'],
+            issue.STATE: data.issue['state'],
+            issue.TYPE: data.extra['type'],
+            issue.TITLE: data.issue['title'],
+            issue.NUMBER: str(data.issue['iid']),
+            issue.UPDATED_AT: data.updated.replace(microsecond=0),
+            issue.CREATED_AT: data.created.replace(microsecond=0),
+            issue.DUEDATE: data.duedate,
+            issue.DESCRIPTION: data.issue['description'],
+            issue.MILESTONE: data.issue['milestone']['title'],
             issue.UPVOTES: 0,
             issue.DOWNVOTES: 0,
             issue.WORK_IN_PROGRESS: 1,
@@ -705,25 +685,25 @@ class TestGitlabIssue:
     def test_custom_issue_priority(self, data):
         overrides = {'default_issue_priority': 'L'}
         service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
-        issue = service.get_issue_for_record(data.arbitrary_issue, data.arbitrary_extra)
+        issue = service.get_issue_for_record(data.issue, data.extra)
         expected_output = {
-            'project': data.arbitrary_extra['project'],
+            'project': data.extra['project'],
             'priority': 'L',
             'annotations': [],
             'tags': [],
-            'due': data.arbitrary_duedate.replace(microsecond=0),
-            'entry': data.arbitrary_created.replace(microsecond=0),
-            issue.URL: data.arbitrary_extra['issue_url'],
+            'due': data.duedate.replace(microsecond=0),
+            'entry': data.created.replace(microsecond=0),
+            issue.URL: data.extra['issue_url'],
             issue.REPO: 'project',
-            issue.STATE: data.arbitrary_issue['state'],
-            issue.TYPE: data.arbitrary_extra['type'],
-            issue.TITLE: data.arbitrary_issue['title'],
-            issue.NUMBER: str(data.arbitrary_issue['iid']),
-            issue.UPDATED_AT: data.arbitrary_updated.replace(microsecond=0),
-            issue.CREATED_AT: data.arbitrary_created.replace(microsecond=0),
-            issue.DUEDATE: data.arbitrary_duedate,
-            issue.DESCRIPTION: data.arbitrary_issue['description'],
-            issue.MILESTONE: data.arbitrary_issue['milestone']['title'],
+            issue.STATE: data.issue['state'],
+            issue.TYPE: data.extra['type'],
+            issue.TITLE: data.issue['title'],
+            issue.NUMBER: str(data.issue['iid']),
+            issue.UPDATED_AT: data.updated.replace(microsecond=0),
+            issue.CREATED_AT: data.created.replace(microsecond=0),
+            issue.DUEDATE: data.duedate,
+            issue.DESCRIPTION: data.issue['description'],
+            issue.MILESTONE: data.issue['milestone']['title'],
             issue.UPVOTES: 0,
             issue.DOWNVOTES: 0,
             issue.WORK_IN_PROGRESS: 1,
@@ -740,30 +720,25 @@ class TestGitlabIssue:
         overrides = {'default_todo_priority': 'H'}
         service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
         service.import_labels_as_tags = True
-        issue = service.get_issue_for_record(
-            data.arbitrary_todo, data.arbitrary_todo_extra
-        )
+        issue = service.get_issue_for_record(data.todo, data.todo_extra)
         expected_output = {
-            'project': data.arbitrary_todo_extra['project'],
+            'project': data.todo_extra['project'],
             'priority': overrides['default_todo_priority'],
             'annotations': [],
             'tags': [],
             'due': None,  # currently not parsed for ToDos
-            'entry': data.arbitrary_created.replace(microsecond=0),
-            issue.URL: data.arbitrary_todo_extra['issue_url'],
+            'entry': data.created.replace(microsecond=0),
+            issue.URL: data.todo_extra['issue_url'],
             issue.REPO: 'project',
-            issue.STATE: data.arbitrary_todo['state'],
-            issue.TYPE: data.arbitrary_todo_extra['type'],
+            issue.STATE: data.todo['state'],
+            issue.TYPE: data.todo_extra['type'],
             issue.TITLE: 'Todo from %s for %s'
-            % (
-                data.arbitrary_todo['author']['name'],
-                data.arbitrary_todo['project']['path'],
-            ),
-            issue.NUMBER: str(data.arbitrary_todo['id']),
-            issue.UPDATED_AT: data.arbitrary_updated.replace(microsecond=0),
-            issue.CREATED_AT: data.arbitrary_created.replace(microsecond=0),
+            % (data.todo['author']['name'], data.todo['project']['path']),
+            issue.NUMBER: str(data.todo['id']),
+            issue.UPDATED_AT: data.updated.replace(microsecond=0),
+            issue.CREATED_AT: data.created.replace(microsecond=0),
             issue.DUEDATE: None,  # Currently not parsed for ToDos
-            issue.DESCRIPTION: data.arbitrary_todo['body'],
+            issue.DESCRIPTION: data.todo['body'],
             issue.MILESTONE: None,
             issue.UPVOTES: 0,
             issue.DOWNVOTES: 0,
@@ -780,25 +755,25 @@ class TestGitlabIssue:
     def test_custom_mr_priority(self, data):
         overrides = {'default_mr_priority': '', 'import_labels_as_tags': True}
         service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
-        issue = service.get_issue_for_record(data.arbitrary_mr, data.arbitrary_mr_extra)
+        issue = service.get_issue_for_record(data.mr, data.mr_extra)
         expected_output = {
-            'project': data.arbitrary_mr_extra['project'],
+            'project': data.mr_extra['project'],
             'priority': overrides['default_mr_priority'],
             'annotations': [],
             'tags': ['feature'],
-            'due': data.arbitrary_duedate.replace(microsecond=0),
-            'entry': data.arbitrary_created.replace(microsecond=0),
-            issue.URL: data.arbitrary_mr_extra['issue_url'],
+            'due': data.duedate.replace(microsecond=0),
+            'entry': data.created.replace(microsecond=0),
+            issue.URL: data.mr_extra['issue_url'],
             issue.REPO: 'project',
-            issue.STATE: data.arbitrary_mr['state'],
-            issue.TYPE: data.arbitrary_mr_extra['type'],
-            issue.TITLE: data.arbitrary_mr['title'],
-            issue.NUMBER: str(data.arbitrary_mr['iid']),
-            issue.UPDATED_AT: data.arbitrary_updated.replace(microsecond=0),
-            issue.CREATED_AT: data.arbitrary_created.replace(microsecond=0),
-            issue.DUEDATE: data.arbitrary_duedate,
-            issue.DESCRIPTION: data.arbitrary_mr['description'],
-            issue.MILESTONE: data.arbitrary_issue['milestone']['title'],
+            issue.STATE: data.mr['state'],
+            issue.TYPE: data.mr_extra['type'],
+            issue.TITLE: data.mr['title'],
+            issue.NUMBER: str(data.mr['iid']),
+            issue.UPDATED_AT: data.updated.replace(microsecond=0),
+            issue.CREATED_AT: data.created.replace(microsecond=0),
+            issue.DUEDATE: data.duedate,
+            issue.DESCRIPTION: data.mr['description'],
+            issue.MILESTONE: data.issue['milestone']['title'],
             issue.UPVOTES: 0,
             issue.DOWNVOTES: 0,
             issue.WORK_IN_PROGRESS: 1,
@@ -812,27 +787,27 @@ class TestGitlabIssue:
         assert actual_output == expected_output
 
     def test_work_in_progress(self, service, data):
-        data.arbitrary_issue['work_in_progress'] = False
-        issue = service.get_issue_for_record(data.arbitrary_issue, data.arbitrary_extra)
+        data.issue['work_in_progress'] = False
+        issue = service.get_issue_for_record(data.issue, data.extra)
 
         expected_output = {
-            'project': data.arbitrary_extra['project'],
+            'project': data.extra['project'],
             'priority': service.config.default_priority,
             'annotations': [],
             'tags': [],
-            'due': data.arbitrary_duedate.replace(microsecond=0),
-            'entry': data.arbitrary_created.replace(microsecond=0),
-            issue.URL: data.arbitrary_extra['issue_url'],
+            'due': data.duedate.replace(microsecond=0),
+            'entry': data.created.replace(microsecond=0),
+            issue.URL: data.extra['issue_url'],
             issue.REPO: 'project',
-            issue.STATE: data.arbitrary_issue['state'],
-            issue.TYPE: data.arbitrary_extra['type'],
-            issue.TITLE: data.arbitrary_issue['title'],
-            issue.NUMBER: str(data.arbitrary_issue['iid']),
-            issue.UPDATED_AT: data.arbitrary_updated.replace(microsecond=0),
-            issue.CREATED_AT: data.arbitrary_created.replace(microsecond=0),
-            issue.DUEDATE: data.arbitrary_duedate,
-            issue.DESCRIPTION: data.arbitrary_issue['description'],
-            issue.MILESTONE: data.arbitrary_issue['milestone']['title'],
+            issue.STATE: data.issue['state'],
+            issue.TYPE: data.extra['type'],
+            issue.TITLE: data.issue['title'],
+            issue.NUMBER: str(data.issue['iid']),
+            issue.UPDATED_AT: data.updated.replace(microsecond=0),
+            issue.CREATED_AT: data.created.replace(microsecond=0),
+            issue.DUEDATE: data.duedate,
+            issue.DESCRIPTION: data.issue['description'],
+            issue.MILESTONE: data.issue['milestone']['title'],
             issue.UPVOTES: 0,
             issue.DOWNVOTES: 0,
             issue.WORK_IN_PROGRESS: 0,
@@ -851,7 +826,7 @@ class TestGitlabIssue:
         service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
         responses.get(
             'https://my-git.org/api/v4/issues?state=opened&per_page=100&page=1',
-            json=[data.arbitrary_issue],
+            json=[data.issue],
         )
         responses.get(
             'https://my-git.org/api/v4/projects/8',
@@ -871,11 +846,11 @@ class TestGitlabIssue:
         expected = {
             'annotations': ['@john_smith - Some comment.'],
             'description': '(bw)Is#3 - Add user settings .. example.com/issues/3',
-            'due': data.arbitrary_duedate,
-            'entry': data.arbitrary_created,
+            'due': data.duedate,
+            'entry': data.created,
             'gitlabassignee': 'jack_smith',
             'gitlabauthor': 'john_smith',
-            'gitlabcreatedon': data.arbitrary_created,
+            'gitlabcreatedon': data.created,
             'gitlabdescription': '',
             'gitlabdownvotes': 0,
             'gitlabmilestone': 'v1.0',
@@ -885,8 +860,8 @@ class TestGitlabIssue:
             'gitlabstate': 'opened',
             'gitlabtitle': 'Add user settings',
             'gitlabtype': 'issue',
-            'gitlabupdatedat': data.arbitrary_updated,
-            'gitlabduedate': data.arbitrary_duedate,
+            'gitlabupdatedat': data.updated,
+            'gitlabduedate': data.duedate,
             'gitlabupvotes': 0,
             'gitlaburl': 'example.com/issues/3',
             'gitlabwip': 1,
@@ -908,7 +883,7 @@ class TestGitlabIssue:
         service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
         responses.get(
             'https://my-git.org/api/v4/merge_requests?state=opened&per_page=100&page=1',
-            json=[data.arbitrary_mr],
+            json=[data.mr],
         )
         responses.get(
             'https://my-git.org/api/v4/projects/8',
@@ -929,11 +904,11 @@ class TestGitlabIssue:
         expected = {
             'annotations': ['@john_smith - Some comment.'],
             'description': '(bw)MR#3 - Add user settings .. example.com/merge_requests/3',
-            'due': data.arbitrary_duedate,
-            'entry': data.arbitrary_created,
+            'due': data.duedate,
+            'entry': data.created,
             'gitlabassignee': 'jack_smith',
             'gitlabauthor': 'john_smith',
-            'gitlabcreatedon': data.arbitrary_created,
+            'gitlabcreatedon': data.created,
             'gitlabdescription': '',
             'gitlabdownvotes': 0,
             'gitlabmilestone': 'v1.0',
@@ -943,8 +918,8 @@ class TestGitlabIssue:
             'gitlabstate': 'opened',
             'gitlabtitle': 'Add user settings',
             'gitlabtype': 'merge_request',
-            'gitlabupdatedat': data.arbitrary_updated,
-            'gitlabduedate': data.arbitrary_duedate,
+            'gitlabupdatedat': data.updated,
+            'gitlabduedate': data.duedate,
             'gitlabupvotes': 0,
             'gitlaburl': 'example.com/merge_requests/3',
             'gitlabwip': 1,
@@ -966,7 +941,7 @@ class TestGitlabIssue:
         service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
         responses.get(
             'https://my-git.org/api/v4/todos?state=pending&per_page=100&page=1',
-            json=[data.arbitrary_todo],
+            json=[data.todo],
         )
         responses.get(
             'https://my-git.org/api/v4/projects/2',
@@ -994,10 +969,10 @@ class TestGitlabIssue:
             'description': '(bw)# - Todo from John Smith for project .. '
             'https://my-git.org/arbitrary_username/project/issues/3',
             'due': None,
-            'entry': data.arbitrary_created,
+            'entry': data.created,
             'gitlabassignee': None,
             'gitlabauthor': 'john_smith',
-            'gitlabcreatedon': data.arbitrary_created,
+            'gitlabcreatedon': data.created,
             'gitlabdescription': 'Add user settings',
             'gitlabdownvotes': 0,
             'gitlabmilestone': None,
@@ -1007,7 +982,7 @@ class TestGitlabIssue:
             'gitlabstate': 'pending',
             'gitlabtitle': 'Todo from John Smith for project',
             'gitlabtype': 'todo',
-            'gitlabupdatedat': data.arbitrary_updated,
+            'gitlabupdatedat': data.updated,
             'gitlabduedate': None,
             'gitlabupvotes': 0,
             'gitlaburl': 'https://my-git.org/arbitrary_username/project/issues/3',
@@ -1047,7 +1022,7 @@ class TestGitlabIssue:
 
         responses.get(
             'https://my-git.org/api/v4/projects/8/issues?state=opened&per_page=100&page=1',
-            json=[data.arbitrary_issue],
+            json=[data.issue],
         )
 
         responses.get(
@@ -1060,11 +1035,11 @@ class TestGitlabIssue:
         expected = {
             'annotations': ['@john_smith - Some comment.'],
             'description': '(bw)Is#3 - Add user settings .. example.com/issues/3',
-            'due': data.arbitrary_duedate,
-            'entry': data.arbitrary_created,
+            'due': data.duedate,
+            'entry': data.created,
             'gitlabassignee': 'jack_smith',
             'gitlabauthor': 'john_smith',
-            'gitlabcreatedon': data.arbitrary_created,
+            'gitlabcreatedon': data.created,
             'gitlabdescription': '',
             'gitlabdownvotes': 0,
             'gitlabmilestone': 'v1.0',
@@ -1074,8 +1049,8 @@ class TestGitlabIssue:
             'gitlabstate': 'opened',
             'gitlabtitle': 'Add user settings',
             'gitlabtype': 'issue',
-            'gitlabupdatedat': data.arbitrary_updated,
-            'gitlabduedate': data.arbitrary_duedate,
+            'gitlabupdatedat': data.updated,
+            'gitlabduedate': data.duedate,
             'gitlabupvotes': 0,
             'gitlaburl': 'example.com/issues/3',
             'gitlabwip': 1,

--- a/tests/services/test_gitlab.py
+++ b/tests/services/test_gitlab.py
@@ -704,9 +704,7 @@ class TestGitlabIssue:
 
     def test_custom_issue_priority(self, data):
         overrides = {'default_issue_priority': 'L'}
-        service = get_mock_service(
-            GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
-        )
+        service = get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
         issue = service.get_issue_for_record(data.arbitrary_issue, data.arbitrary_extra)
         expected_output = {
             'project': data.arbitrary_extra['project'],
@@ -740,9 +738,7 @@ class TestGitlabIssue:
 
     def test_custom_todo_priority(self, data):
         overrides = {'default_todo_priority': 'H'}
-        service = get_mock_service(
-            GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
-        )
+        service = get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
         service.import_labels_as_tags = True
         issue = service.get_issue_for_record(
             data.arbitrary_todo, data.arbitrary_todo_extra
@@ -783,9 +779,7 @@ class TestGitlabIssue:
 
     def test_custom_mr_priority(self, data):
         overrides = {'default_mr_priority': '', 'import_labels_as_tags': True}
-        service = get_mock_service(
-            GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
-        )
+        service = get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
         issue = service.get_issue_for_record(data.arbitrary_mr, data.arbitrary_mr_extra)
         expected_output = {
             'project': data.arbitrary_mr_extra['project'],
@@ -854,9 +848,7 @@ class TestGitlabIssue:
     @responses.activate
     def test_issues_from_query(self, data):
         overrides = {'issue_query': 'issues?state=opened'}
-        service = get_mock_service(
-            GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
-        )
+        service = get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
         responses.get(
             'https://my-git.org/api/v4/issues?state=opened&per_page=100&page=1',
             json=[data.arbitrary_issue],
@@ -913,9 +905,7 @@ class TestGitlabIssue:
             'include_merge_requests': 'true',
             'merge_request_query': 'merge_requests?state=opened',
         }
-        service = get_mock_service(
-            GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
-        )
+        service = get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
         responses.get(
             'https://my-git.org/api/v4/merge_requests?state=opened&per_page=100&page=1',
             json=[data.arbitrary_mr],
@@ -973,9 +963,7 @@ class TestGitlabIssue:
             'include_todos': 'true',
             'todo_query': 'todos?state=pending',
         }
-        service = get_mock_service(
-            GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
-        )
+        service = get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
         responses.get(
             'https://my-git.org/api/v4/todos?state=pending&per_page=100&page=1',
             json=[data.arbitrary_todo],
@@ -1038,9 +1026,7 @@ class TestGitlabIssue:
             'include_repos': 'arbitrary_namespace/project',
             'include_all_todos': 'false',
         }
-        service = get_mock_service(
-            GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
-        )
+        service = get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
         todo = next(service.issues())
         assert TaskConstructor(todo).get_taskwarrior_record() == expected
 
@@ -1120,9 +1106,7 @@ class TestGitlabIssue:
         overrides = {'only_if_assigned': 'jack_smith'}
 
         # Should not raise an error
-        service = get_mock_service(
-            GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
-        )
+        service = get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
 
         # Verify service was created successfully
         assert service is not None
@@ -1139,9 +1123,7 @@ class TestGitlabIssue:
 
         # Should exit with 1
         with pytest.raises(SystemExit) as cm:
-            get_mock_service(
-                GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
-            )
+            get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
         assert cm.value.code == 1
 
     @responses.activate
@@ -1170,7 +1152,5 @@ class TestGitlabIssue:
 
         # Should exit with 1
         with pytest.raises(SystemExit) as cm:
-            get_mock_service(
-                GitlabService, self.SERVICE_CONFIG, config_overrides=overrides
-            )
+            get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
         assert cm.value.code == 1

--- a/tests/services/test_gitlab.py
+++ b/tests/services/test_gitlab.py
@@ -644,11 +644,20 @@ class TestGitlabService:
         )
 
 
-class TestGitlabIssue:
-    @pytest.fixture
-    def service(self):
-        return get_mock_service(GitlabService, SERVICE_CONFIG)
+@pytest.fixture
+def make_service():
+    def make(**overrides):
+        return get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
 
+    return make
+
+
+@pytest.fixture
+def service(make_service):
+    return make_service()
+
+
+class TestGitlabIssue:
     def test_to_taskwarrior(self, service, data):
         issue = service.get_issue_for_record(data.issue, data.extra)
 
@@ -682,9 +691,9 @@ class TestGitlabIssue:
 
         assert actual_output == expected_output
 
-    def test_custom_issue_priority(self, data):
+    def test_custom_issue_priority(self, data, make_service):
         overrides = {'default_issue_priority': 'L'}
-        service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
+        service = make_service(**overrides)
         issue = service.get_issue_for_record(data.issue, data.extra)
         expected_output = {
             'project': data.extra['project'],
@@ -716,9 +725,9 @@ class TestGitlabIssue:
 
         assert actual_output == expected_output
 
-    def test_custom_todo_priority(self, data):
+    def test_custom_todo_priority(self, data, make_service):
         overrides = {'default_todo_priority': 'H'}
-        service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
+        service = make_service(**overrides)
         service.import_labels_as_tags = True
         issue = service.get_issue_for_record(data.todo, data.todo_extra)
         expected_output = {
@@ -752,9 +761,9 @@ class TestGitlabIssue:
 
         assert actual_output == expected_output
 
-    def test_custom_mr_priority(self, data):
+    def test_custom_mr_priority(self, data, make_service):
         overrides = {'default_mr_priority': '', 'import_labels_as_tags': True}
-        service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
+        service = make_service(**overrides)
         issue = service.get_issue_for_record(data.mr, data.mr_extra)
         expected_output = {
             'project': data.mr_extra['project'],
@@ -821,9 +830,9 @@ class TestGitlabIssue:
         assert actual_output == expected_output
 
     @responses.activate
-    def test_issues_from_query(self, data):
+    def test_issues_from_query(self, data, make_service):
         overrides = {'issue_query': 'issues?state=opened'}
-        service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
+        service = make_service(**overrides)
         responses.get(
             'https://my-git.org/api/v4/issues?state=opened&per_page=100&page=1',
             json=[data.issue],
@@ -873,14 +882,14 @@ class TestGitlabIssue:
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     @responses.activate
-    def test_mrs_from_query(self, data):
+    def test_mrs_from_query(self, data, make_service):
         overrides = {
             'include_issues': 'false',
             'include_todos': 'false',
             'include_merge_requests': 'true',
             'merge_request_query': 'merge_requests?state=opened',
         }
-        service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
+        service = make_service(**overrides)
         responses.get(
             'https://my-git.org/api/v4/merge_requests?state=opened&per_page=100&page=1',
             json=[data.mr],
@@ -931,14 +940,14 @@ class TestGitlabIssue:
         assert TaskConstructor(mr).get_taskwarrior_record() == expected
 
     @responses.activate
-    def test_todos_from_query(self, data):
+    def test_todos_from_query(self, data, make_service):
         overrides = {
             'include_issues': 'false',
             'include_merge_requests': 'false',
             'include_todos': 'true',
             'todo_query': 'todos?state=pending',
         }
-        service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
+        service = make_service(**overrides)
         responses.get(
             'https://my-git.org/api/v4/todos?state=pending&per_page=100&page=1',
             json=[data.todo],
@@ -1001,7 +1010,7 @@ class TestGitlabIssue:
             'include_repos': 'arbitrary_namespace/project',
             'include_all_todos': 'false',
         }
-        service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
+        service = make_service(**overrides)
         todo = next(service.issues())
         assert TaskConstructor(todo).get_taskwarrior_record() == expected
 
@@ -1063,7 +1072,7 @@ class TestGitlabIssue:
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     @responses.activate
-    def test_only_if_assigned_user_lookup(self):
+    def test_only_if_assigned_user_lookup(self, make_service):
         """Test that only_if_assigned correctly looks up the user and uses first match"""
         # Mock the user lookup API call - WITH username in query string
         responses.get(
@@ -1081,13 +1090,13 @@ class TestGitlabIssue:
         overrides = {'only_if_assigned': 'jack_smith'}
 
         # Should not raise an error
-        service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
+        service = make_service(**overrides)
 
         # Verify service was created successfully
         assert service is not None
 
     @responses.activate
-    def test_only_if_assigned_user_not_found(self):
+    def test_only_if_assigned_user_not_found(self, make_service):
         """Test that empty user list causes SystemExit"""
         # Mock empty user lookup response
         responses.get(
@@ -1098,11 +1107,11 @@ class TestGitlabIssue:
 
         # Should exit with 1
         with pytest.raises(SystemExit) as cm:
-            get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
+            make_service(**overrides)
         assert cm.value.code == 1
 
     @responses.activate
-    def test_only_if_assigned_multiple_users(self):
+    def test_only_if_assigned_multiple_users(self, make_service):
         """Test that multiple users found causes SystemExit"""
         # Mock multiple users with similar names
         responses.get(
@@ -1127,5 +1136,5 @@ class TestGitlabIssue:
 
         # Should exit with 1
         with pytest.raises(SystemExit) as cm:
-            get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
+            make_service(**overrides)
         assert cm.value.code == 1

--- a/tests/services/test_gitlab.py
+++ b/tests/services/test_gitlab.py
@@ -1,5 +1,4 @@
 from datetime import date, datetime, timedelta, timezone
-from types import SimpleNamespace
 
 import pytest
 import responses
@@ -9,13 +8,14 @@ from bugwarrior.services.gitlab import GitlabClient, GitlabService
 
 from ..base import get_validated_service, validate
 
+CREATED = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(microsecond=0)
+UPDATED = datetime.now(timezone.utc).replace(microsecond=0)
+DUEDATE = datetime.combine(date.today(), datetime.min.time(), tzinfo=timezone.utc)
+
 
 @pytest.fixture
-def data():
-    created = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(microsecond=0)
-    updated = datetime.now(timezone.utc).replace(microsecond=0)
-    duedate = datetime.combine(date.today(), datetime.min.time(), tzinfo=timezone.utc)
-    issue = {
+def issue():
+    return {
         "id": 42,
         "iid": 3,
         "project_id": 8,
@@ -26,7 +26,7 @@ def data():
             "id": 1,
             "title": "v1.0",
             "description": "",
-            "due_date": duedate.date().isoformat(),
+            "due_date": DUEDATE.date().isoformat(),
             "state": "closed",
             "updated_at": "2012-07-04T13:42:48Z",
             "created_at": "2012-07-04T13:42:48Z",
@@ -58,12 +58,16 @@ def data():
             "created_at": "2012-05-23T08:00:58Z",
         },
         "state": "opened",
-        "updated_at": updated.isoformat(),
-        "created_at": created.isoformat(),
+        "updated_at": UPDATED.isoformat(),
+        "created_at": CREATED.isoformat(),
         "weight": 3,
         "work_in_progress": True,
     }
-    extra = {
+
+
+@pytest.fixture
+def extra():
+    return {
         'issue_url': 'https://my-git.org/arbitrary_username/project/issues/3',
         'project': 'project',
         'namespace': 'arbitrary_namespace',
@@ -71,7 +75,11 @@ def data():
         'annotations': [],
         'description': '',
     }
-    todo = {
+
+
+@pytest.fixture
+def todo():
+    return {
         "id": 42,
         "project": {
             "id": 2,
@@ -101,7 +109,7 @@ def data():
                 "id": 1,
                 "title": "v1.0",
                 "description": "",
-                "due_date": duedate.date().isoformat(),
+                "due_date": DUEDATE.date().isoformat(),
                 "state": "closed",
                 "updated_at": "2012-07-04T13:42:48Z",
                 "created_at": "2012-07-04T13:42:48Z",
@@ -123,25 +131,33 @@ def data():
                 "created_at": "2012-05-23T08:00:58Z",
             },
             "state": "opened",
-            "updated_at": updated.isoformat(),
-            "created_at": created.isoformat(),
+            "updated_at": UPDATED.isoformat(),
+            "created_at": CREATED.isoformat(),
             "weight": 3,
             "work_in_progress": True,
         },
         "target_url": "https://my-git.org/arbitrary_username/project/issues/3",
         "body": "Add user settings",
         "state": "pending",
-        "created_at": created.isoformat(),
-        "updated_at": updated.isoformat(),
+        "created_at": CREATED.isoformat(),
+        "updated_at": UPDATED.isoformat(),
     }
-    todo_extra = {
+
+
+@pytest.fixture
+def todo_extra():
+    return {
         'issue_url': 'https://my-git.org/arbitrary_username/project/issues/3',
         'project': 'project',
         'namespace': 'arbitrary_namespace',
         'type': 'todo',
         'annotations': [],
     }
-    mr = {
+
+
+@pytest.fixture
+def mr():
+    return {
         "id": 42,
         "iid": 3,
         "project_id": 8,
@@ -152,7 +168,7 @@ def data():
             "id": 1,
             "title": "v1.0",
             "description": "",
-            "due_date": duedate.date().isoformat(),
+            "due_date": DUEDATE.date().isoformat(),
             "state": "closed",
             "updated_at": "2012-07-04T13:42:48Z",
             "created_at": "2012-07-04T13:42:48Z",
@@ -174,12 +190,16 @@ def data():
             "created_at": "2012-05-23T08:00:58Z",
         },
         "state": "opened",
-        "updated_at": updated.isoformat(),
-        "created_at": created.isoformat(),
+        "updated_at": UPDATED.isoformat(),
+        "created_at": CREATED.isoformat(),
         "weight": 3,
         "work_in_progress": True,
     }
-    mr_extra = {
+
+
+@pytest.fixture
+def mr_extra():
+    return {
         'issue_url': 'https://my-git.org/arbitrary_username/project/merge_requests/3',
         'project': 'project',
         'namespace': 'arbitrary_namespace',
@@ -187,14 +207,18 @@ def data():
         'annotations': [],
         "description": "",
     }
-    project = {
+
+
+@pytest.fixture
+def project():
+    return {
         "id": 8,
         "description": "This is the description of an arbitrary project",
         "name": "Arbitrary Project",
         "name_with_namespace": "Arbitrary Namespace / Arbitrary Project",
         "path": "arbitrary_project",
         "path_with_namespace": "arbitrary_namespace/arbitrary_project",
-        "created_at": created.isoformat(),
+        "created_at": CREATED.isoformat(),
         "default_branch": "main",
         "tag_list": [],
         "topics": [],
@@ -205,7 +229,7 @@ def data():
         "avatar_url": None,
         "forks_count": 7,
         "star_count": 11,
-        "last_activity_at": updated.isoformat(),
+        "last_activity_at": UPDATED.isoformat(),
         "namespace": {
             "id": 2,
             "name": "Arbitrary Namespace",
@@ -290,18 +314,6 @@ def data():
         "keep_latest_artifact": False,
         "permissions": {"project_access": None, "group_access": None},
     }
-    return SimpleNamespace(
-        created=created,
-        updated=updated,
-        duedate=duedate,
-        issue=issue,
-        extra=extra,
-        todo=todo,
-        todo_extra=todo_extra,
-        mr=mr,
-        mr_extra=mr_extra,
-        project=project,
-    )
 
 
 SERVICE_CLASS = GitlabService
@@ -369,21 +381,21 @@ class TestGitlabClient:
         assert expected_base_url == http_client._base_url()
 
     @responses.activate
-    def test_get_repo(self, client, data):
-        responses.get('https://my-git.org/api/v4/projects/8', json=data.project)
+    def test_get_repo(self, client, project):
+        responses.get('https://my-git.org/api/v4/projects/8', json=project)
         result = client.get_repo_cached(repo_id=8)
-        assert result == data.project
+        assert result == project
 
     @responses.activate
-    def test_get_repos(self, client, data):
+    def test_get_repos(self, client, project):
         responses.get(
             'https://my-git.org/api/v4/projects?simple=True&archived=False&page=1&per_page=100',
-            json=[data.project],
+            json=[project],
         )
         responses.get(
             'https://my-git.org/api/v4/projects'
             + '?simple=True&archived=False&membership=True&page=1&per_page=100',
-            json=[data.project],
+            json=[project],
         )
         responses.get(
             'https://my-git.org/api/v4/projects'
@@ -393,18 +405,16 @@ class TestGitlabClient:
         responses.get(
             'https://my-git.org/api/v4/projects/'
             + 'arbitrary_namespace%2Farbitrary_project?simple=true',
-            json=data.project,
+            json=project,
         )
-        responses.get(
-            'https://my-git.org/api/v4/projects/8?simple=true', json=data.project
-        )
+        responses.get('https://my-git.org/api/v4/projects/8?simple=true', json=project)
         responses.get(
             'https://my-git.org/api/v4/projects/non_existing?simple=true', json=[]
         )
         responses.get(
             'https://my-git.org/api/v4/projects'
             + '?simple=True&membership=True&owned=False&page=1&per_page=100',
-            json=[data.project],
+            json=[project],
         )
         responses.get(
             'https://my-git.org/api/v4/projects'
@@ -415,12 +425,12 @@ class TestGitlabClient:
         result = client.get_repos(
             include_repos=[], only_membership=False, only_owned=False
         )
-        assert result == [data.project]
+        assert result == [project]
 
         result = client.get_repos(
             include_repos=[], only_membership=True, only_owned=False
         )
-        assert result == [data.project]
+        assert result == [project]
 
         result = client.get_repos(
             include_repos=[], only_membership=True, only_owned=True
@@ -432,12 +442,12 @@ class TestGitlabClient:
             only_membership=False,
             only_owned=False,
         )
-        assert result == [data.project]
+        assert result == [project]
 
         result = client.get_repos(
             include_repos=['id:8'], only_membership=False, only_owned=False
         )
-        assert result == [data.project]
+        assert result == [project]
 
         # A repo that cannot be fetched is skipped rather than included.
         result = client.get_repos(
@@ -446,55 +456,53 @@ class TestGitlabClient:
         assert result == []
 
     @responses.activate
-    def test_get_notes(self, client, data):
+    def test_get_notes(self, client, issue):
         responses.get(
             'https://my-git.org/api/v4/projects/8/issues/3/notes?page=1&per_page=100',
             json=[{'author': {'username': 'john_smith'}, 'body': 'Some comment.'}],
         )
         expected = [{'author': {'username': 'john_smith'}, 'body': 'Some comment.'}]
-        result = client.get_notes(data.issue['project_id'], 'issues', data.issue['iid'])
+        result = client.get_notes(issue['project_id'], 'issues', issue['iid'])
         assert result == expected
 
     @responses.activate
-    def test_get_repo_issues(self, client, data):
+    def test_get_repo_issues(self, client, issue):
         responses.get(
             'https://my-git.org/api/v4/projects/8/issues?state=opened&page=1&per_page=100',
-            json=[data.issue],
+            json=[issue],
         )
-        assert client.get_repo_issues(data.issue['project_id']) == {
-            data.issue['id']: (data.issue['project_id'], data.issue)
+        assert client.get_repo_issues(issue['project_id']) == {
+            issue['id']: (issue['project_id'], issue)
         }
 
     @responses.activate
-    def test_get_repo_merge_requests(self, client, data):
+    def test_get_repo_merge_requests(self, client, issue, mr):
         responses.get(
             'https://my-git.org/api/v4/projects/8/merge_requests?state=opened&page=1&per_page=100',
-            json=[data.mr],
+            json=[mr],
         )
-        assert client.get_repo_merge_requests(data.issue['project_id']) == {
-            data.mr['id']: (data.issue['project_id'], data.mr)
+        assert client.get_repo_merge_requests(issue['project_id']) == {
+            mr['id']: (issue['project_id'], mr)
         }
 
     @responses.activate
-    def test_get_issues_from_query(self, client, data):
+    def test_get_issues_from_query(self, client, issue):
         responses.get(
             'https://my-git.org/api/v4/'
             + 'issues?assignee_id=2&state=opened&scope=all&page=1&per_page=100',
-            json=[data.issue],
+            json=[issue],
         )
         assert client.get_issues_from_query(
             'issues?assignee_id=2&state=opened&scope=all'
-        ) == {data.issue['id']: (data.issue['project_id'], data.issue)}
+        ) == {issue['id']: (issue['project_id'], issue)}
 
     @responses.activate
-    def test_get_todos(self, client, data):
+    def test_get_todos(self, client, todo):
         responses.get(
             'https://my-git.org/api/v4/todos?state=pending&page=1&per_page=100',
-            json=[data.todo],
+            json=[todo],
         )
-        assert client.get_todos('todos?state=pending') == [
-            (data.todo['project'], data.todo)
-        ]
+        assert client.get_todos('todos?state=pending') == [(todo['project'], todo)]
 
 
 class TestGitlabService:
@@ -590,11 +598,11 @@ class TestGitlabService:
         repo = {'path_with_namespace': 'foobar/baz', 'id': 1234}
         assert self.get_service(config).filter_repos(repo)
 
-    def test_include_only_if_assigned(self, config, data):
+    def test_include_only_if_assigned(self, config, issue):
         config['myservice']['only_if_assigned'] = 'jack_smith'
-        assert self.get_service(config).include((1, data.issue))
+        assert self.get_service(config).include((1, issue))
         config['myservice']['only_if_assigned'] = 'smack_jith'
-        assert not self.get_service(config).include((1, data.issue))
+        assert not self.get_service(config).include((1, issue))
 
     def test_default_priorities(self, config):
         config['myservice'].update(
@@ -646,96 +654,96 @@ class TestGitlabService:
 
 
 class TestGitlabIssue:
-    def test_to_taskwarrior(self, service, data):
-        issue = service.get_issue_for_record(data.issue, data.extra)
+    def test_to_taskwarrior(self, service, issue, extra):
+        gitlab_issue = service.get_issue_for_record(issue, extra)
 
         expected_output = {
-            'project': data.extra['project'],
+            'project': extra['project'],
             'priority': service.config.default_priority,
             'annotations': [],
             'tags': [],
-            'due': data.duedate.replace(microsecond=0),
-            'entry': data.created.replace(microsecond=0),
-            issue.URL: data.extra['issue_url'],
-            issue.REPO: 'project',
-            issue.STATE: data.issue['state'],
-            issue.TYPE: data.extra['type'],
-            issue.TITLE: data.issue['title'],
-            issue.NUMBER: str(data.issue['iid']),
-            issue.UPDATED_AT: data.updated.replace(microsecond=0),
-            issue.CREATED_AT: data.created.replace(microsecond=0),
-            issue.DUEDATE: data.duedate,
-            issue.DESCRIPTION: data.issue['description'],
-            issue.MILESTONE: data.issue['milestone']['title'],
-            issue.UPVOTES: 0,
-            issue.DOWNVOTES: 0,
-            issue.WORK_IN_PROGRESS: 1,
-            issue.AUTHOR: 'john_smith',
-            issue.ASSIGNEE: 'jack_smith',
-            issue.NAMESPACE: 'arbitrary_namespace',
-            issue.WEIGHT: 3,
+            'due': DUEDATE.replace(microsecond=0),
+            'entry': CREATED.replace(microsecond=0),
+            gitlab_issue.URL: extra['issue_url'],
+            gitlab_issue.REPO: 'project',
+            gitlab_issue.STATE: issue['state'],
+            gitlab_issue.TYPE: extra['type'],
+            gitlab_issue.TITLE: issue['title'],
+            gitlab_issue.NUMBER: str(issue['iid']),
+            gitlab_issue.UPDATED_AT: UPDATED.replace(microsecond=0),
+            gitlab_issue.CREATED_AT: CREATED.replace(microsecond=0),
+            gitlab_issue.DUEDATE: DUEDATE,
+            gitlab_issue.DESCRIPTION: issue['description'],
+            gitlab_issue.MILESTONE: issue['milestone']['title'],
+            gitlab_issue.UPVOTES: 0,
+            gitlab_issue.DOWNVOTES: 0,
+            gitlab_issue.WORK_IN_PROGRESS: 1,
+            gitlab_issue.AUTHOR: 'john_smith',
+            gitlab_issue.ASSIGNEE: 'jack_smith',
+            gitlab_issue.NAMESPACE: 'arbitrary_namespace',
+            gitlab_issue.WEIGHT: 3,
         }
-        actual_output = issue.to_taskwarrior()
+        actual_output = gitlab_issue.to_taskwarrior()
 
         assert actual_output == expected_output
 
-    def test_custom_issue_priority(self, data, make_service):
+    def test_custom_issue_priority(self, issue, extra, make_service):
         overrides = {'default_issue_priority': 'L'}
         service = make_service(**overrides)
-        issue = service.get_issue_for_record(data.issue, data.extra)
+        gitlab_issue = service.get_issue_for_record(issue, extra)
         expected_output = {
-            'project': data.extra['project'],
+            'project': extra['project'],
             'priority': 'L',
             'annotations': [],
             'tags': [],
-            'due': data.duedate.replace(microsecond=0),
-            'entry': data.created.replace(microsecond=0),
-            issue.URL: data.extra['issue_url'],
-            issue.REPO: 'project',
-            issue.STATE: data.issue['state'],
-            issue.TYPE: data.extra['type'],
-            issue.TITLE: data.issue['title'],
-            issue.NUMBER: str(data.issue['iid']),
-            issue.UPDATED_AT: data.updated.replace(microsecond=0),
-            issue.CREATED_AT: data.created.replace(microsecond=0),
-            issue.DUEDATE: data.duedate,
-            issue.DESCRIPTION: data.issue['description'],
-            issue.MILESTONE: data.issue['milestone']['title'],
-            issue.UPVOTES: 0,
-            issue.DOWNVOTES: 0,
-            issue.WORK_IN_PROGRESS: 1,
-            issue.AUTHOR: 'john_smith',
-            issue.ASSIGNEE: 'jack_smith',
-            issue.NAMESPACE: 'arbitrary_namespace',
-            issue.WEIGHT: 3,
+            'due': DUEDATE.replace(microsecond=0),
+            'entry': CREATED.replace(microsecond=0),
+            gitlab_issue.URL: extra['issue_url'],
+            gitlab_issue.REPO: 'project',
+            gitlab_issue.STATE: issue['state'],
+            gitlab_issue.TYPE: extra['type'],
+            gitlab_issue.TITLE: issue['title'],
+            gitlab_issue.NUMBER: str(issue['iid']),
+            gitlab_issue.UPDATED_AT: UPDATED.replace(microsecond=0),
+            gitlab_issue.CREATED_AT: CREATED.replace(microsecond=0),
+            gitlab_issue.DUEDATE: DUEDATE,
+            gitlab_issue.DESCRIPTION: issue['description'],
+            gitlab_issue.MILESTONE: issue['milestone']['title'],
+            gitlab_issue.UPVOTES: 0,
+            gitlab_issue.DOWNVOTES: 0,
+            gitlab_issue.WORK_IN_PROGRESS: 1,
+            gitlab_issue.AUTHOR: 'john_smith',
+            gitlab_issue.ASSIGNEE: 'jack_smith',
+            gitlab_issue.NAMESPACE: 'arbitrary_namespace',
+            gitlab_issue.WEIGHT: 3,
         }
-        actual_output = issue.to_taskwarrior()
+        actual_output = gitlab_issue.to_taskwarrior()
 
         assert actual_output == expected_output
 
-    def test_custom_todo_priority(self, data, make_service):
+    def test_custom_todo_priority(self, todo, todo_extra, make_service):
         overrides = {'default_todo_priority': 'H'}
         service = make_service(**overrides)
         service.import_labels_as_tags = True
-        issue = service.get_issue_for_record(data.todo, data.todo_extra)
+        issue = service.get_issue_for_record(todo, todo_extra)
         expected_output = {
-            'project': data.todo_extra['project'],
+            'project': todo_extra['project'],
             'priority': overrides['default_todo_priority'],
             'annotations': [],
             'tags': [],
             'due': None,  # currently not parsed for ToDos
-            'entry': data.created.replace(microsecond=0),
-            issue.URL: data.todo_extra['issue_url'],
+            'entry': CREATED.replace(microsecond=0),
+            issue.URL: todo_extra['issue_url'],
             issue.REPO: 'project',
-            issue.STATE: data.todo['state'],
-            issue.TYPE: data.todo_extra['type'],
+            issue.STATE: todo['state'],
+            issue.TYPE: todo_extra['type'],
             issue.TITLE: 'Todo from %s for %s'
-            % (data.todo['author']['name'], data.todo['project']['path']),
-            issue.NUMBER: str(data.todo['id']),
-            issue.UPDATED_AT: data.updated.replace(microsecond=0),
-            issue.CREATED_AT: data.created.replace(microsecond=0),
+            % (todo['author']['name'], todo['project']['path']),
+            issue.NUMBER: str(todo['id']),
+            issue.UPDATED_AT: UPDATED.replace(microsecond=0),
+            issue.CREATED_AT: CREATED.replace(microsecond=0),
             issue.DUEDATE: None,  # Currently not parsed for ToDos
-            issue.DESCRIPTION: data.todo['body'],
+            issue.DESCRIPTION: todo['body'],
             issue.MILESTONE: None,
             issue.UPVOTES: 0,
             issue.DOWNVOTES: 0,
@@ -749,81 +757,81 @@ class TestGitlabIssue:
 
         assert actual_output == expected_output
 
-    def test_custom_mr_priority(self, data, make_service):
+    def test_custom_mr_priority(self, issue, mr, mr_extra, make_service):
         overrides = {'default_mr_priority': '', 'import_labels_as_tags': True}
         service = make_service(**overrides)
-        issue = service.get_issue_for_record(data.mr, data.mr_extra)
+        gitlab_issue = service.get_issue_for_record(mr, mr_extra)
         expected_output = {
-            'project': data.mr_extra['project'],
+            'project': mr_extra['project'],
             'priority': overrides['default_mr_priority'],
             'annotations': [],
             'tags': ['feature'],
-            'due': data.duedate.replace(microsecond=0),
-            'entry': data.created.replace(microsecond=0),
-            issue.URL: data.mr_extra['issue_url'],
-            issue.REPO: 'project',
-            issue.STATE: data.mr['state'],
-            issue.TYPE: data.mr_extra['type'],
-            issue.TITLE: data.mr['title'],
-            issue.NUMBER: str(data.mr['iid']),
-            issue.UPDATED_AT: data.updated.replace(microsecond=0),
-            issue.CREATED_AT: data.created.replace(microsecond=0),
-            issue.DUEDATE: data.duedate,
-            issue.DESCRIPTION: data.mr['description'],
-            issue.MILESTONE: data.issue['milestone']['title'],
-            issue.UPVOTES: 0,
-            issue.DOWNVOTES: 0,
-            issue.WORK_IN_PROGRESS: 1,
-            issue.AUTHOR: 'john_smith',
-            issue.ASSIGNEE: 'jack_smith',
-            issue.NAMESPACE: 'arbitrary_namespace',
-            issue.WEIGHT: 3,
+            'due': DUEDATE.replace(microsecond=0),
+            'entry': CREATED.replace(microsecond=0),
+            gitlab_issue.URL: mr_extra['issue_url'],
+            gitlab_issue.REPO: 'project',
+            gitlab_issue.STATE: mr['state'],
+            gitlab_issue.TYPE: mr_extra['type'],
+            gitlab_issue.TITLE: mr['title'],
+            gitlab_issue.NUMBER: str(mr['iid']),
+            gitlab_issue.UPDATED_AT: UPDATED.replace(microsecond=0),
+            gitlab_issue.CREATED_AT: CREATED.replace(microsecond=0),
+            gitlab_issue.DUEDATE: DUEDATE,
+            gitlab_issue.DESCRIPTION: mr['description'],
+            gitlab_issue.MILESTONE: issue['milestone']['title'],
+            gitlab_issue.UPVOTES: 0,
+            gitlab_issue.DOWNVOTES: 0,
+            gitlab_issue.WORK_IN_PROGRESS: 1,
+            gitlab_issue.AUTHOR: 'john_smith',
+            gitlab_issue.ASSIGNEE: 'jack_smith',
+            gitlab_issue.NAMESPACE: 'arbitrary_namespace',
+            gitlab_issue.WEIGHT: 3,
         }
-        actual_output = issue.to_taskwarrior()
+        actual_output = gitlab_issue.to_taskwarrior()
 
         assert actual_output == expected_output
 
-    def test_work_in_progress(self, service, data):
-        data.issue['work_in_progress'] = False
-        issue = service.get_issue_for_record(data.issue, data.extra)
+    def test_work_in_progress(self, service, issue, extra):
+        issue['work_in_progress'] = False
+        gitlab_issue = service.get_issue_for_record(issue, extra)
 
         expected_output = {
-            'project': data.extra['project'],
+            'project': extra['project'],
             'priority': service.config.default_priority,
             'annotations': [],
             'tags': [],
-            'due': data.duedate.replace(microsecond=0),
-            'entry': data.created.replace(microsecond=0),
-            issue.URL: data.extra['issue_url'],
-            issue.REPO: 'project',
-            issue.STATE: data.issue['state'],
-            issue.TYPE: data.extra['type'],
-            issue.TITLE: data.issue['title'],
-            issue.NUMBER: str(data.issue['iid']),
-            issue.UPDATED_AT: data.updated.replace(microsecond=0),
-            issue.CREATED_AT: data.created.replace(microsecond=0),
-            issue.DUEDATE: data.duedate,
-            issue.DESCRIPTION: data.issue['description'],
-            issue.MILESTONE: data.issue['milestone']['title'],
-            issue.UPVOTES: 0,
-            issue.DOWNVOTES: 0,
-            issue.WORK_IN_PROGRESS: 0,
-            issue.AUTHOR: 'john_smith',
-            issue.ASSIGNEE: 'jack_smith',
-            issue.NAMESPACE: 'arbitrary_namespace',
-            issue.WEIGHT: 3,
+            'due': DUEDATE.replace(microsecond=0),
+            'entry': CREATED.replace(microsecond=0),
+            gitlab_issue.URL: extra['issue_url'],
+            gitlab_issue.REPO: 'project',
+            gitlab_issue.STATE: issue['state'],
+            gitlab_issue.TYPE: extra['type'],
+            gitlab_issue.TITLE: issue['title'],
+            gitlab_issue.NUMBER: str(issue['iid']),
+            gitlab_issue.UPDATED_AT: UPDATED.replace(microsecond=0),
+            gitlab_issue.CREATED_AT: CREATED.replace(microsecond=0),
+            gitlab_issue.DUEDATE: DUEDATE,
+            gitlab_issue.DESCRIPTION: issue['description'],
+            gitlab_issue.MILESTONE: issue['milestone']['title'],
+            gitlab_issue.UPVOTES: 0,
+            gitlab_issue.DOWNVOTES: 0,
+            gitlab_issue.WORK_IN_PROGRESS: 0,
+            gitlab_issue.AUTHOR: 'john_smith',
+            gitlab_issue.ASSIGNEE: 'jack_smith',
+            gitlab_issue.NAMESPACE: 'arbitrary_namespace',
+            gitlab_issue.WEIGHT: 3,
         }
-        actual_output = issue.to_taskwarrior()
+        actual_output = gitlab_issue.to_taskwarrior()
 
         assert actual_output == expected_output
 
     @responses.activate
-    def test_issues_from_query(self, data, make_service):
+    def test_issues_from_query(self, issue, make_service):
         overrides = {'issue_query': 'issues?state=opened'}
         service = make_service(**overrides)
         responses.get(
             'https://my-git.org/api/v4/issues?state=opened&per_page=100&page=1',
-            json=[data.issue],
+            json=[issue],
         )
         responses.get(
             'https://my-git.org/api/v4/projects/8',
@@ -839,15 +847,15 @@ class TestGitlabIssue:
             'https://my-git.org/api/v4/projects/8/issues/3/notes?page=1&per_page=100',
             json=[{'author': {'username': 'john_smith'}, 'body': 'Some comment.'}],
         )
-        issue = next(service.issues())
+        gitlab_issue = next(service.issues())
         expected = {
             'annotations': ['@john_smith - Some comment.'],
             'description': '(bw)Is#3 - Add user settings .. example.com/issues/3',
-            'due': data.duedate,
-            'entry': data.created,
+            'due': DUEDATE,
+            'entry': CREATED,
             'gitlabassignee': 'jack_smith',
             'gitlabauthor': 'john_smith',
-            'gitlabcreatedon': data.created,
+            'gitlabcreatedon': CREATED,
             'gitlabdescription': '',
             'gitlabdownvotes': 0,
             'gitlabmilestone': 'v1.0',
@@ -857,8 +865,8 @@ class TestGitlabIssue:
             'gitlabstate': 'opened',
             'gitlabtitle': 'Add user settings',
             'gitlabtype': 'issue',
-            'gitlabupdatedat': data.updated,
-            'gitlabduedate': data.duedate,
+            'gitlabupdatedat': UPDATED,
+            'gitlabduedate': DUEDATE,
             'gitlabupvotes': 0,
             'gitlaburl': 'example.com/issues/3',
             'gitlabwip': 1,
@@ -867,10 +875,10 @@ class TestGitlabIssue:
             'project': 'arbitrary_username/project',
             'tags': [],
         }
-        assert TaskConstructor(issue).get_taskwarrior_record() == expected
+        assert TaskConstructor(gitlab_issue).get_taskwarrior_record() == expected
 
     @responses.activate
-    def test_mrs_from_query(self, data, make_service):
+    def test_mrs_from_query(self, mr, make_service):
         overrides = {
             'include_issues': 'false',
             'include_todos': 'false',
@@ -880,7 +888,7 @@ class TestGitlabIssue:
         service = make_service(**overrides)
         responses.get(
             'https://my-git.org/api/v4/merge_requests?state=opened&per_page=100&page=1',
-            json=[data.mr],
+            json=[mr],
         )
         responses.get(
             'https://my-git.org/api/v4/projects/8',
@@ -897,15 +905,15 @@ class TestGitlabIssue:
             + 'merge_requests/3/notes?page=1&per_page=100',
             json=[{'author': {'username': 'john_smith'}, 'body': 'Some comment.'}],
         )
-        mr = next(service.issues())
+        gitlab_mr = next(service.issues())
         expected = {
             'annotations': ['@john_smith - Some comment.'],
             'description': '(bw)MR#3 - Add user settings .. example.com/merge_requests/3',
-            'due': data.duedate,
-            'entry': data.created,
+            'due': DUEDATE,
+            'entry': CREATED,
             'gitlabassignee': 'jack_smith',
             'gitlabauthor': 'john_smith',
-            'gitlabcreatedon': data.created,
+            'gitlabcreatedon': CREATED,
             'gitlabdescription': '',
             'gitlabdownvotes': 0,
             'gitlabmilestone': 'v1.0',
@@ -915,8 +923,8 @@ class TestGitlabIssue:
             'gitlabstate': 'opened',
             'gitlabtitle': 'Add user settings',
             'gitlabtype': 'merge_request',
-            'gitlabupdatedat': data.updated,
-            'gitlabduedate': data.duedate,
+            'gitlabupdatedat': UPDATED,
+            'gitlabduedate': DUEDATE,
             'gitlabupvotes': 0,
             'gitlaburl': 'example.com/merge_requests/3',
             'gitlabwip': 1,
@@ -925,10 +933,10 @@ class TestGitlabIssue:
             'project': 'arbitrary_username/project',
             'tags': [],
         }
-        assert TaskConstructor(mr).get_taskwarrior_record() == expected
+        assert TaskConstructor(gitlab_mr).get_taskwarrior_record() == expected
 
     @responses.activate
-    def test_todos_from_query(self, data, make_service):
+    def test_todos_from_query(self, todo, make_service):
         overrides = {
             'include_issues': 'false',
             'include_merge_requests': 'false',
@@ -938,7 +946,7 @@ class TestGitlabIssue:
         service = make_service(**overrides)
         responses.get(
             'https://my-git.org/api/v4/todos?state=pending&per_page=100&page=1',
-            json=[data.todo],
+            json=[todo],
         )
         responses.get(
             'https://my-git.org/api/v4/projects/2',
@@ -960,16 +968,16 @@ class TestGitlabIssue:
                 'path_with_namespace': 'arbitrary_namespace/project',
             },
         )
-        todo = next(service.issues())
+        gitlab_todo = next(service.issues())
         expected = {
             'annotations': [],
             'description': '(bw)# - Todo from John Smith for project .. '
             'https://my-git.org/arbitrary_username/project/issues/3',
             'due': None,
-            'entry': data.created,
+            'entry': CREATED,
             'gitlabassignee': None,
             'gitlabauthor': 'john_smith',
-            'gitlabcreatedon': data.created,
+            'gitlabcreatedon': CREATED,
             'gitlabdescription': 'Add user settings',
             'gitlabdownvotes': 0,
             'gitlabmilestone': None,
@@ -979,7 +987,7 @@ class TestGitlabIssue:
             'gitlabstate': 'pending',
             'gitlabtitle': 'Todo from John Smith for project',
             'gitlabtype': 'todo',
-            'gitlabupdatedat': data.updated,
+            'gitlabupdatedat': UPDATED,
             'gitlabduedate': None,
             'gitlabupvotes': 0,
             'gitlaburl': 'https://my-git.org/arbitrary_username/project/issues/3',
@@ -989,7 +997,7 @@ class TestGitlabIssue:
             'project': 'project',
             'tags': [],
         }
-        assert TaskConstructor(todo).get_taskwarrior_record() == expected
+        assert TaskConstructor(gitlab_todo).get_taskwarrior_record() == expected
 
         overrides = {
             'include_issues': 'false',
@@ -999,11 +1007,11 @@ class TestGitlabIssue:
             'include_all_todos': 'false',
         }
         service = make_service(**overrides)
-        todo = next(service.issues())
-        assert TaskConstructor(todo).get_taskwarrior_record() == expected
+        gitlab_todo = next(service.issues())
+        assert TaskConstructor(gitlab_todo).get_taskwarrior_record() == expected
 
     @responses.activate
-    def test_issues(self, service, data):
+    def test_issues(self, service, issue):
         responses.get(
             'https://my-git.org/api/v4/projects?simple=True&archived=False&per_page=100&page=1',
             json=[
@@ -1019,7 +1027,7 @@ class TestGitlabIssue:
 
         responses.get(
             'https://my-git.org/api/v4/projects/8/issues?state=opened&per_page=100&page=1',
-            json=[data.issue],
+            json=[issue],
         )
 
         responses.get(
@@ -1027,16 +1035,16 @@ class TestGitlabIssue:
             json=[{'author': {'username': 'john_smith'}, 'body': 'Some comment.'}],
         )
 
-        issue = next(service.issues())
+        gitlab_issue = next(service.issues())
 
         expected = {
             'annotations': ['@john_smith - Some comment.'],
             'description': '(bw)Is#3 - Add user settings .. example.com/issues/3',
-            'due': data.duedate,
-            'entry': data.created,
+            'due': DUEDATE,
+            'entry': CREATED,
             'gitlabassignee': 'jack_smith',
             'gitlabauthor': 'john_smith',
-            'gitlabcreatedon': data.created,
+            'gitlabcreatedon': CREATED,
             'gitlabdescription': '',
             'gitlabdownvotes': 0,
             'gitlabmilestone': 'v1.0',
@@ -1046,8 +1054,8 @@ class TestGitlabIssue:
             'gitlabstate': 'opened',
             'gitlabtitle': 'Add user settings',
             'gitlabtype': 'issue',
-            'gitlabupdatedat': data.updated,
-            'gitlabduedate': data.duedate,
+            'gitlabupdatedat': UPDATED,
+            'gitlabduedate': DUEDATE,
             'gitlabupvotes': 0,
             'gitlaburl': 'example.com/issues/3',
             'gitlabwip': 1,
@@ -1057,7 +1065,7 @@ class TestGitlabIssue:
             'tags': [],
         }
 
-        assert TaskConstructor(issue).get_taskwarrior_record() == expected
+        assert TaskConstructor(gitlab_issue).get_taskwarrior_record() == expected
 
     @responses.activate
     def test_only_if_assigned_user_lookup(self, make_service):
@@ -1080,7 +1088,7 @@ class TestGitlabIssue:
         # Should not raise an error
         service = make_service(**overrides)
 
-        # Verify service was created successfully
+        # Verify service was CREATED successfully
         assert service is not None
 
     @responses.activate

--- a/tests/services/test_gitlab.py
+++ b/tests/services/test_gitlab.py
@@ -4,10 +4,10 @@ from types import SimpleNamespace
 import pytest
 import responses
 
-from bugwarrior.collect import TaskConstructor, get_service_instances
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.gitlab import GitlabClient, GitlabService
 
-from ..base import validate
+from ..base import get_validated_service, validate
 from .base import get_mock_service
 
 
@@ -309,6 +309,14 @@ def data():
     )
 
 
+SERVICE_CONFIG = {
+    'service': 'gitlab',
+    'host': 'my-git.org',
+    'login': 'arbitrary_login',
+    'token': 'arbitrary_token',
+}
+
+
 class TestGitlabClient:
     @pytest.fixture
     def client(self):
@@ -524,8 +532,7 @@ class TestGitlabService:
         }
 
     def get_service(self, config):
-        conf = validate(config)
-        service = get_service_instances(conf)[0]
+        service = get_validated_service(config)
         service.gitlab_client.repo_cache = {
             1: {'id': 1, 'path_with_namespace': 'arbitrary_namespace/arbitrary_project'}
         }
@@ -658,16 +665,9 @@ class TestGitlabService:
 
 
 class TestGitlabIssue:
-    SERVICE_CONFIG = {
-        'service': 'gitlab',
-        'host': 'my-git.org',
-        'login': 'arbitrary_login',
-        'token': 'arbitrary_token',
-    }
-
     @pytest.fixture
     def service(self):
-        return get_mock_service(GitlabService, self.SERVICE_CONFIG)
+        return get_mock_service(GitlabService, SERVICE_CONFIG)
 
     def test_to_taskwarrior(self, service, data):
         issue = service.get_issue_for_record(data.arbitrary_issue, data.arbitrary_extra)
@@ -704,7 +704,7 @@ class TestGitlabIssue:
 
     def test_custom_issue_priority(self, data):
         overrides = {'default_issue_priority': 'L'}
-        service = get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
+        service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
         issue = service.get_issue_for_record(data.arbitrary_issue, data.arbitrary_extra)
         expected_output = {
             'project': data.arbitrary_extra['project'],
@@ -738,7 +738,7 @@ class TestGitlabIssue:
 
     def test_custom_todo_priority(self, data):
         overrides = {'default_todo_priority': 'H'}
-        service = get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
+        service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
         service.import_labels_as_tags = True
         issue = service.get_issue_for_record(
             data.arbitrary_todo, data.arbitrary_todo_extra
@@ -779,7 +779,7 @@ class TestGitlabIssue:
 
     def test_custom_mr_priority(self, data):
         overrides = {'default_mr_priority': '', 'import_labels_as_tags': True}
-        service = get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
+        service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
         issue = service.get_issue_for_record(data.arbitrary_mr, data.arbitrary_mr_extra)
         expected_output = {
             'project': data.arbitrary_mr_extra['project'],
@@ -848,7 +848,7 @@ class TestGitlabIssue:
     @responses.activate
     def test_issues_from_query(self, data):
         overrides = {'issue_query': 'issues?state=opened'}
-        service = get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
+        service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
         responses.get(
             'https://my-git.org/api/v4/issues?state=opened&per_page=100&page=1',
             json=[data.arbitrary_issue],
@@ -905,7 +905,7 @@ class TestGitlabIssue:
             'include_merge_requests': 'true',
             'merge_request_query': 'merge_requests?state=opened',
         }
-        service = get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
+        service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
         responses.get(
             'https://my-git.org/api/v4/merge_requests?state=opened&per_page=100&page=1',
             json=[data.arbitrary_mr],
@@ -963,7 +963,7 @@ class TestGitlabIssue:
             'include_todos': 'true',
             'todo_query': 'todos?state=pending',
         }
-        service = get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
+        service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
         responses.get(
             'https://my-git.org/api/v4/todos?state=pending&per_page=100&page=1',
             json=[data.arbitrary_todo],
@@ -1026,7 +1026,7 @@ class TestGitlabIssue:
             'include_repos': 'arbitrary_namespace/project',
             'include_all_todos': 'false',
         }
-        service = get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
+        service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
         todo = next(service.issues())
         assert TaskConstructor(todo).get_taskwarrior_record() == expected
 
@@ -1106,7 +1106,7 @@ class TestGitlabIssue:
         overrides = {'only_if_assigned': 'jack_smith'}
 
         # Should not raise an error
-        service = get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
+        service = get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
 
         # Verify service was created successfully
         assert service is not None
@@ -1123,7 +1123,7 @@ class TestGitlabIssue:
 
         # Should exit with 1
         with pytest.raises(SystemExit) as cm:
-            get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
+            get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
         assert cm.value.code == 1
 
     @responses.activate
@@ -1152,5 +1152,5 @@ class TestGitlabIssue:
 
         # Should exit with 1
         with pytest.raises(SystemExit) as cm:
-            get_mock_service(GitlabService, {**self.SERVICE_CONFIG, **overrides})
+            get_mock_service(GitlabService, {**SERVICE_CONFIG, **overrides})
         assert cm.value.code == 1

--- a/tests/services/test_gitlab.py
+++ b/tests/services/test_gitlab.py
@@ -1088,7 +1088,7 @@ class TestGitlabIssue:
         # Should not raise an error
         service = make_service(**overrides)
 
-        # Verify service was CREATED successfully
+        # Verify service was created successfully
         assert service is not None
 
     @responses.activate

--- a/tests/services/test_gmail.py
+++ b/tests/services/test_gmail.py
@@ -129,9 +129,7 @@ class TestGmailIssue:
         }
         mock_api().users().threads().get().execute.return_value = record
         monkeypatch.setattr(gmail.GmailService, 'build_api', mock_api)
-        return get_mock_service(
-            gmail.GmailService, SERVICE_CONFIG, section='test_section'
-        )
+        return get_mock_service(gmail.GmailService, SERVICE_CONFIG)
 
     def test_config_paths(self, service):
         credentials_path = (

--- a/tests/services/test_gmail.py
+++ b/tests/services/test_gmail.py
@@ -8,10 +8,10 @@ from unittest.mock import patch
 from google.oauth2.credentials import Credentials
 import pytest
 
-from bugwarrior.collect import TaskConstructor, get_service_instances
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.services import gmail
 
-from ..base import validate
+from ..base import get_validated_service
 from .base import get_mock_service
 
 TEST_CREDENTIAL = {
@@ -21,6 +21,13 @@ TEST_CREDENTIAL = {
     "client_id": "example.apps.googleusercontent.com",
     "client_secret": "itsasecrettoeveryone",
     "scopes": ["https://www.googleapis.com/auth/gmail.readonly"],
+}
+
+
+SERVICE_CONFIG = {
+    'service': 'gmail',
+    'add_tags': 'added',
+    'login_name': 'test@example.com',
 }
 
 
@@ -36,8 +43,7 @@ class TestGmailService:
     def service(self, config, monkeypatch):
         monkeypatch.setattr(gmail.GmailService, 'build_api', mock.Mock())
 
-        conf = validate(config)
-        return get_service_instances(conf)[0]
+        return get_validated_service(config)
 
     def test_get_credentials_exists_and_valid(self, service):
         expected = Credentials(**copy(TEST_CREDENTIAL))
@@ -107,12 +113,6 @@ TEST_LABELS = [
 
 
 class TestGmailIssue:
-    SERVICE_CONFIG = {
-        'service': 'gmail',
-        'add_tags': 'added',
-        'login_name': 'test@example.com',
-    }
-
     @pytest.fixture
     def service(self, monkeypatch):
         mock_api = mock.Mock()
@@ -125,7 +125,7 @@ class TestGmailIssue:
         mock_api().users().threads().get().execute.return_value = TEST_THREAD
         monkeypatch.setattr(gmail.GmailService, 'build_api', mock_api)
         return get_mock_service(
-            gmail.GmailService, self.SERVICE_CONFIG, section='test_section'
+            gmail.GmailService, SERVICE_CONFIG, section='test_section'
         )
 
     def test_config_paths(self, service):

--- a/tests/services/test_gmail.py
+++ b/tests/services/test_gmail.py
@@ -1,4 +1,3 @@
-from copy import copy
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import pickle
@@ -14,14 +13,17 @@ from bugwarrior.services import gmail
 from ..base import get_validated_service
 from .base import get_mock_service
 
-TEST_CREDENTIAL = {
-    "token": "itsatokeneveryone",
-    "refresh_token": "itsarefreshtokeneveryone",
-    "token_uri": "https://oauth2.googleapis.com/token",
-    "client_id": "example.apps.googleusercontent.com",
-    "client_secret": "itsasecrettoeveryone",
-    "scopes": ["https://www.googleapis.com/auth/gmail.readonly"],
-}
+
+@pytest.fixture
+def credential():
+    return {
+        "token": "itsatokeneveryone",
+        "refresh_token": "itsarefreshtokeneveryone",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "client_id": "example.apps.googleusercontent.com",
+        "client_secret": "itsasecrettoeveryone",
+        "scopes": ["https://www.googleapis.com/auth/gmail.readonly"],
+    }
 
 
 SERVICE_CONFIG = {
@@ -45,16 +47,16 @@ class TestGmailService:
 
         return get_validated_service(config)
 
-    def test_get_credentials_exists_and_valid(self, service):
-        expected = Credentials(**copy(TEST_CREDENTIAL))
+    def test_get_credentials_exists_and_valid(self, service, credential):
+        expected = Credentials(**credential)
         assert expected.valid is True
         with open(service.credentials_path, "wb") as token:
             pickle.dump(expected, token)
 
         assert service.get_credentials().to_json() == expected.to_json()
 
-    def test_get_credentials_with_refresh(self, service):
-        expired_credential = Credentials(**copy(TEST_CREDENTIAL))
+    def test_get_credentials_with_refresh(self, service, credential):
+        expired_credential = Credentials(**credential)
         expired_credential.expiry = datetime.now(timezone.utc).replace(tzinfo=None)
         assert expired_credential.valid is False
         with open(service.credentials_path, "wb") as token:
@@ -79,50 +81,53 @@ class TestGmailService:
         assert refreshed_credential.valid is True
 
 
-TEST_THREAD = {
-    "messages": [
-        {
-            "payload": {
-                "headers": [
-                    {"name": "From", "value": "Foo Bar <foobar@example.com>"},
-                    {"name": "Subject", "value": "Regarding Bugwarrior"},
-                    {"name": "To", "value": "ct@example.com"},
-                    {
-                        "name": "Message-ID",
-                        "value": "<CMCRSF+6r=x5JtW4wlRYR5qdfRq+iAtSoec5NqrHvRpvVgHbHdg@mail.gmail.com>",  # noqa: E501
-                    },
-                ],
-                "parts": [{}],
-            },
-            "snippet": "Bugwarrior is great",
-            "internalDate": 1546722467000,
-            "threadId": "1234",
-            "labelIds": ["IMPORTANT", "Label_1", "Label_43", "CATEGORY_PERSONAL"],
-            "id": "9999",
-        }
-    ],
-    "id": "1234",
-}
+@pytest.fixture
+def record():
+    return {
+        "messages": [
+            {
+                "payload": {
+                    "headers": [
+                        {"name": "From", "value": "Foo Bar <foobar@example.com>"},
+                        {"name": "Subject", "value": "Regarding Bugwarrior"},
+                        {"name": "To", "value": "ct@example.com"},
+                        {
+                            "name": "Message-ID",
+                            "value": "<CMCRSF+6r=x5JtW4wlRYR5qdfRq+iAtSoec5NqrHvRpvVgHbHdg@mail.gmail.com>",  # noqa: E501
+                        },
+                    ],
+                    "parts": [{}],
+                },
+                "snippet": "Bugwarrior is great",
+                "internalDate": 1546722467000,
+                "threadId": "1234",
+                "labelIds": ["IMPORTANT", "Label_1", "Label_43", "CATEGORY_PERSONAL"],
+                "id": "9999",
+            }
+        ],
+        "id": "1234",
+    }
 
-TEST_LABELS = [
-    {"id": "IMPORTANT", "name": "IMPORTANT"},
-    {"id": "CATEGORY_PERSONAL", "name": "CATEGORY_PERSONAL"},
-    {"id": "Label_1", "name": "sticky"},
-    {"id": "Label_43", "name": "postit"},
-]
+
+@pytest.fixture
+def labels():
+    return [
+        {"id": "IMPORTANT", "name": "IMPORTANT"},
+        {"id": "CATEGORY_PERSONAL", "name": "CATEGORY_PERSONAL"},
+        {"id": "Label_1", "name": "sticky"},
+        {"id": "Label_43", "name": "postit"},
+    ]
 
 
 class TestGmailIssue:
     @pytest.fixture
-    def service(self, monkeypatch):
+    def service(self, record, labels, monkeypatch):
         mock_api = mock.Mock()
-        mock_api().users().labels().list().execute.return_value = {
-            'labels': TEST_LABELS
-        }
+        mock_api().users().labels().list().execute.return_value = {'labels': labels}
         mock_api().users().threads().list().execute.return_value = {
-            'threads': [{'id': TEST_THREAD['id']}]
+            'threads': [{'id': record['id']}]
         }
-        mock_api().users().threads().get().execute.return_value = TEST_THREAD
+        mock_api().users().threads().get().execute.return_value = record
         monkeypatch.setattr(gmail.GmailService, 'build_api', mock_api)
         return get_mock_service(
             gmail.GmailService, SERVICE_CONFIG, section='test_section'
@@ -135,10 +140,9 @@ class TestGmailIssue:
         )
         assert Path(service.credentials_path) == credentials_path
 
-    def test_to_taskwarrior(self, service):
-        thread = TEST_THREAD
+    def test_to_taskwarrior(self, service, record):
         issue = service.get_issue_for_record(
-            thread, gmail.thread_extras(thread, service.get_labels())
+            record, gmail.thread_extras(record, service.get_labels())
         )
         expected = {
             'annotations': [],

--- a/tests/services/test_gmail.py
+++ b/tests/services/test_gmail.py
@@ -1,16 +1,18 @@
 from copy import copy
 from datetime import datetime, timedelta, timezone
-import os.path
+from pathlib import Path
 import pickle
 from unittest import mock
 from unittest.mock import patch
 
 from google.oauth2.credentials import Credentials
+import pytest
 
 from bugwarrior.collect import TaskConstructor, get_service_instances
 from bugwarrior.services import gmail
 
-from .base import ConfigTest, ServiceIssueTest
+from ..base import validate
+from .base import get_mock_service
 
 TEST_CREDENTIAL = {
     "token": "itsatokeneveryone",
@@ -22,36 +24,34 @@ TEST_CREDENTIAL = {
 }
 
 
-class TestGmailService(ConfigTest):
-    def setUp(self):
-        super().setUp()
-        self.config = {
+class TestGmailService:
+    @pytest.fixture
+    def config(self):
+        return {
             'general': {'targets': ['myservice']},
             'myservice': {'service': 'gmail'},
         }
 
-        mock_data = mock.Mock()
-        mock_data.path = self.tempdir
+    @pytest.fixture
+    def service(self, config, monkeypatch):
+        monkeypatch.setattr(gmail.GmailService, 'build_api', mock.Mock())
 
-        mock_api = mock.Mock()
-        gmail.GmailService.build_api = mock_api
+        conf = validate(config)
+        return get_service_instances(conf)[0]
 
-        conf = self.validate()
-        self.service = get_service_instances(conf)[0]
-
-    def test_get_credentials_exists_and_valid(self):
+    def test_get_credentials_exists_and_valid(self, service):
         expected = Credentials(**copy(TEST_CREDENTIAL))
         assert expected.valid is True
-        with open(self.service.credentials_path, "wb") as token:
+        with open(service.credentials_path, "wb") as token:
             pickle.dump(expected, token)
 
-        assert self.service.get_credentials().to_json() == expected.to_json()
+        assert service.get_credentials().to_json() == expected.to_json()
 
-    def test_get_credentials_with_refresh(self):
+    def test_get_credentials_with_refresh(self, service):
         expired_credential = Credentials(**copy(TEST_CREDENTIAL))
         expired_credential.expiry = datetime.now(timezone.utc).replace(tzinfo=None)
         assert expired_credential.valid is False
-        with open(self.service.credentials_path, "wb") as token:
+        with open(service.credentials_path, "wb") as token:
             pickle.dump(expired_credential, token)
 
         with patch("google.oauth2.reauth.refresh_grant") as mock_refresh_grant:
@@ -69,7 +69,7 @@ class TestGmailService(ConfigTest):
                 grant_response,
                 rapt_token,
             )
-            refreshed_credential = self.service.get_credentials()
+            refreshed_credential = service.get_credentials()
         assert refreshed_credential.valid is True
 
 
@@ -106,16 +106,15 @@ TEST_LABELS = [
 ]
 
 
-class TestGmailIssue(ServiceIssueTest):
+class TestGmailIssue:
     SERVICE_CONFIG = {
         'service': 'gmail',
         'add_tags': 'added',
         'login_name': 'test@example.com',
     }
 
-    def setUp(self):
-        super().setUp()
-
+    @pytest.fixture
+    def service(self, monkeypatch):
         mock_api = mock.Mock()
         mock_api().users().labels().list().execute.return_value = {
             'labels': TEST_LABELS
@@ -124,20 +123,22 @@ class TestGmailIssue(ServiceIssueTest):
             'threads': [{'id': TEST_THREAD['id']}]
         }
         mock_api().users().threads().get().execute.return_value = TEST_THREAD
-        gmail.GmailService.build_api = mock_api
-        self.service = self.get_mock_service(gmail.GmailService, section='test_section')
-
-    def test_config_paths(self):
-        credentials_path = os.path.join(
-            self.service.main_config.data.path,
-            'gmail_credentials_test_example_com.pickle',
+        monkeypatch.setattr(gmail.GmailService, 'build_api', mock_api)
+        return get_mock_service(
+            gmail.GmailService, self.SERVICE_CONFIG, section='test_section'
         )
-        assert self.service.credentials_path == credentials_path
 
-    def test_to_taskwarrior(self):
+    def test_config_paths(self, service):
+        credentials_path = (
+            Path(service.main_config.data.path)
+            / 'gmail_credentials_test_example_com.pickle'
+        )
+        assert Path(service.credentials_path) == credentials_path
+
+    def test_to_taskwarrior(self, service):
         thread = TEST_THREAD
-        issue = self.service.get_issue_for_record(
-            thread, gmail.thread_extras(thread, self.service.get_labels())
+        issue = service.get_issue_for_record(
+            thread, gmail.thread_extras(thread, service.get_labels())
         )
         expected = {
             'annotations': [],
@@ -159,8 +160,8 @@ class TestGmailIssue(ServiceIssueTest):
 
         assert taskwarrior == expected
 
-    def test_issues(self):
-        issue = next(self.service.issues())
+    def test_issues(self, service):
+        issue = next(service.issues())
         expected = {
             'annotations': ['@Foo Bar - Regarding Bugwarrior'],
             'entry': datetime(2019, 1, 5, 21, 7, 47, tzinfo=timezone.utc),

--- a/tests/services/test_gmail.py
+++ b/tests/services/test_gmail.py
@@ -11,7 +11,6 @@ from bugwarrior.collect import TaskConstructor
 from bugwarrior.services import gmail
 
 from ..base import get_validated_service
-from .base import get_mock_service
 
 
 @pytest.fixture
@@ -25,6 +24,8 @@ def credential():
         "scopes": ["https://www.googleapis.com/auth/gmail.readonly"],
     }
 
+
+SERVICE_CLASS = gmail.GmailService
 
 SERVICE_CONFIG = {
     'service': 'gmail',
@@ -121,7 +122,7 @@ def labels():
 
 class TestGmailIssue:
     @pytest.fixture
-    def service(self, record, labels, monkeypatch):
+    def service(self, record, labels, make_service, monkeypatch):
         mock_api = mock.Mock()
         mock_api().users().labels().list().execute.return_value = {'labels': labels}
         mock_api().users().threads().list().execute.return_value = {
@@ -129,7 +130,7 @@ class TestGmailIssue:
         }
         mock_api().users().threads().get().execute.return_value = record
         monkeypatch.setattr(gmail.GmailService, 'build_api', mock_api)
-        return get_mock_service(gmail.GmailService, SERVICE_CONFIG)
+        return make_service()
 
     def test_config_paths(self, service):
         credentials_path = (

--- a/tests/services/test_jira.py
+++ b/tests/services/test_jira.py
@@ -2,12 +2,14 @@ from collections import namedtuple
 from datetime import datetime, timezone
 from unittest import mock
 
+import pytest
+
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.config import validation
 from bugwarrior.config.load import format_config
 from bugwarrior.services.jira import JiraExtraFields, JiraService
 
-from .base import ConfigTest, ServiceIssueTest
+from .base import get_mock_service
 
 
 class FakeJiraClient:
@@ -22,10 +24,10 @@ class FakeJiraClient:
         return None
 
 
-class testJiraService(ConfigTest):
-    def setUp(self):
-        super().setUp()
-        self.config = {
+class TestJiraService:
+    @pytest.fixture
+    def config(self):
+        return {
             'general': {'targets': ['myjira']},
             'myjira': {
                 'service': 'jira',
@@ -39,19 +41,19 @@ class testJiraService(ConfigTest):
             },
         }
 
-    def test_body_length_no_limit(self):
+    def test_body_length_no_limit(self, config):
         description = "A very short issue body.  Fixes #828."
-        self.config['myjira']['body_length'] = '5'
-        formatted = format_config(self.config)
+        config['myjira']['body_length'] = '5'
+        formatted = format_config(config)
         conf = validation.validate_config(formatted, 'general', 'configpath')
         service = JiraService(conf.service_configs[0], conf.main, _skip_server=True)
         issue = mock.Mock()
         issue.record = dict(fields=dict(description=description))
         assert description[:5] == service.body(issue)
 
-    def test_body_length_limit(self):
+    def test_body_length_limit(self, config):
         description = "A very short issue body.  Fixes #828."
-        formatted = format_config(self.config)
+        formatted = format_config(config)
         conf = validation.validate_config(formatted, 'general', 'configpath')
         service = JiraService(conf.service_configs[0], conf.main, _skip_server=True)
         issue = mock.Mock()
@@ -59,7 +61,7 @@ class testJiraService(ConfigTest):
         assert description == service.body(issue)
 
 
-class TestJiraIssue(ServiceIssueTest):
+class TestJiraIssue:
     SERVICE_CONFIG = {
         'service': 'jira',
         'username': 'one',
@@ -106,13 +108,10 @@ class TestJiraIssue(ServiceIssueTest):
                     55Z,endDate=2016-09-23T16:08:00.000Z,completeDate=<null>,sequence=2322]'
     ]
 
-    def setUp(self):
-        super().setUp()
+    @pytest.fixture
+    def service(self):
         with mock.patch('jira.client.JIRA._get_json'):
-            self.service = self.get_mock_service(JiraService)
-
-    def get_mock_service(self, *args, **kwargs):
-        service = super().get_mock_service(*args, **kwargs)
+            service = get_mock_service(JiraService, self.SERVICE_CONFIG)
         service.jira = FakeJiraClient(self.arbitrary_record)
         service.sprint_field_names = ['Sprint']
         return service
@@ -122,7 +121,7 @@ class TestJiraIssue(ServiceIssueTest):
             ['jiraextra1:customfield_10000', 'jiraextra2:namedfield.valueinside']
         )
 
-    def test_to_taskwarrior(self):
+    def test_to_taskwarrior(self, service):
         arbitrary_url = 'http://one'
         arbitrary_extra = {
             'annotations': ['an annotation'],
@@ -130,9 +129,7 @@ class TestJiraIssue(ServiceIssueTest):
             'sprint_field_names': [],
         }
 
-        issue = self.service.get_issue_for_record(
-            self.arbitrary_record, arbitrary_extra
-        )
+        issue = service.get_issue_for_record(self.arbitrary_record, arbitrary_extra)
 
         expected_output = {
             'project': self.arbitrary_project,
@@ -165,7 +162,7 @@ class TestJiraIssue(ServiceIssueTest):
 
         assert actual_output == expected_output
 
-    def test_to_taskwarrior_sprint_with_goal(self):
+    def test_to_taskwarrior_sprint_with_goal(self, service):
         record_with_goal = self.arbitrary_record.copy()
         record_with_goal['fields'] = self.arbitrary_record_with_due['fields'].copy()
         record_with_goal['fields']['Sprint'] = [
@@ -176,10 +173,10 @@ class TestJiraIssue(ServiceIssueTest):
         arbitrary_url = 'http://one'
         arbitrary_extra = {
             'annotations': ['an annotation'],
-            'sprint_field_names': self.service.sprint_field_names,
+            'sprint_field_names': service.sprint_field_names,
         }
 
-        issue = self.service.get_issue_for_record(record_with_goal, arbitrary_extra)
+        issue = service.get_issue_for_record(record_with_goal, arbitrary_extra)
 
         expected_output = {
             'project': self.arbitrary_project,
@@ -210,8 +207,8 @@ class TestJiraIssue(ServiceIssueTest):
 
         assert actual_output == expected_output
 
-    def test_issues(self):
-        issue = next(self.service.issues())
+    def test_issues(self, service):
+        issue = next(service.issues())
 
         expected = {
             'annotations': [],
@@ -239,21 +236,21 @@ class TestJiraIssue(ServiceIssueTest):
 
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
-    def test_get_due(self):
-        issue = self.service.get_issue_for_record(
+    def test_get_due(self, service):
+        issue = service.get_issue_for_record(
             self.arbitrary_record_with_due,
-            extra={'sprint_field_names': self.service.sprint_field_names},
+            extra={'sprint_field_names': service.sprint_field_names},
         )
 
         assert issue.get_due() == datetime(2016, 9, 23, 16, 8, tzinfo=timezone.utc)
 
-    def test_get_due_sprint_dict_missing_end_date(self):
+    def test_get_due_sprint_dict_missing_end_date(self, service):
         record = self.arbitrary_record.copy()
         record['fields'] = self.arbitrary_record['fields'].copy()
         record['fields']['Sprint'] = [{'id': 1, 'state': 'active', 'name': 'Sprint 1'}]
 
-        issue = self.service.get_issue_for_record(
-            record, extra={'sprint_field_names': self.service.sprint_field_names}
+        issue = service.get_issue_for_record(
+            record, extra={'sprint_field_names': service.sprint_field_names}
         )
 
         assert issue.get_due() is None

--- a/tests/services/test_jira.py
+++ b/tests/services/test_jira.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 from datetime import datetime, timezone
-from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -24,35 +23,39 @@ SERVICE_CONFIG = {
 }
 
 
-@pytest.fixture
-def data():
-    estimation = 3600
-    arbitrary_id = '10'
-    arbitrary_subtask_ids = ['11', '12']
-    arbitrary_parent_id = '13'
-    arbitrary_namedfield_valueinside = 77
-    project = 'DONUT'
-    summary = 'lkjaldsfjaldf'
+ESTIMATION = 3600
+ARBITRARY_ID = '10'
+ARBITRARY_SUBTASK_IDS = ['11', '12']
+ARBITRARY_PARENT_ID = '13'
+ARBITRARY_NAMEDFIELD_VALUEINSIDE = 77
+PROJECT = 'DONUT'
+SUMMARY = 'lkjaldsfjaldf'
 
-    record = {
+
+@pytest.fixture
+def record():
+    return {
         'fields': {
             'priority': 'Blocker',
-            'summary': summary,
-            'timeestimate': estimation,
+            'summary': SUMMARY,
+            'timeestimate': ESTIMATION,
             'created': '2016-06-06T06:07:08.123-0700',
             'fixVersions': [{'name': '1.2.3'}],
             'issuetype': {'name': 'Epic'},
             'status': {'name': 'Open'},
             'subtasks': [
-                {'key': 'DONUT-%s' % subtask} for subtask in arbitrary_subtask_ids
+                {'key': 'DONUT-%s' % subtask} for subtask in ARBITRARY_SUBTASK_IDS
             ],
-            'parent': {'key': f'DONUT-{arbitrary_parent_id}'},
+            'parent': {'key': f'DONUT-{ARBITRARY_PARENT_ID}'},
             'customfield_10000': 'foo',
-            'namedfield': {'valueinside': arbitrary_namedfield_valueinside},
+            'namedfield': {'valueinside': ARBITRARY_NAMEDFIELD_VALUEINSIDE},
         },
-        'key': '%s-%s' % (project, arbitrary_id),
+        'key': '%s-%s' % (PROJECT, ARBITRARY_ID),
     }
 
+
+@pytest.fixture
+def record_with_due(record):
     record_with_due = record.copy()
     record_with_due['fields'] = record_with_due['fields'].copy()
     record_with_due['fields']['Sprint'] = [
@@ -60,14 +63,7 @@ def data():
                     state=ACTIVE,name=Sprint 1,startDate=2016-09-06T16:08:07.4\
                     55Z,endDate=2016-09-23T16:08:00.000Z,completeDate=<null>,sequence=2322]'
     ]
-
-    return SimpleNamespace(
-        estimation=estimation,
-        project=project,
-        summary=summary,
-        record=record,
-        record_with_due=record_with_due,
-    )
+    return record_with_due
 
 
 class FakeJiraClient:
@@ -121,10 +117,10 @@ class TestJiraService:
 
 class TestJiraIssue:
     @pytest.fixture
-    def service(self, data, make_service):
+    def service(self, record, make_service):
         with mock.patch('jira.client.JIRA._get_json'):
             service = make_service()
-        service.jira = FakeJiraClient(data.record)
+        service.jira = FakeJiraClient(record)
         service.sprint_field_names = ['Sprint']
         return service
 
@@ -133,7 +129,7 @@ class TestJiraIssue:
             ['jiraextra1:customfield_10000', 'jiraextra2:namedfield.valueinside']
         )
 
-    def test_to_taskwarrior(self, service, data):
+    def test_to_taskwarrior(self, service, record):
         url = 'http://one'
         extra = {
             'annotations': ['an annotation'],
@@ -141,11 +137,11 @@ class TestJiraIssue:
             'sprint_field_names': [],
         }
 
-        issue = service.get_issue_for_record(data.record, extra)
+        issue = service.get_issue_for_record(record, extra)
 
         expected_output = {
-            'project': data.project,
-            'priority': (issue.PRIORITY_MAP[data.record['fields']['priority']]),
+            'project': PROJECT,
+            'priority': (issue.PRIORITY_MAP[record['fields']['priority']]),
             'annotations': extra['annotations'],
             'due': None,
             'tags': [],
@@ -158,10 +154,10 @@ class TestJiraIssue:
             'jiraextra1': 'foo',
             'jiraextra2': 77,
             issue.URL: url,
-            issue.FOREIGN_ID: data.record['key'],
-            issue.SUMMARY: data.summary,
+            issue.FOREIGN_ID: record['key'],
+            issue.SUMMARY: SUMMARY,
             issue.DESCRIPTION: 'issue body',
-            issue.ESTIMATE: data.estimation / 60 / 60,
+            issue.ESTIMATE: ESTIMATION / 60 / 60,
         }
 
         def get_url(*args):
@@ -172,9 +168,9 @@ class TestJiraIssue:
 
         assert actual_output == expected_output
 
-    def test_to_taskwarrior_sprint_with_goal(self, service, data):
-        record_with_goal = data.record.copy()
-        record_with_goal['fields'] = data.record_with_due['fields'].copy()
+    def test_to_taskwarrior_sprint_with_goal(self, service, record, record_with_due):
+        record_with_goal = record.copy()
+        record_with_goal['fields'] = record_with_due['fields'].copy()
         record_with_goal['fields']['Sprint'] = [
             'com.atlassian.greenhopper.service.sprint.Sprint@4c9c41a5[id=2322,rapidViewId=1173,\
             state=ACTIVE,name=Sprint 1,goal=Do foo, bar, baz,startDate=2016-09-06T16:08:07.4\
@@ -189,7 +185,7 @@ class TestJiraIssue:
         issue = service.get_issue_for_record(record_with_goal, extra)
 
         expected_output = {
-            'project': data.project,
+            'project': PROJECT,
             'priority': (issue.PRIORITY_MAP[record_with_goal['fields']['priority']]),
             'annotations': extra['annotations'],
             'due': datetime(2016, 9, 23, 16, 8, tzinfo=timezone.utc),
@@ -204,9 +200,9 @@ class TestJiraIssue:
             'jiraextra2': 77,
             issue.URL: url,
             issue.FOREIGN_ID: record_with_goal['key'],
-            issue.SUMMARY: data.summary,
+            issue.SUMMARY: SUMMARY,
             issue.DESCRIPTION: None,
-            issue.ESTIMATE: data.estimation / 60 / 60,
+            issue.ESTIMATE: ESTIMATION / 60 / 60,
         }
 
         def get_url(*args):
@@ -246,21 +242,22 @@ class TestJiraIssue:
 
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
-    def test_get_due(self, service, data):
+    def test_get_due(self, service, record_with_due):
         issue = service.get_issue_for_record(
-            data.record_with_due,
-            extra={'sprint_field_names': service.sprint_field_names},
+            record_with_due, extra={'sprint_field_names': service.sprint_field_names}
         )
 
         assert issue.get_due() == datetime(2016, 9, 23, 16, 8, tzinfo=timezone.utc)
 
-    def test_get_due_sprint_dict_missing_end_date(self, service, data):
-        record = data.record.copy()
-        record['fields'] = data.record['fields'].copy()
-        record['fields']['Sprint'] = [{'id': 1, 'state': 'active', 'name': 'Sprint 1'}]
+    def test_get_due_sprint_dict_missing_end_date(self, service, record):
+        sprint_record = record.copy()
+        sprint_record['fields'] = record['fields'].copy()
+        sprint_record['fields']['Sprint'] = [
+            {'id': 1, 'state': 'active', 'name': 'Sprint 1'}
+        ]
 
         issue = service.get_issue_for_record(
-            record, extra={'sprint_field_names': service.sprint_field_names}
+            sprint_record, extra={'sprint_field_names': service.sprint_field_names}
         )
 
         assert issue.get_due() is None

--- a/tests/services/test_jira.py
+++ b/tests/services/test_jira.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -23,13 +24,59 @@ SERVICE_CONFIG = {
 }
 
 
+@pytest.fixture
+def data():
+    estimation = 3600
+    arbitrary_id = '10'
+    arbitrary_subtask_ids = ['11', '12']
+    arbitrary_parent_id = '13'
+    arbitrary_namedfield_valueinside = 77
+    project = 'DONUT'
+    summary = 'lkjaldsfjaldf'
+
+    record = {
+        'fields': {
+            'priority': 'Blocker',
+            'summary': summary,
+            'timeestimate': estimation,
+            'created': '2016-06-06T06:07:08.123-0700',
+            'fixVersions': [{'name': '1.2.3'}],
+            'issuetype': {'name': 'Epic'},
+            'status': {'name': 'Open'},
+            'subtasks': [
+                {'key': 'DONUT-%s' % subtask} for subtask in arbitrary_subtask_ids
+            ],
+            'parent': {'key': f'DONUT-{arbitrary_parent_id}'},
+            'customfield_10000': 'foo',
+            'namedfield': {'valueinside': arbitrary_namedfield_valueinside},
+        },
+        'key': '%s-%s' % (project, arbitrary_id),
+    }
+
+    record_with_due = record.copy()
+    record_with_due['fields'] = record_with_due['fields'].copy()
+    record_with_due['fields']['Sprint'] = [
+        'com.atlassian.greenhopper.service.sprint.Sprint@4c9c41a5[id=2322,rapidViewId=1173,\
+                    state=ACTIVE,name=Sprint 1,startDate=2016-09-06T16:08:07.4\
+                    55Z,endDate=2016-09-23T16:08:00.000Z,completeDate=<null>,sequence=2322]'
+    ]
+
+    return SimpleNamespace(
+        estimation=estimation,
+        project=project,
+        summary=summary,
+        record=record,
+        record_with_due=record_with_due,
+    )
+
+
 class FakeJiraClient:
-    def __init__(self, arbitrary_record):
-        self.arbitrary_record = arbitrary_record
+    def __init__(self, record):
+        self.record = record
 
     def search_issues(self, *args, **kwargs):
         Case = namedtuple('Case', ['raw', 'key'])
-        return [Case(self.arbitrary_record, self.arbitrary_record['key'])]
+        return [Case(self.record, self.record['key'])]
 
     def comments(self, *args, **kwargs):
         return None
@@ -73,46 +120,11 @@ class TestJiraService:
 
 
 class TestJiraIssue:
-    arbitrary_estimation = 3600
-    arbitrary_id = '10'
-    arbitrary_subtask_ids = ['11', '12']
-    arbitrary_parent_id = '13'
-    arbitrary_namedfield_valueinside = 77
-    arbitrary_project = 'DONUT'
-    arbitrary_summary = 'lkjaldsfjaldf'
-
-    arbitrary_record = {
-        'fields': {
-            'priority': 'Blocker',
-            'summary': arbitrary_summary,
-            'timeestimate': arbitrary_estimation,
-            'created': '2016-06-06T06:07:08.123-0700',
-            'fixVersions': [{'name': '1.2.3'}],
-            'issuetype': {'name': 'Epic'},
-            'status': {'name': 'Open'},
-            'subtasks': [
-                {'key': 'DONUT-%s' % subtask} for subtask in arbitrary_subtask_ids
-            ],
-            'parent': {'key': f'DONUT-{arbitrary_parent_id}'},
-            'customfield_10000': 'foo',
-            'namedfield': {'valueinside': arbitrary_namedfield_valueinside},
-        },
-        'key': '%s-%s' % (arbitrary_project, arbitrary_id),
-    }
-
-    arbitrary_record_with_due = arbitrary_record.copy()
-    arbitrary_record_with_due['fields'] = arbitrary_record_with_due['fields'].copy()
-    arbitrary_record_with_due['fields']['Sprint'] = [
-        'com.atlassian.greenhopper.service.sprint.Sprint@4c9c41a5[id=2322,rapidViewId=1173,\
-                    state=ACTIVE,name=Sprint 1,startDate=2016-09-06T16:08:07.4\
-                    55Z,endDate=2016-09-23T16:08:00.000Z,completeDate=<null>,sequence=2322]'
-    ]
-
     @pytest.fixture
-    def service(self):
+    def service(self, data):
         with mock.patch('jira.client.JIRA._get_json'):
             service = get_mock_service(JiraService, SERVICE_CONFIG)
-        service.jira = FakeJiraClient(self.arbitrary_record)
+        service.jira = FakeJiraClient(data.record)
         service.sprint_field_names = ['Sprint']
         return service
 
@@ -121,22 +133,20 @@ class TestJiraIssue:
             ['jiraextra1:customfield_10000', 'jiraextra2:namedfield.valueinside']
         )
 
-    def test_to_taskwarrior(self, service):
-        arbitrary_url = 'http://one'
-        arbitrary_extra = {
+    def test_to_taskwarrior(self, service, data):
+        url = 'http://one'
+        extra = {
             'annotations': ['an annotation'],
             'body': 'issue body',
             'sprint_field_names': [],
         }
 
-        issue = service.get_issue_for_record(self.arbitrary_record, arbitrary_extra)
+        issue = service.get_issue_for_record(data.record, extra)
 
         expected_output = {
-            'project': self.arbitrary_project,
-            'priority': (
-                issue.PRIORITY_MAP[self.arbitrary_record['fields']['priority']]
-            ),
-            'annotations': arbitrary_extra['annotations'],
+            'project': data.project,
+            'priority': (issue.PRIORITY_MAP[data.record['fields']['priority']]),
+            'annotations': extra['annotations'],
             'due': None,
             'tags': [],
             'entry': datetime(2016, 6, 6, 13, 7, 8, tzinfo=timezone.utc),
@@ -147,41 +157,41 @@ class TestJiraIssue:
             'jiraparent': 'DONUT-13',
             'jiraextra1': 'foo',
             'jiraextra2': 77,
-            issue.URL: arbitrary_url,
-            issue.FOREIGN_ID: self.arbitrary_record['key'],
-            issue.SUMMARY: self.arbitrary_summary,
+            issue.URL: url,
+            issue.FOREIGN_ID: data.record['key'],
+            issue.SUMMARY: data.summary,
             issue.DESCRIPTION: 'issue body',
-            issue.ESTIMATE: self.arbitrary_estimation / 60 / 60,
+            issue.ESTIMATE: data.estimation / 60 / 60,
         }
 
         def get_url(*args):
-            return arbitrary_url
+            return url
 
         with mock.patch.object(issue, 'get_url', side_effect=get_url):
             actual_output = issue.to_taskwarrior()
 
         assert actual_output == expected_output
 
-    def test_to_taskwarrior_sprint_with_goal(self, service):
-        record_with_goal = self.arbitrary_record.copy()
-        record_with_goal['fields'] = self.arbitrary_record_with_due['fields'].copy()
+    def test_to_taskwarrior_sprint_with_goal(self, service, data):
+        record_with_goal = data.record.copy()
+        record_with_goal['fields'] = data.record_with_due['fields'].copy()
         record_with_goal['fields']['Sprint'] = [
             'com.atlassian.greenhopper.service.sprint.Sprint@4c9c41a5[id=2322,rapidViewId=1173,\
             state=ACTIVE,name=Sprint 1,goal=Do foo, bar, baz,startDate=2016-09-06T16:08:07.4\
             55Z,endDate=2016-09-23T16:08:00.000Z,completeDate=<null>,sequence=2322]'
         ]
-        arbitrary_url = 'http://one'
-        arbitrary_extra = {
+        url = 'http://one'
+        extra = {
             'annotations': ['an annotation'],
             'sprint_field_names': service.sprint_field_names,
         }
 
-        issue = service.get_issue_for_record(record_with_goal, arbitrary_extra)
+        issue = service.get_issue_for_record(record_with_goal, extra)
 
         expected_output = {
-            'project': self.arbitrary_project,
+            'project': data.project,
             'priority': (issue.PRIORITY_MAP[record_with_goal['fields']['priority']]),
-            'annotations': arbitrary_extra['annotations'],
+            'annotations': extra['annotations'],
             'due': datetime(2016, 9, 23, 16, 8, tzinfo=timezone.utc),
             'tags': [],
             'entry': datetime(2016, 6, 6, 13, 7, 8, tzinfo=timezone.utc),
@@ -192,15 +202,15 @@ class TestJiraIssue:
             'jiraparent': 'DONUT-13',
             'jiraextra1': 'foo',
             'jiraextra2': 77,
-            issue.URL: arbitrary_url,
+            issue.URL: url,
             issue.FOREIGN_ID: record_with_goal['key'],
-            issue.SUMMARY: self.arbitrary_summary,
+            issue.SUMMARY: data.summary,
             issue.DESCRIPTION: None,
-            issue.ESTIMATE: self.arbitrary_estimation / 60 / 60,
+            issue.ESTIMATE: data.estimation / 60 / 60,
         }
 
         def get_url(*args):
-            return arbitrary_url
+            return url
 
         with mock.patch.object(issue, 'get_url', side_effect=get_url):
             actual_output = issue.to_taskwarrior()
@@ -236,17 +246,17 @@ class TestJiraIssue:
 
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
-    def test_get_due(self, service):
+    def test_get_due(self, service, data):
         issue = service.get_issue_for_record(
-            self.arbitrary_record_with_due,
+            data.record_with_due,
             extra={'sprint_field_names': service.sprint_field_names},
         )
 
         assert issue.get_due() == datetime(2016, 9, 23, 16, 8, tzinfo=timezone.utc)
 
-    def test_get_due_sprint_dict_missing_end_date(self, service):
-        record = self.arbitrary_record.copy()
-        record['fields'] = self.arbitrary_record['fields'].copy()
+    def test_get_due_sprint_dict_missing_end_date(self, service, data):
+        record = data.record.copy()
+        record['fields'] = data.record['fields'].copy()
         record['fields']['Sprint'] = [{'id': 1, 'state': 'active', 'name': 'Sprint 1'}]
 
         issue = service.get_issue_for_record(

--- a/tests/services/test_jira.py
+++ b/tests/services/test_jira.py
@@ -10,7 +10,7 @@ from bugwarrior.config import validation
 from bugwarrior.config.load import format_config
 from bugwarrior.services.jira import JiraExtraFields, JiraService
 
-from .base import get_mock_service
+SERVICE_CLASS = JiraService
 
 SERVICE_CONFIG = {
     'service': 'jira',
@@ -121,9 +121,9 @@ class TestJiraService:
 
 class TestJiraIssue:
     @pytest.fixture
-    def service(self, data):
+    def service(self, data, make_service):
         with mock.patch('jira.client.JIRA._get_json'):
-            service = get_mock_service(JiraService, SERVICE_CONFIG)
+            service = make_service()
         service.jira = FakeJiraClient(data.record)
         service.sprint_field_names = ['Sprint']
         return service

--- a/tests/services/test_jira.py
+++ b/tests/services/test_jira.py
@@ -56,14 +56,12 @@ def record():
 
 @pytest.fixture
 def record_with_due(record):
-    record_with_due = record.copy()
-    record_with_due['fields'] = record_with_due['fields'].copy()
-    record_with_due['fields']['Sprint'] = [
+    record['fields']['Sprint'] = [
         'com.atlassian.greenhopper.service.sprint.Sprint@4c9c41a5[id=2322,rapidViewId=1173,\
                     state=ACTIVE,name=Sprint 1,startDate=2016-09-06T16:08:07.4\
                     55Z,endDate=2016-09-23T16:08:00.000Z,completeDate=<null>,sequence=2322]'
     ]
-    return record_with_due
+    return record
 
 
 class FakeJiraClient:
@@ -168,10 +166,8 @@ class TestJiraIssue:
 
         assert actual_output == expected_output
 
-    def test_to_taskwarrior_sprint_with_goal(self, service, record, record_with_due):
-        record_with_goal = record.copy()
-        record_with_goal['fields'] = record_with_due['fields'].copy()
-        record_with_goal['fields']['Sprint'] = [
+    def test_to_taskwarrior_sprint_with_goal(self, service, record):
+        record['fields']['Sprint'] = [
             'com.atlassian.greenhopper.service.sprint.Sprint@4c9c41a5[id=2322,rapidViewId=1173,\
             state=ACTIVE,name=Sprint 1,goal=Do foo, bar, baz,startDate=2016-09-06T16:08:07.4\
             55Z,endDate=2016-09-23T16:08:00.000Z,completeDate=<null>,sequence=2322]'
@@ -182,11 +178,11 @@ class TestJiraIssue:
             'sprint_field_names': service.sprint_field_names,
         }
 
-        issue = service.get_issue_for_record(record_with_goal, extra)
+        issue = service.get_issue_for_record(record, extra)
 
         expected_output = {
             'project': PROJECT,
-            'priority': (issue.PRIORITY_MAP[record_with_goal['fields']['priority']]),
+            'priority': (issue.PRIORITY_MAP[record['fields']['priority']]),
             'annotations': extra['annotations'],
             'due': datetime(2016, 9, 23, 16, 8, tzinfo=timezone.utc),
             'tags': [],
@@ -199,7 +195,7 @@ class TestJiraIssue:
             'jiraextra1': 'foo',
             'jiraextra2': 77,
             issue.URL: url,
-            issue.FOREIGN_ID: record_with_goal['key'],
+            issue.FOREIGN_ID: record['key'],
             issue.SUMMARY: SUMMARY,
             issue.DESCRIPTION: None,
             issue.ESTIMATE: ESTIMATION / 60 / 60,
@@ -250,14 +246,10 @@ class TestJiraIssue:
         assert issue.get_due() == datetime(2016, 9, 23, 16, 8, tzinfo=timezone.utc)
 
     def test_get_due_sprint_dict_missing_end_date(self, service, record):
-        sprint_record = record.copy()
-        sprint_record['fields'] = record['fields'].copy()
-        sprint_record['fields']['Sprint'] = [
-            {'id': 1, 'state': 'active', 'name': 'Sprint 1'}
-        ]
+        record['fields']['Sprint'] = [{'id': 1, 'state': 'active', 'name': 'Sprint 1'}]
 
         issue = service.get_issue_for_record(
-            sprint_record, extra={'sprint_field_names': service.sprint_field_names}
+            record, extra={'sprint_field_names': service.sprint_field_names}
         )
 
         assert issue.get_due() is None

--- a/tests/services/test_jira.py
+++ b/tests/services/test_jira.py
@@ -86,8 +86,8 @@ class TestJiraService:
     @pytest.fixture
     def config(self):
         return {
-            'general': {'targets': ['myjira']},
-            'myjira': {
+            'general': {'targets': ['myservice']},
+            'myservice': {
                 'service': 'jira',
                 'base_uri': 'https://example.com',
                 'username': 'milou',
@@ -101,7 +101,7 @@ class TestJiraService:
 
     def test_body_length_no_limit(self, config):
         description = "A very short issue body.  Fixes #828."
-        config['myjira']['body_length'] = '5'
+        config['myservice']['body_length'] = '5'
         formatted = format_config(config)
         conf = validation.validate_config(formatted, 'general', 'configpath')
         service = JiraService(conf.service_configs[0], conf.main, _skip_server=True)

--- a/tests/services/test_jira.py
+++ b/tests/services/test_jira.py
@@ -11,6 +11,17 @@ from bugwarrior.services.jira import JiraExtraFields, JiraService
 
 from .base import get_mock_service
 
+SERVICE_CONFIG = {
+    'service': 'jira',
+    'username': 'one',
+    'base_uri': 'https://two.org',
+    'password': 'three',
+    'extra_fields': [
+        'jiraextra1:customfield_10000',
+        'jiraextra2:namedfield.valueinside',
+    ],
+}
+
 
 class FakeJiraClient:
     def __init__(self, arbitrary_record):
@@ -62,17 +73,6 @@ class TestJiraService:
 
 
 class TestJiraIssue:
-    SERVICE_CONFIG = {
-        'service': 'jira',
-        'username': 'one',
-        'base_uri': 'https://two.org',
-        'password': 'three',
-        'extra_fields': [
-            'jiraextra1:customfield_10000',
-            'jiraextra2:namedfield.valueinside',
-        ],
-    }
-
     arbitrary_estimation = 3600
     arbitrary_id = '10'
     arbitrary_subtask_ids = ['11', '12']
@@ -111,7 +111,7 @@ class TestJiraIssue:
     @pytest.fixture
     def service(self):
         with mock.patch('jira.client.JIRA._get_json'):
-            service = get_mock_service(JiraService, self.SERVICE_CONFIG)
+            service = get_mock_service(JiraService, SERVICE_CONFIG)
         service.jira = FakeJiraClient(self.arbitrary_record)
         service.sprint_field_names = ['Sprint']
         return service

--- a/tests/services/test_kanboard.py
+++ b/tests/services/test_kanboard.py
@@ -9,6 +9,13 @@ from bugwarrior.services.kanboard import KanboardService
 from ..base import validate
 from .base import get_mock_service
 
+SERVICE_CONFIG = {
+    "service": "kanboard",
+    "url": "http://example.com",
+    "username": "myuser",
+    "password": "mypass",
+}
+
 
 class TestKanboardServiceConfig:
     @pytest.fixture
@@ -46,17 +53,10 @@ class TestKanboardServiceConfig:
 
 
 class TestKanboardService:
-    SERVICE_CONFIG = {
-        "service": "kanboard",
-        "url": "http://example.com",
-        "username": "myuser",
-        "password": "mypass",
-    }
-
     @pytest.fixture
     def service(self):
         with mock.patch("bugwarrior.services.kanboard.Client"):
-            service = get_mock_service(KanboardService, self.SERVICE_CONFIG)
+            service = get_mock_service(KanboardService, SERVICE_CONFIG)
         service.client = mock.MagicMock()
         return service
 

--- a/tests/services/test_kanboard.py
+++ b/tests/services/test_kanboard.py
@@ -1,48 +1,51 @@
 from datetime import datetime, timezone
 from unittest import mock
 
+import pytest
+
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.kanboard import KanboardService
 
-from .base import ConfigTest, ServiceIssueTest
+from ..base import validate
+from .base import get_mock_service
 
 
-class TestKanboardServiceConfig(ConfigTest):
-    def setUp(self):
-        super().setUp()
-        self.config = {"general": {"targets": ["kb"]}, "kb": {"service": "kanboard"}}
+class TestKanboardServiceConfig:
+    @pytest.fixture
+    def config(self):
+        return {"general": {"targets": ["kb"]}, "kb": {"service": "kanboard"}}
 
-    def test_validate_config_required_fields(self):
-        self.config["kb"].update(
+    def test_validate_config_required_fields(self, config):
+        config["kb"].update(
             {"url": "http://example.com/", "username": "myuser", "password": "mypass"}
         )
 
-        self.validate()
+        validate(config)
 
-    def test_validate_config_no_url(self):
-        self.config["kb"].update({"username": "myuser", "password": "mypass"})
+    def test_validate_config_no_url(self, config, assert_validation_error):
+        config["kb"].update({"username": "myuser", "password": "mypass"})
 
-        self.assertValidationError('[kb]\nurl  <- Field required')
+        assert_validation_error(config, '[kb]\nurl  <- Field required')
 
-    def test_validate_config_no_username(self):
-        self.config["kb"].update({"url": "http://one.com/", "password": "mypass"})
+    def test_validate_config_no_username(self, config, assert_validation_error):
+        config["kb"].update({"url": "http://one.com/", "password": "mypass"})
 
-        self.assertValidationError('[kb]\nusername  <- Field required')
+        assert_validation_error(config, '[kb]\nusername  <- Field required')
 
-    def test_validate_config_no_password(self):
-        self.config["kb"].update({"url": "http://one.com/", "username": "myuser"})
+    def test_validate_config_no_password(self, config, assert_validation_error):
+        config["kb"].update({"url": "http://one.com/", "username": "myuser"})
 
-        self.assertValidationError('[kb]\npassword  <- Field required')
+        assert_validation_error(config, '[kb]\npassword  <- Field required')
 
-    def test_keyring_service(self):
-        self.config["kb"].update(
+    def test_keyring_service(self, config):
+        config["kb"].update(
             {"url": "http://example.com/", "username": "myuser", "password": "mypass"}
         )
-        service_config = self.validate().service_configs[0]
+        service_config = validate(config).service_configs[0]
         assert service_config.keyring_service == "kanboard://myuser@example.com"
 
 
-class TestKanboardService(ServiceIssueTest):
+class TestKanboardService:
     SERVICE_CONFIG = {
         "service": "kanboard",
         "url": "http://example.com",
@@ -50,39 +53,36 @@ class TestKanboardService(ServiceIssueTest):
         "password": "mypass",
     }
 
-    def setUp(self):
-        super().setUp()
-        with mock.patch("kanboard.Client"):
-            self.service = self.get_mock_service(KanboardService)
-
-    def get_mock_service(self, *args, **kwargs):
-        service = super().get_mock_service(*args, **kwargs)
+    @pytest.fixture
+    def service(self):
+        with mock.patch("bugwarrior.services.kanboard.Client"):
+            service = get_mock_service(KanboardService, self.SERVICE_CONFIG)
         service.client = mock.MagicMock()
         return service
 
-    def test_annotations_zero_comments(self):
+    def test_annotations_zero_comments(self, service):
         task = {"id": 1, "nb_comments": 0}
         url = "ignore"
 
-        annotations = self.service.annotations(task, url)
+        annotations = service.annotations(task, url)
 
         assert annotations == []
-        self.service.client.get_all_comments.assert_not_called()
+        service.client.get_all_comments.assert_not_called()
 
-    def test_annotations_some_comments(self):
+    def test_annotations_some_comments(self, service):
         task = {"id": 1, "nb_comments": 2}
         url = "ignore"
 
-        self.service.client.get_all_comments.return_value = [
+        service.client.get_all_comments.return_value = [
             {"name": "a", "comment": "c1"},
             {"name": "b", "comment": "c2"},
         ]
-        annotations = self.service.annotations(task, url)
+        annotations = service.annotations(task, url)
 
         assert annotations == ["@a - c1", "@b - c2"]
-        self.service.client.get_all_comments.assert_called_once_with(task_id=1)
+        service.client.get_all_comments.assert_called_once_with(task_id=1)
 
-    def test_to_taskwarrior(self):
+    def test_to_taskwarrior(self, service):
         record = {
             "project_id": "2",
             "project_name": "myproject",
@@ -100,7 +100,7 @@ class TestKanboardService(ServiceIssueTest):
             "tags": ["tag"],
         }
 
-        issue = self.service.get_issue_for_record(record, extra)
+        issue = service.get_issue_for_record(record, extra)
 
         expected_output = {
             "project": record["project_name"],
@@ -120,10 +120,10 @@ class TestKanboardService(ServiceIssueTest):
 
         assert actual_output == expected_output
 
-    def test_issues(self):
+    def test_issues(self, service):
         # Setup the fake client
-        self.service.client.get_my_projects_list.return_value = {"1": "project"}
-        self.service.client.search_tasks.return_value = [
+        service.client.get_my_projects_list.return_value = {"1": "project"}
+        service.client.search_tasks.return_value = [
             {
                 "nb_comments": "0",
                 "nb_files": "0",
@@ -147,7 +147,7 @@ class TestKanboardService(ServiceIssueTest):
                 "creator_id": "0",
             }
         ]
-        self.service.client.get_task.return_value = {
+        service.client.get_task.return_value = {
             "id": "3",
             "title": "Task #3",
             "description": "",
@@ -175,17 +175,17 @@ class TestKanboardService(ServiceIssueTest):
             "recurrence_basedate": "0",
             "url": "http://example.com?task_id=3&project_id=1",
         }
-        self.service.client.get_task_tags.return_value = {"1": "tag1", "2": "tag2"}
+        service.client.get_task_tags.return_value = {"1": "tag1", "2": "tag2"}
 
-        issue = next(self.service.issues())
+        issue = next(service.issues())
 
         # Check calls on the client
-        self.service.client.get_my_projects_list.assert_called_once_with()
-        self.service.client.search_tasks.assert_called_once_with(
-            project_id="1", query=self.service.query
+        service.client.get_my_projects_list.assert_called_once_with()
+        service.client.search_tasks.assert_called_once_with(
+            project_id="1", query=service.query
         )
-        self.service.client.get_task.assert_called_once_with(task_id="3")
-        self.service.client.get_task_tags.assert_called_once_with(task_id="3")
+        service.client.get_task.assert_called_once_with(task_id="3")
+        service.client.get_task_tags.assert_called_once_with(task_id="3")
 
         expected = {
             "description": "(bw)Is#3 - T3 .. http://example.com?task_id=3&project_id=1",

--- a/tests/services/test_kanboard.py
+++ b/tests/services/test_kanboard.py
@@ -17,35 +17,38 @@ SERVICE_CONFIG = {
 }
 
 
-class TestKanboardServiceConfig:
+class TestKanboardConfig:
     @pytest.fixture
     def config(self):
-        return {"general": {"targets": ["kb"]}, "kb": {"service": "kanboard"}}
+        return {
+            "general": {"targets": ["myservice"]},
+            "myservice": {"service": "kanboard"},
+        }
 
     def test_validate_config_required_fields(self, config):
-        config["kb"].update(
+        config["myservice"].update(
             {"url": "http://example.com/", "username": "myuser", "password": "mypass"}
         )
 
         validate(config)
 
     def test_validate_config_no_url(self, config, assert_validation_error):
-        config["kb"].update({"username": "myuser", "password": "mypass"})
+        config["myservice"].update({"username": "myuser", "password": "mypass"})
 
-        assert_validation_error(config, '[kb]\nurl  <- Field required')
+        assert_validation_error(config, '[myservice]\nurl  <- Field required')
 
     def test_validate_config_no_username(self, config, assert_validation_error):
-        config["kb"].update({"url": "http://one.com/", "password": "mypass"})
+        config["myservice"].update({"url": "http://one.com/", "password": "mypass"})
 
-        assert_validation_error(config, '[kb]\nusername  <- Field required')
+        assert_validation_error(config, '[myservice]\nusername  <- Field required')
 
     def test_validate_config_no_password(self, config, assert_validation_error):
-        config["kb"].update({"url": "http://one.com/", "username": "myuser"})
+        config["myservice"].update({"url": "http://one.com/", "username": "myuser"})
 
-        assert_validation_error(config, '[kb]\npassword  <- Field required')
+        assert_validation_error(config, '[myservice]\npassword  <- Field required')
 
     def test_keyring_service(self, config):
-        config["kb"].update(
+        config["myservice"].update(
             {"url": "http://example.com/", "username": "myuser", "password": "mypass"}
         )
         service_config = validate(config).service_configs[0]

--- a/tests/services/test_kanboard.py
+++ b/tests/services/test_kanboard.py
@@ -7,7 +7,8 @@ from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.kanboard import KanboardService
 
 from ..base import validate
-from .base import get_mock_service
+
+SERVICE_CLASS = KanboardService
 
 SERVICE_CONFIG = {
     "service": "kanboard",
@@ -57,9 +58,9 @@ class TestKanboardConfig:
 
 class TestKanboardService:
     @pytest.fixture
-    def service(self):
+    def service(self, make_service):
         with mock.patch("bugwarrior.services.kanboard.Client"):
-            service = get_mock_service(KanboardService, SERVICE_CONFIG)
+            service = make_service()
         service.client = mock.MagicMock()
         return service
 

--- a/tests/services/test_linear.py
+++ b/tests/services/test_linear.py
@@ -81,6 +81,13 @@ RESPONSE = json.loads(
 )
 
 
+SERVICE_CONFIG = {
+    "service": "linear",
+    "api_token": "abc123",
+    "import_labels_as_tags": True,
+}
+
+
 class TestLinearServiceConfig:
     @pytest.fixture
     def config(self):
@@ -129,15 +136,9 @@ class TestLinearServiceConfig:
 
 
 class TestLinearIssue:
-    SERVICE_CONFIG = {
-        "service": "linear",
-        "api_token": "abc123",
-        "import_labels_as_tags": True,
-    }
-
     @pytest.fixture
     def service(self):
-        return get_mock_service(LinearService, self.SERVICE_CONFIG)
+        return get_mock_service(LinearService, SERVICE_CONFIG)
 
     @pytest.fixture(autouse=True)
     def mock_api(self):

--- a/tests/services/test_linear.py
+++ b/tests/services/test_linear.py
@@ -1,12 +1,14 @@
 from datetime import datetime, timezone
 import json
 
+import pytest
 import responses
 
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.linear import LinearService
 
-from .base import ConfigTest, ServiceIssueTest
+from ..base import validate
+from .base import get_mock_service
 
 RESPONSE = json.loads(
     """
@@ -79,69 +81,73 @@ RESPONSE = json.loads(
 )
 
 
-class TestLinearServiceConfig(ConfigTest):
-    def setUp(self):
-        super().setUp()
-        self.config = {
-            "general": {"targets": ["linear"]},
-            "linear": {"service": "linear"},
-        }
+class TestLinearServiceConfig:
+    @pytest.fixture
+    def config(self):
+        return {"general": {"targets": ["linear"]}, "linear": {"service": "linear"}}
 
-    def test_validate_config(self):
-        self.config["linear"].update(
+    def test_validate_config(self, config):
+        config["linear"].update(
             {"only_if_assigned": "foo@bar.com", "api_token": "abc123"}
         )
 
-        self.validate()
+        validate(config)
 
-    def test_validate_config_no_api_token(self):
-        self.config["linear"].update({"only_if_assigned": "foo@bar.com"})
+    def test_validate_config_no_api_token(self, config, assert_validation_error):
+        config["linear"].update({"only_if_assigned": "foo@bar.com"})
 
-        self.assertValidationError("[linear]\napi_token  <- Field required")
+        assert_validation_error(config, "[linear]\napi_token  <- Field required")
 
-    def test_statuses_and_status_types_incompatible(self):
-        self.config["linear"].update(
+    def test_statuses_and_status_types_incompatible(
+        self, config, assert_validation_error
+    ):
+        config["linear"].update(
             {"api_token": "abc123", "statuses": "Done, Todo", "status_types": "started"}
         )
-        self.assertValidationError("statuses and status_types are incompatible")
+        assert_validation_error(config, "statuses and status_types are incompatible")
 
-    def test_status_types_defaults_when_neither_set(self):
-        self.config["linear"].update({"api_token": "abc123"})
-        conf = self.validate()
+    def test_status_types_defaults_when_neither_set(self, config):
+        config["linear"].update({"api_token": "abc123"})
+        conf = validate(config)
         assert conf.service_configs[0].status_types == [
             "backlog",
             "unstarted",
             "started",
         ]
 
-    def test_statuses_only(self):
-        self.config["linear"].update({"api_token": "abc123", "statuses": "Done, Todo"})
-        conf = self.validate()
+    def test_statuses_only(self, config):
+        config["linear"].update({"api_token": "abc123", "statuses": "Done, Todo"})
+        conf = validate(config)
         assert conf.service_configs[0].statuses == ["Done", "Todo"]
         assert conf.service_configs[0].status_types is None
 
-    def test_status_types_only(self):
-        self.config["linear"].update({"api_token": "abc123", "status_types": "started"})
-        conf = self.validate()
+    def test_status_types_only(self, config):
+        config["linear"].update({"api_token": "abc123", "status_types": "started"})
+        conf = validate(config)
         assert conf.service_configs[0].status_types == ["started"]
         assert conf.service_configs[0].statuses == []
 
 
-class TestLinearIssue(ServiceIssueTest):
+class TestLinearIssue:
     SERVICE_CONFIG = {
         "service": "linear",
         "api_token": "abc123",
         "import_labels_as_tags": True,
     }
 
-    def setUp(self):
-        super().setUp()
-        self.service = self.get_mock_service(LinearService)
-        responses.add(responses.POST, "https://api.linear.app/graphql", json=RESPONSE)
+    @pytest.fixture
+    def service(self):
+        return get_mock_service(LinearService, self.SERVICE_CONFIG)
 
-    def test_to_taskwarrior(self):
+    @pytest.fixture(autouse=True)
+    def mock_api(self):
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+            rsps.add(responses.POST, "https://api.linear.app/graphql", json=RESPONSE)
+            yield rsps
+
+    def test_to_taskwarrior(self, service):
         issue = RESPONSE["data"]["issues"]["nodes"][0]
-        issue = self.service.get_issue_for_record(issue, {})
+        issue = service.get_issue_for_record(issue, {})
 
         created_timestamp = datetime(2025, 7, 24, 17, 3, 4, 0, tzinfo=timezone.utc)
         updated_timestamp = datetime(2025, 7, 25, 17, 3, 4, 0, tzinfo=timezone.utc)
@@ -170,7 +176,7 @@ class TestLinearIssue(ServiceIssueTest):
         assert actual_output == expected_output
 
         issue = RESPONSE["data"]["issues"]["nodes"][1]
-        issue = self.service.get_issue_for_record(issue, {})
+        issue = service.get_issue_for_record(issue, {})
 
         created_timestamp = datetime(2025, 7, 24, 15, 34, 7, 0, tzinfo=timezone.utc)
         updated_timestamp = datetime(2025, 7, 24, 17, 8, 33, 0, tzinfo=timezone.utc)
@@ -198,9 +204,8 @@ class TestLinearIssue(ServiceIssueTest):
         actual_output = issue.to_taskwarrior()
         assert actual_output == expected_output
 
-    @responses.activate
-    def test_issues(self):
-        issue = next(self.service.issues())
+    def test_issues(self, service):
+        issue = next(service.issues())
         created_timestamp = datetime(2025, 7, 24, 17, 3, 4, 0, tzinfo=timezone.utc)
         updated_timestamp = datetime(2025, 7, 25, 17, 3, 4, 0, tzinfo=timezone.utc)
         closed_timestamp = datetime(2025, 7, 26, 17, 3, 4, 0, tzinfo=timezone.utc)
@@ -227,41 +232,37 @@ class TestLinearIssue(ServiceIssueTest):
         }
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
-    def test_priority_mapping(self):
-        # Linear priority integers must map onto taskwarrior's H/M/L buckets,
-        # with "No priority" (0) and a missing field both falling back to the
-        # service-wide default.
-        cases = [
+    # Linear priority integers must map onto taskwarrior's H/M/L buckets,
+    # with "No priority" (0) falling back to the service-wide default.
+    @pytest.mark.parametrize(
+        ('linear_priority', 'expected'),
+        [
             (0, "M"),  # No priority -> default_priority (M)
             (1, "H"),  # Urgent
             (2, "H"),  # High
             (3, "M"),  # Medium
             (4, "L"),  # Low
-        ]
-        for linear_priority, expected in cases:
-            with self.subTest(linear_priority=linear_priority):
-                record = {
-                    **RESPONSE["data"]["issues"]["nodes"][0],
-                    "priority": linear_priority,
-                }
-                issue = self.service.get_issue_for_record(record, {})
-                assert issue.to_taskwarrior()["priority"] == expected
+        ],
+    )
+    def test_priority_mapping(self, service, linear_priority, expected):
+        record = {**RESPONSE["data"]["issues"]["nodes"][0], "priority": linear_priority}
+        issue = service.get_issue_for_record(record, {})
+        assert issue.to_taskwarrior()["priority"] == expected
 
-        # A record without a priority key at all should also fall back.
+    def test_priority_missing(self, service):
+        # A record without a priority key at all should also fall back to the
+        # service-wide default.
         record = {
             k: v
             for k, v in RESPONSE["data"]["issues"]["nodes"][0].items()
             if k != "priority"
         }
-        issue = self.service.get_issue_for_record(record, {})
+        issue = service.get_issue_for_record(record, {})
         assert issue.to_taskwarrior()["priority"] == "M"
 
     @responses.activate
-    def test_issues_paginates(self):
-        """Drains every page when Linear signals ``hasNextPage``."""
-        # Reset the default mock registered in setUp so we can control page order.
-        responses.reset()
-
+    def test_issues_paginates(self, service):
+        """Drains every page when Linear signals hasNextPage."""
         page_one = {
             "data": {
                 "issues": {
@@ -281,7 +282,7 @@ class TestLinearIssue(ServiceIssueTest):
         responses.add(responses.POST, "https://api.linear.app/graphql", json=page_one)
         responses.add(responses.POST, "https://api.linear.app/graphql", json=page_two)
 
-        identifiers = [issue.record["identifier"] for issue in self.service.issues()]
+        identifiers = [issue.record["identifier"] for issue in service.issues()]
         assert identifiers == ["DUS-5", "DUS-1"]
 
         # Two HTTP calls were made, and the second one carried the cursor

--- a/tests/services/test_linear.py
+++ b/tests/services/test_linear.py
@@ -8,7 +8,6 @@ from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.linear import LinearService
 
 from ..base import validate
-from .base import get_mock_service
 
 RESPONSE = json.loads(
     """
@@ -81,6 +80,8 @@ RESPONSE = json.loads(
 )
 
 
+SERVICE_CLASS = LinearService
+
 SERVICE_CONFIG = {
     "service": "linear",
     "api_token": "abc123",
@@ -139,10 +140,6 @@ class TestLinearConfig:
 
 
 class TestLinearIssue:
-    @pytest.fixture
-    def service(self):
-        return get_mock_service(LinearService, SERVICE_CONFIG)
-
     @pytest.fixture(autouse=True)
     def mock_api(self):
         with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
@@ -264,8 +261,7 @@ class TestLinearIssue:
         issue = service.get_issue_for_record(record, {})
         assert issue.to_taskwarrior()["priority"] == "M"
 
-    @responses.activate
-    def test_issues_paginates(self, service):
+    def test_issues_paginates(self, service, mock_api):
         """Drains every page when Linear signals hasNextPage."""
         page_one = {
             "data": {
@@ -283,16 +279,18 @@ class TestLinearIssue:
                 }
             }
         }
-        responses.add(responses.POST, "https://api.linear.app/graphql", json=page_one)
-        responses.add(responses.POST, "https://api.linear.app/graphql", json=page_two)
+        # Replace the default single-page registration from mock_api.
+        mock_api.reset()
+        mock_api.add(responses.POST, "https://api.linear.app/graphql", json=page_one)
+        mock_api.add(responses.POST, "https://api.linear.app/graphql", json=page_two)
 
         identifiers = [issue.record["identifier"] for issue in service.issues()]
         assert identifiers == ["DUS-5", "DUS-1"]
 
         # Two HTTP calls were made, and the second one carried the cursor
         # returned by the first.
-        assert len(responses.calls) == 2
-        first_body = json.loads(responses.calls[0].request.body)
-        second_body = json.loads(responses.calls[1].request.body)
+        assert len(mock_api.calls) == 2
+        first_body = json.loads(mock_api.calls[0].request.body)
+        second_body = json.loads(mock_api.calls[1].request.body)
         assert first_body["variables"]["after"] is None
         assert second_body["variables"]["after"] == "cursor-page-2"

--- a/tests/services/test_linear.py
+++ b/tests/services/test_linear.py
@@ -88,33 +88,36 @@ SERVICE_CONFIG = {
 }
 
 
-class TestLinearServiceConfig:
+class TestLinearConfig:
     @pytest.fixture
     def config(self):
-        return {"general": {"targets": ["linear"]}, "linear": {"service": "linear"}}
+        return {
+            "general": {"targets": ["myservice"]},
+            "myservice": {"service": "linear"},
+        }
 
     def test_validate_config(self, config):
-        config["linear"].update(
+        config["myservice"].update(
             {"only_if_assigned": "foo@bar.com", "api_token": "abc123"}
         )
 
         validate(config)
 
     def test_validate_config_no_api_token(self, config, assert_validation_error):
-        config["linear"].update({"only_if_assigned": "foo@bar.com"})
+        config["myservice"].update({"only_if_assigned": "foo@bar.com"})
 
-        assert_validation_error(config, "[linear]\napi_token  <- Field required")
+        assert_validation_error(config, "[myservice]\napi_token  <- Field required")
 
     def test_statuses_and_status_types_incompatible(
         self, config, assert_validation_error
     ):
-        config["linear"].update(
+        config["myservice"].update(
             {"api_token": "abc123", "statuses": "Done, Todo", "status_types": "started"}
         )
         assert_validation_error(config, "statuses and status_types are incompatible")
 
     def test_status_types_defaults_when_neither_set(self, config):
-        config["linear"].update({"api_token": "abc123"})
+        config["myservice"].update({"api_token": "abc123"})
         conf = validate(config)
         assert conf.service_configs[0].status_types == [
             "backlog",
@@ -123,13 +126,13 @@ class TestLinearServiceConfig:
         ]
 
     def test_statuses_only(self, config):
-        config["linear"].update({"api_token": "abc123", "statuses": "Done, Todo"})
+        config["myservice"].update({"api_token": "abc123", "statuses": "Done, Todo"})
         conf = validate(config)
         assert conf.service_configs[0].statuses == ["Done", "Todo"]
         assert conf.service_configs[0].status_types is None
 
     def test_status_types_only(self, config):
-        config["linear"].update({"api_token": "abc123", "status_types": "started"})
+        config["myservice"].update({"api_token": "abc123", "status_types": "started"})
         conf = validate(config)
         assert conf.service_configs[0].status_types == ["started"]
         assert conf.service_configs[0].statuses == []

--- a/tests/services/test_logseq.py
+++ b/tests/services/test_logseq.py
@@ -2,13 +2,15 @@ import copy
 import datetime
 from unittest import mock
 
+import pytest
+
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.logseq import LogseqClient, LogseqIssue, LogseqService
 
-from .base import ServiceIssueTest
+from .base import get_mock_service
 
 
-class TestLogseqIssue(ServiceIssueTest):
+class TestLogseqIssue:
     SERVICE_CONFIG = {
         "service": "logseq",
         "host": "localhost",
@@ -75,14 +77,14 @@ class TestLogseqIssue(ServiceIssueTest):
         "format": "markdown",
     }
 
-    def setUp(self):
-        super().setUp()
+    @pytest.fixture
+    def service(self):
+        service = get_mock_service(LogseqService, self.SERVICE_CONFIG)
+        service.client = mock.MagicMock(spec=LogseqClient)
+        return service
 
-        self.service = self.get_mock_service(LogseqService)
-        self.service.client = mock.MagicMock(spec=LogseqClient)
-
-    def test_to_taskwarrior(self):
-        issue = self.service.get_issue_for_record(self.test_record, self.test_extra)
+    def test_to_taskwarrior(self, service):
+        issue = service.get_issue_for_record(self.test_record, self.test_extra)
 
         expected = {
             "annotations": [],
@@ -110,30 +112,32 @@ class TestLogseqIssue(ServiceIssueTest):
 
     def test_to_taskwarrior_with_tags(self):
         overrides = {"import_labels_as_tags": "True"}
-        service = self.get_mock_service(LogseqService, config_overrides=overrides)
+        service = get_mock_service(
+            LogseqService, self.SERVICE_CONFIG, config_overrides=overrides
+        )
         issue = service.get_issue_for_record(self.test_record, self.test_extra)
 
         actual = issue.to_taskwarrior()
         assert actual["tags"] == ["Testtagone", "TestTagTwo", "TestTagThree"]
 
-    def test_to_taskwarrior_todo(self):
+    def test_to_taskwarrior_todo(self, service):
         test_record = copy.copy(self.test_record)
         test_record["content"] = "TODO test task in todo state\n"
         test_record["marker"] = "TODO"
-        issue = self.service.get_issue_for_record(test_record, self.test_extra)
+        issue = service.get_issue_for_record(test_record, self.test_extra)
         actual = issue.to_taskwarrior()
         assert actual["status"] == "pending"
 
-    def test_to_taskwarrior_waiting(self):
+    def test_to_taskwarrior_waiting(self, service):
         test_record = copy.copy(self.test_record)
         test_record["content"] = "WAITING test task in waiting state\n"
         test_record["marker"] = "WAITING"
-        issue = self.service.get_issue_for_record(test_record, self.test_extra)
+        issue = service.get_issue_for_record(test_record, self.test_extra)
         actual = issue.to_taskwarrior()
         assert actual["status"] == "pending"
         assert actual["wait"] == LogseqIssue.SOMEDAY
 
-    def test_to_taskwarrior_dates_with_time(self):
+    def test_to_taskwarrior_dates_with_time(self, service):
         test_record = copy.copy(self.test_record)
         test_record["content"] = (
             "DOING test schedule and deadline dates with times\n"
@@ -142,7 +146,7 @@ class TestLogseqIssue(ServiceIssueTest):
         )
         print(test_record)
 
-        issue = self.service.get_issue_for_record(test_record, self.test_extra)
+        issue = service.get_issue_for_record(test_record, self.test_extra)
         actual = issue.to_taskwarrior()
 
         scheduled = datetime.datetime(year=2025, month=7, day=1, hour=12, minute=30)
@@ -152,7 +156,7 @@ class TestLogseqIssue(ServiceIssueTest):
         assert actual[issue.SCHEDULED] == scheduled
         assert actual[issue.DEADLINE] == deadline
 
-    def test_to_taskwarrior_dates_with_repeat(self):
+    def test_to_taskwarrior_dates_with_repeat(self, service):
         test_record = copy.copy(self.test_record)
         test_record["content"] = (
             "DOING test schedule and deadline dates with times\n"
@@ -161,7 +165,7 @@ class TestLogseqIssue(ServiceIssueTest):
         )
         print(test_record)
 
-        issue = self.service.get_issue_for_record(test_record, self.test_extra)
+        issue = service.get_issue_for_record(test_record, self.test_extra)
         actual = issue.to_taskwarrior()
 
         scheduled = datetime.datetime(year=2025, month=7, day=1, hour=12, minute=30)
@@ -171,11 +175,11 @@ class TestLogseqIssue(ServiceIssueTest):
         assert actual[issue.SCHEDULED] == scheduled
         assert actual[issue.DEADLINE] == deadline
 
-    def test_issues(self):
-        self.service.client.get_graph_name.return_value = self.test_extra["graph"]
-        self.service.client.get_issues.return_value = [[self.test_record]]
-        self.service.client.get_page.return_value = self.test_page
-        issue = next(self.service.issues())
+    def test_issues(self, service):
+        service.client.get_graph_name.return_value = self.test_extra["graph"]
+        service.client.get_issues.return_value = [[self.test_record]]
+        service.client.get_page.return_value = self.test_page
+        issue = next(service.issues())
 
         expected = {
             "annotations": [],

--- a/tests/services/test_logseq.py
+++ b/tests/services/test_logseq.py
@@ -1,4 +1,3 @@
-import copy
 import datetime
 from unittest import mock
 
@@ -17,8 +16,9 @@ SERVICE_CONFIG = {
 }
 
 
-class TestLogseqIssue:
-    test_record = {
+@pytest.fixture
+def record():
+    return {
         "properties": {
             "id": "67dae9ea-8e4d-4ad1-91dc-72aacc72a802",
             "duration": '{"TODO":[0,1699562197346]}',
@@ -58,13 +58,19 @@ class TestLogseqIssue:
         "refs": [{"id": 4}, {"id": 10}, {"id": 555}, {"id": 568}],
     }
 
-    test_extra = {
+
+@pytest.fixture
+def extra():
+    return {
         "baseURI": "logseq://graph/Test?block-id=",
         "graph": "Test",
         "page_title": "TestPageTitle",
     }
 
-    test_page = {
+
+@pytest.fixture
+def page():
+    return {
         "updatedAt": 1751385600000,
         "journalDay": 20250701,
         "createdAt": 1751371200000,
@@ -77,14 +83,16 @@ class TestLogseqIssue:
         "format": "markdown",
     }
 
+
+class TestLogseqIssue:
     @pytest.fixture
     def service(self):
         service = get_mock_service(LogseqService, SERVICE_CONFIG)
         service.client = mock.MagicMock(spec=LogseqClient)
         return service
 
-    def test_to_taskwarrior(self, service):
-        issue = service.get_issue_for_record(self.test_record, self.test_extra)
+    def test_to_taskwarrior(self, service, record, extra):
+        issue = service.get_issue_for_record(record, extra)
 
         expected = {
             "annotations": [],
@@ -93,14 +101,14 @@ class TestLogseqIssue:
             "wait": None,
             "status": "pending",
             "priority": "L",
-            "project": self.test_extra["graph"],
+            "project": extra["graph"],
             "tags": [],
-            issue.ID: int(self.test_record["id"]),
-            issue.UUID: self.test_record["uuid"],
-            issue.STATE: self.test_record["marker"],
+            issue.ID: int(record["id"]),
+            issue.UUID: record["uuid"],
+            issue.STATE: record["marker"],
             issue.TITLE: "Do something http://example.com/page#NotATag `#code`"
             + " #【Test tag one】 #【TestTagTwo】 #TestTagThree",
-            issue.URI: self.test_extra["baseURI"] + self.test_record["uuid"],
+            issue.URI: extra["baseURI"] + record["uuid"],
             issue.SCHEDULED: datetime.datetime(year=2025, month=7, day=1),
             issue.DEADLINE: datetime.datetime(year=2025, month=7, day=31),
             issue.PAGE: "TestPageTitle",
@@ -110,41 +118,37 @@ class TestLogseqIssue:
 
         assert actual == expected
 
-    def test_to_taskwarrior_with_tags(self):
+    def test_to_taskwarrior_with_tags(self, record, extra):
         overrides = {"import_labels_as_tags": "True"}
         service = get_mock_service(LogseqService, {**SERVICE_CONFIG, **overrides})
-        issue = service.get_issue_for_record(self.test_record, self.test_extra)
+        issue = service.get_issue_for_record(record, extra)
 
         actual = issue.to_taskwarrior()
         assert actual["tags"] == ["Testtagone", "TestTagTwo", "TestTagThree"]
 
-    def test_to_taskwarrior_todo(self, service):
-        test_record = copy.copy(self.test_record)
-        test_record["content"] = "TODO test task in todo state\n"
-        test_record["marker"] = "TODO"
-        issue = service.get_issue_for_record(test_record, self.test_extra)
+    def test_to_taskwarrior_todo(self, service, record, extra):
+        record["content"] = "TODO test task in todo state\n"
+        record["marker"] = "TODO"
+        issue = service.get_issue_for_record(record, extra)
         actual = issue.to_taskwarrior()
         assert actual["status"] == "pending"
 
-    def test_to_taskwarrior_waiting(self, service):
-        test_record = copy.copy(self.test_record)
-        test_record["content"] = "WAITING test task in waiting state\n"
-        test_record["marker"] = "WAITING"
-        issue = service.get_issue_for_record(test_record, self.test_extra)
+    def test_to_taskwarrior_waiting(self, service, record, extra):
+        record["content"] = "WAITING test task in waiting state\n"
+        record["marker"] = "WAITING"
+        issue = service.get_issue_for_record(record, extra)
         actual = issue.to_taskwarrior()
         assert actual["status"] == "pending"
         assert actual["wait"] == LogseqIssue.SOMEDAY
 
-    def test_to_taskwarrior_dates_with_time(self, service):
-        test_record = copy.copy(self.test_record)
-        test_record["content"] = (
+    def test_to_taskwarrior_dates_with_time(self, service, record, extra):
+        record["content"] = (
             "DOING test schedule and deadline dates with times\n"
             "SCHEDULED: <2025-07-01 Tue 12:30>\n"
             "DEADLINE: <2025-07-31 Thu 12:30>"
         )
-        print(test_record)
 
-        issue = service.get_issue_for_record(test_record, self.test_extra)
+        issue = service.get_issue_for_record(record, extra)
         actual = issue.to_taskwarrior()
 
         scheduled = datetime.datetime(year=2025, month=7, day=1, hour=12, minute=30)
@@ -154,16 +158,14 @@ class TestLogseqIssue:
         assert actual[issue.SCHEDULED] == scheduled
         assert actual[issue.DEADLINE] == deadline
 
-    def test_to_taskwarrior_dates_with_repeat(self, service):
-        test_record = copy.copy(self.test_record)
-        test_record["content"] = (
+    def test_to_taskwarrior_dates_with_repeat(self, service, record, extra):
+        record["content"] = (
             "DOING test schedule and deadline dates with times\n"
             "SCHEDULED: <2025-07-01 Tue 12:30 .+1d>\n"
             "DEADLINE: <2025-07-31 Thu .+1d>"
         )
-        print(test_record)
 
-        issue = service.get_issue_for_record(test_record, self.test_extra)
+        issue = service.get_issue_for_record(record, extra)
         actual = issue.to_taskwarrior()
 
         scheduled = datetime.datetime(year=2025, month=7, day=1, hour=12, minute=30)
@@ -173,32 +175,32 @@ class TestLogseqIssue:
         assert actual[issue.SCHEDULED] == scheduled
         assert actual[issue.DEADLINE] == deadline
 
-    def test_issues(self, service):
-        service.client.get_graph_name.return_value = self.test_extra["graph"]
-        service.client.get_issues.return_value = [[self.test_record]]
-        service.client.get_page.return_value = self.test_page
+    def test_issues(self, service, record, extra, page):
+        service.client.get_graph_name.return_value = extra["graph"]
+        service.client.get_issues.return_value = [[record]]
+        service.client.get_page.return_value = page
         issue = next(service.issues())
 
         expected = {
             "annotations": [],
-            "description": f"(bw)#{self.test_record['id']}"
+            "description": f"(bw)#{record['id']}"
             + " - Do something http://example.com/pag"
             + " .. "
-            + self.test_extra["baseURI"]
-            + self.test_record["uuid"],
+            + extra["baseURI"]
+            + record["uuid"],
             "due": datetime.datetime(year=2025, month=7, day=31),
             "scheduled": datetime.datetime(year=2025, month=7, day=1),
             "wait": None,
             "status": "pending",
             "priority": "L",
-            "project": self.test_extra["graph"],
+            "project": extra["graph"],
             "tags": [],
-            issue.ID: int(self.test_record["id"]),
-            issue.UUID: self.test_record["uuid"],
-            issue.STATE: self.test_record["marker"],
+            issue.ID: int(record["id"]),
+            issue.UUID: record["uuid"],
+            issue.STATE: record["marker"],
             issue.TITLE: "Do something http://example.com/page#NotATag `#code`"
             + " #【Test tag one】 #【TestTagTwo】 #TestTagThree",
-            issue.URI: self.test_extra["baseURI"] + self.test_record["uuid"],
+            issue.URI: extra["baseURI"] + record["uuid"],
             issue.SCHEDULED: datetime.datetime(year=2025, month=7, day=1),
             issue.DEADLINE: datetime.datetime(year=2025, month=7, day=31),
             issue.PAGE: "Jul 1st, 2025",

--- a/tests/services/test_logseq.py
+++ b/tests/services/test_logseq.py
@@ -182,8 +182,7 @@ class TestLogseqIssue:
         expected = {
             "annotations": [],
             "description": f"(bw)#{self.test_record['id']}"
-            + " - Do something http://example.com/page#NotATag `#code`"
-            + " #【Test tag one】 #【TestTagTwo】 #TestTagThree"
+            + " - Do something http://example.com/pag"
             + " .. "
             + self.test_extra["baseURI"]
             + self.test_record["uuid"],

--- a/tests/services/test_logseq.py
+++ b/tests/services/test_logseq.py
@@ -6,7 +6,7 @@ import pytest
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.logseq import LogseqClient, LogseqIssue, LogseqService
 
-from .base import get_mock_service
+SERVICE_CLASS = LogseqService
 
 SERVICE_CONFIG = {
     "service": "logseq",
@@ -86,8 +86,8 @@ def page():
 
 class TestLogseqIssue:
     @pytest.fixture
-    def service(self):
-        service = get_mock_service(LogseqService, SERVICE_CONFIG)
+    def service(self, make_service):
+        service = make_service()
         service.client = mock.MagicMock(spec=LogseqClient)
         return service
 
@@ -118,9 +118,9 @@ class TestLogseqIssue:
 
         assert actual == expected
 
-    def test_to_taskwarrior_with_tags(self, record, extra):
+    def test_to_taskwarrior_with_tags(self, make_service, record, extra):
         overrides = {"import_labels_as_tags": "True"}
-        service = get_mock_service(LogseqService, {**SERVICE_CONFIG, **overrides})
+        service = make_service(**overrides)
         issue = service.get_issue_for_record(record, extra)
 
         actual = issue.to_taskwarrior()

--- a/tests/services/test_logseq.py
+++ b/tests/services/test_logseq.py
@@ -112,9 +112,7 @@ class TestLogseqIssue:
 
     def test_to_taskwarrior_with_tags(self):
         overrides = {"import_labels_as_tags": "True"}
-        service = get_mock_service(
-            LogseqService, self.SERVICE_CONFIG, config_overrides=overrides
-        )
+        service = get_mock_service(LogseqService, {**self.SERVICE_CONFIG, **overrides})
         issue = service.get_issue_for_record(self.test_record, self.test_extra)
 
         actual = issue.to_taskwarrior()

--- a/tests/services/test_logseq.py
+++ b/tests/services/test_logseq.py
@@ -9,15 +9,15 @@ from bugwarrior.services.logseq import LogseqClient, LogseqIssue, LogseqService
 
 from .base import get_mock_service
 
+SERVICE_CONFIG = {
+    "service": "logseq",
+    "host": "localhost",
+    "port": 12315,
+    "token": "TESTTOKEN",
+}
+
 
 class TestLogseqIssue:
-    SERVICE_CONFIG = {
-        "service": "logseq",
-        "host": "localhost",
-        "port": 12315,
-        "token": "TESTTOKEN",
-    }
-
     test_record = {
         "properties": {
             "id": "67dae9ea-8e4d-4ad1-91dc-72aacc72a802",
@@ -79,7 +79,7 @@ class TestLogseqIssue:
 
     @pytest.fixture
     def service(self):
-        service = get_mock_service(LogseqService, self.SERVICE_CONFIG)
+        service = get_mock_service(LogseqService, SERVICE_CONFIG)
         service.client = mock.MagicMock(spec=LogseqClient)
         return service
 
@@ -112,7 +112,7 @@ class TestLogseqIssue:
 
     def test_to_taskwarrior_with_tags(self):
         overrides = {"import_labels_as_tags": "True"}
-        service = get_mock_service(LogseqService, {**self.SERVICE_CONFIG, **overrides})
+        service = get_mock_service(LogseqService, {**SERVICE_CONFIG, **overrides})
         issue = service.get_issue_for_record(self.test_record, self.test_extra)
 
         actual = issue.to_taskwarrior()

--- a/tests/services/test_pagure.py
+++ b/tests/services/test_pagure.py
@@ -29,17 +29,20 @@ def extra():
     return {'type': 'issue', 'project': 'repo', 'annotations': []}
 
 
+@pytest.fixture
+def make_service():
+    def make(**overrides):
+        return get_mock_service(PagureService, {**SERVICE_CONFIG, **overrides})
+
+    return make
+
+
+@pytest.fixture
+def service(make_service):
+    return make_service()
+
+
 class TestPagureIssue:
-    @pytest.fixture
-    def service(self):
-        return get_mock_service(PagureService, SERVICE_CONFIG)
-
-    def make_legacy_tags_service(self):
-        return get_mock_service(
-            PagureService,
-            {**SERVICE_CONFIG, 'import_tags': True, 'tag_template': 'pg_{{label}}'},
-        )
-
     def test_to_taskwarrior(self, service, record, extra):
         issue = service.get_issue_for_record(record, extra)
 
@@ -98,8 +101,10 @@ class TestPagureIssue:
         }
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
-    def test_get_tags_from_labels_uses_legacy_tag_options(self, caplog, record, extra):
-        service = self.make_legacy_tags_service()
+    def test_get_tags_from_labels_uses_legacy_tag_options(
+        self, caplog, make_service, record, extra
+    ):
+        service = make_service(import_tags=True, tag_template='pg_{{label}}')
         issue = service.get_issue_for_record(record, extra)
 
         assert issue.get_tags() == ['pg_Bug', 'pg_Needs_Work']
@@ -109,9 +114,9 @@ class TestPagureIssue:
         assert 'tag_template is deprecated in favor of label_template' in caplog.text
 
     def test_refine_record_does_not_apply_legacy_tag_template_as_field_template(
-        self, record, extra
+        self, make_service, record, extra
     ):
-        service = self.make_legacy_tags_service()
+        service = make_service(import_tags=True, tag_template='pg_{{label}}')
         issue = service.get_issue_for_record(record, extra)
 
         assert issue.config.templates == {}

--- a/tests/services/test_pagure.py
+++ b/tests/services/test_pagure.py
@@ -2,10 +2,8 @@ from bugwarrior.collect import TaskConstructor
 from bugwarrior.config import schema
 from bugwarrior.services.pagure import PagureIssue, PagureService
 
-from .base import ConfigTest
 
-
-class TestPagureIssue(ConfigTest):
+class TestPagureIssue:
     arbitrary_issue = {
         'html_url': 'https://pagure.io/repo/issue/1',
         'repo': 'repo',
@@ -32,17 +30,14 @@ class TestPagureIssue(ConfigTest):
             self.arbitrary_issue, service_config, main_config, self.arbitrary_extra
         )
 
-    def test_get_tags_from_labels_uses_legacy_tag_options(self):
+    def test_get_tags_from_labels_uses_legacy_tag_options(self, caplog):
         issue = self.get_issue()
 
         assert issue.get_tags() == ['pg_Bug', 'pg_Needs_Work']
         assert (
-            'import_tags is deprecated in favor of import_labels_as_tags'
-            in self.caplog.text
+            'import_tags is deprecated in favor of import_labels_as_tags' in caplog.text
         )
-        assert (
-            'tag_template is deprecated in favor of label_template' in self.caplog.text
-        )
+        assert 'tag_template is deprecated in favor of label_template' in caplog.text
 
     def test_refine_record_does_not_apply_legacy_tag_template_as_field_template(self):
         issue = self.get_issue()

--- a/tests/services/test_pagure.py
+++ b/tests/services/test_pagure.py
@@ -1,6 +1,14 @@
+import datetime
+
+import pytest
+import responses
+
 from bugwarrior.collect import TaskConstructor
-from bugwarrior.config import schema
-from bugwarrior.services.pagure import PagureIssue, PagureService
+from bugwarrior.services.pagure import PagureService
+
+from .base import get_mock_service
+
+SERVICE_CONFIG = {'service': 'pagure', 'base_url': 'https://pagure.io', 'repo': 'repo'}
 
 
 class TestPagureIssue:
@@ -11,27 +19,81 @@ class TestPagureIssue:
         'id': 1,
         'date_created': '0',
         'tags': ['Bug', 'Needs Work'],
+        'comments': [],
     }
-    arbitrary_extra = {'type': 'issue', 'project': 'repo'}
+    arbitrary_extra = {'type': 'issue', 'project': 'repo', 'annotations': []}
 
-    def get_issue(self):
-        service_config = PagureService.CONFIG_SCHEMA(
-            service='pagure',
-            target='pagure',
-            base_url='https://pagure.io',
-            repo='repo',
-            import_tags=True,
-            tag_template='pg_{{label}}',
+    @pytest.fixture
+    def service(self):
+        return get_mock_service(PagureService, SERVICE_CONFIG)
+
+    def make_legacy_tags_service(self):
+        return get_mock_service(
+            PagureService,
+            {**SERVICE_CONFIG, 'import_tags': True, 'tag_template': 'pg_{{label}}'},
         )
-        main_config = schema.MainSectionConfig(
-            targets=['pagure'], annotation_length=100, description_length=100
+
+    def test_to_taskwarrior(self, service):
+        issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
+
+        expected = {
+            'annotations': [],
+            'priority': 'M',
+            'project': 'repo',
+            'tags': [],
+            issue.URL: 'https://pagure.io/repo/issue/1',
+            issue.REPO: 'repo',
+            issue.TYPE: 'issue',
+            issue.TITLE: 'Hello World',
+            issue.ID: 1,
+            issue.DATE_CREATED: datetime.datetime(
+                1970, 1, 1, tzinfo=datetime.timezone.utc
+            ),
+        }
+        assert issue.to_taskwarrior() == expected
+
+    @responses.activate
+    def test_issues(self, service):
+        responses.get(
+            'https://pagure.io/api/0/repo/issues',
+            json={
+                'issues': [
+                    {
+                        'id': 1,
+                        'title': 'Hello World',
+                        'date_created': '0',
+                        'tags': ['Bug', 'Needs Work'],
+                        'comments': [],
+                    }
+                ]
+            },
         )
-        return PagureIssue(
-            self.arbitrary_issue, service_config, main_config, self.arbitrary_extra
+        responses.get(
+            'https://pagure.io/api/0/repo/pull-requests', json={'requests': []}
         )
+
+        issue = next(service.issues())
+
+        expected = {
+            'annotations': [],
+            'description': '(bw)Is#1 - Hello World .. https://pagure.io/repo/issue/1',
+            'priority': 'M',
+            'project': 'repo',
+            'tags': [],
+            issue.URL: 'https://pagure.io/repo/issue/1',
+            issue.REPO: 'repo',
+            issue.TYPE: 'issue',
+            issue.TITLE: 'Hello World',
+            issue.ID: 1,
+            issue.DATE_CREATED: datetime.datetime(
+                1970, 1, 1, tzinfo=datetime.timezone.utc
+            ),
+        }
+        assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
     def test_get_tags_from_labels_uses_legacy_tag_options(self, caplog):
-        issue = self.get_issue()
+        service = self.make_legacy_tags_service()
+        issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
 
         assert issue.get_tags() == ['pg_Bug', 'pg_Needs_Work']
         assert (
@@ -40,7 +102,8 @@ class TestPagureIssue:
         assert 'tag_template is deprecated in favor of label_template' in caplog.text
 
     def test_refine_record_does_not_apply_legacy_tag_template_as_field_template(self):
-        issue = self.get_issue()
+        service = self.make_legacy_tags_service()
+        issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
 
         assert issue.config.templates == {}
         assert TaskConstructor(issue).get_taskwarrior_record()['tags'] == [

--- a/tests/services/test_pagure.py
+++ b/tests/services/test_pagure.py
@@ -6,7 +6,7 @@ import responses
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.pagure import PagureService
 
-from .base import get_mock_service
+SERVICE_CLASS = PagureService
 
 SERVICE_CONFIG = {'service': 'pagure', 'base_url': 'https://pagure.io', 'repo': 'repo'}
 
@@ -27,19 +27,6 @@ def record():
 @pytest.fixture
 def extra():
     return {'type': 'issue', 'project': 'repo', 'annotations': []}
-
-
-@pytest.fixture
-def make_service():
-    def make(**overrides):
-        return get_mock_service(PagureService, {**SERVICE_CONFIG, **overrides})
-
-    return make
-
-
-@pytest.fixture
-def service(make_service):
-    return make_service()
 
 
 class TestPagureIssue:

--- a/tests/services/test_pagure.py
+++ b/tests/services/test_pagure.py
@@ -11,8 +11,9 @@ from .base import get_mock_service
 SERVICE_CONFIG = {'service': 'pagure', 'base_url': 'https://pagure.io', 'repo': 'repo'}
 
 
-class TestPagureIssue:
-    arbitrary_issue = {
+@pytest.fixture
+def record():
+    return {
         'html_url': 'https://pagure.io/repo/issue/1',
         'repo': 'repo',
         'title': 'Hello World',
@@ -21,8 +22,14 @@ class TestPagureIssue:
         'tags': ['Bug', 'Needs Work'],
         'comments': [],
     }
-    arbitrary_extra = {'type': 'issue', 'project': 'repo', 'annotations': []}
 
+
+@pytest.fixture
+def extra():
+    return {'type': 'issue', 'project': 'repo', 'annotations': []}
+
+
+class TestPagureIssue:
     @pytest.fixture
     def service(self):
         return get_mock_service(PagureService, SERVICE_CONFIG)
@@ -33,8 +40,8 @@ class TestPagureIssue:
             {**SERVICE_CONFIG, 'import_tags': True, 'tag_template': 'pg_{{label}}'},
         )
 
-    def test_to_taskwarrior(self, service):
-        issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
+    def test_to_taskwarrior(self, service, record, extra):
+        issue = service.get_issue_for_record(record, extra)
 
         expected = {
             'annotations': [],
@@ -91,9 +98,9 @@ class TestPagureIssue:
         }
         assert TaskConstructor(issue).get_taskwarrior_record() == expected
 
-    def test_get_tags_from_labels_uses_legacy_tag_options(self, caplog):
+    def test_get_tags_from_labels_uses_legacy_tag_options(self, caplog, record, extra):
         service = self.make_legacy_tags_service()
-        issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
+        issue = service.get_issue_for_record(record, extra)
 
         assert issue.get_tags() == ['pg_Bug', 'pg_Needs_Work']
         assert (
@@ -101,9 +108,11 @@ class TestPagureIssue:
         )
         assert 'tag_template is deprecated in favor of label_template' in caplog.text
 
-    def test_refine_record_does_not_apply_legacy_tag_template_as_field_template(self):
+    def test_refine_record_does_not_apply_legacy_tag_template_as_field_template(
+        self, record, extra
+    ):
         service = self.make_legacy_tags_service()
-        issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
+        issue = service.get_issue_for_record(record, extra)
 
         assert issue.config.templates == {}
         assert TaskConstructor(issue).get_taskwarrior_record()['tags'] == [

--- a/tests/services/test_phab.py
+++ b/tests/services/test_phab.py
@@ -7,26 +7,33 @@ from .base import get_mock_service
 SERVICE_CONFIG = {'service': 'phabricator', 'host': 'https://phabricator.example.com'}
 
 
-class TestPhabricatorIssue:
-    arbitrary_issue = {
-        "id": 42,
-        "uri": "https://phabricator.example.com/arbitrary_username/project/issues/3",
-        "title": "A phine phabricator issue",
+@pytest.fixture
+def record():
+    return {
+        'id': 42,
+        'uri': 'https://phabricator.example.com/arbitrary_username/project/issues/3',
+        'title': 'A phine phabricator issue',
     }
-    arbitrary_extra = {'type': 'issue', 'project': 'PHROJECT', 'annotations': []}
 
+
+@pytest.fixture
+def extra():
+    return {'type': 'issue', 'project': 'PHROJECT', 'annotations': []}
+
+
+class TestPhabricatorIssue:
     @pytest.fixture
     def service(self):
         return get_mock_service(PhabricatorService, SERVICE_CONFIG)
 
-    def test_to_taskwarrior(self, service):
+    def test_to_taskwarrior(self, service, record, extra):
         service.import_labels_as_tags = True
-        issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
+        issue = service.get_issue_for_record(record, extra)
 
         expected_output = {
-            issue.URL: self.arbitrary_issue['uri'],
-            issue.TYPE: self.arbitrary_extra['type'],
-            issue.TITLE: self.arbitrary_issue['title'],
+            issue.URL: record['uri'],
+            issue.TYPE: extra['type'],
+            issue.TITLE: record['title'],
             issue.OBJECT_NAME: '3',
             'project': 'PHROJECT',
             'priority': 'M',

--- a/tests/services/test_phab.py
+++ b/tests/services/test_phab.py
@@ -4,13 +4,10 @@ from bugwarrior.services.phab import PhabricatorService
 
 from .base import get_mock_service
 
+SERVICE_CONFIG = {'service': 'phabricator', 'host': 'https://phabricator.example.com'}
+
 
 class TestPhabricatorIssue:
-    SERVICE_CONFIG = {
-        'service': 'phabricator',
-        'host': 'https://phabricator.example.com',
-    }
-
     arbitrary_issue = {
         "id": 42,
         "uri": "https://phabricator.example.com/arbitrary_username/project/issues/3",
@@ -20,7 +17,7 @@ class TestPhabricatorIssue:
 
     @pytest.fixture
     def service(self):
-        return get_mock_service(PhabricatorService, self.SERVICE_CONFIG)
+        return get_mock_service(PhabricatorService, SERVICE_CONFIG)
 
     def test_to_taskwarrior(self, service):
         service.import_labels_as_tags = True

--- a/tests/services/test_phab.py
+++ b/tests/services/test_phab.py
@@ -2,7 +2,7 @@ import pytest
 
 from bugwarrior.services.phab import PhabricatorService
 
-from .base import get_mock_service
+SERVICE_CLASS = PhabricatorService
 
 SERVICE_CONFIG = {'service': 'phabricator', 'host': 'https://phabricator.example.com'}
 
@@ -22,10 +22,6 @@ def extra():
 
 
 class TestPhabricatorIssue:
-    @pytest.fixture
-    def service(self):
-        return get_mock_service(PhabricatorService, SERVICE_CONFIG)
-
     def test_to_taskwarrior(self, service, record, extra):
         service.import_labels_as_tags = True
         issue = service.get_issue_for_record(record, extra)

--- a/tests/services/test_phab.py
+++ b/tests/services/test_phab.py
@@ -1,44 +1,30 @@
-from datetime import date, datetime, timedelta, timezone
-
 import pytest
 
 from bugwarrior.services.phab import PhabricatorService
 
-from .base import ServiceIssueTest
+from .base import get_mock_service
 
 
-class TestPhabricatorIssue(ServiceIssueTest):
+class TestPhabricatorIssue:
     SERVICE_CONFIG = {
         'service': 'phabricator',
         'host': 'https://phabricator.example.com',
     }
 
-    def setUp(self):
-        super().setUp()
-        self.service = self.get_mock_service(PhabricatorService)
-        self.arbitrary_created = (
-            datetime.now(timezone.utc) - timedelta(hours=1)
-        ).replace(microsecond=0)
-        self.arbitrary_updated = datetime.now(timezone.utc).replace(microsecond=0)
-        self.arbitrary_duedate = datetime.combine(
-            date.today(), datetime.min.time(), tzinfo=timezone.utc
-        )
-        self.arbitrary_issue = {
-            "id": 42,
-            "uri": "https://phabricator.example.com/arbitrary_username/project/issues/3",
-            "title": "A phine phabricator issue",
-        }
-        self.arbitrary_extra = {
-            'type': 'issue',
-            'project': 'PHROJECT',
-            'annotations': [],
-        }
+    arbitrary_issue = {
+        "id": 42,
+        "uri": "https://phabricator.example.com/arbitrary_username/project/issues/3",
+        "title": "A phine phabricator issue",
+    }
+    arbitrary_extra = {'type': 'issue', 'project': 'PHROJECT', 'annotations': []}
 
-    def test_to_taskwarrior(self):
-        self.service.import_labels_as_tags = True
-        issue = self.service.get_issue_for_record(
-            self.arbitrary_issue, self.arbitrary_extra
-        )
+    @pytest.fixture
+    def service(self):
+        return get_mock_service(PhabricatorService, self.SERVICE_CONFIG)
+
+    def test_to_taskwarrior(self, service):
+        service.import_labels_as_tags = True
+        issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
 
         expected_output = {
             issue.URL: self.arbitrary_issue['uri'],

--- a/tests/services/test_pivotaltracker.py
+++ b/tests/services/test_pivotaltracker.py
@@ -312,7 +312,7 @@ class TestPivotalTrackerIssue:
                 '@task - status: False - Port 90',
             ],
             'description': (
-                '(bw)Story#561 - Tractor beam loses power intermittently .. '
+                '(bw)Story#561 - Tractor beam loses power intermitte .. '
                 'http://localhost/story/show/561'
             ),
             'pivotalclosed': story_date,

--- a/tests/services/test_pivotaltracker.py
+++ b/tests/services/test_pivotaltracker.py
@@ -157,6 +157,16 @@ EXTRA = {
 }
 
 
+SERVICE_CONFIG = {
+    'service': 'pivotaltracker',
+    'token': '123456',
+    'user_id': 106,
+    'account_ids': '100',
+    'import_labels_as_tags': True,
+    'import_blockers': True,
+}
+
+
 class TestPivotalTrackerServiceConfig:
     @pytest.fixture
     def config(self):
@@ -203,18 +213,9 @@ class TestPivotalTrackerServiceConfig:
 
 
 class TestPivotalTrackerIssue:
-    SERVICE_CONFIG = {
-        'service': 'pivotaltracker',
-        'token': '123456',
-        'user_id': 106,
-        'account_ids': '100',
-        'import_labels_as_tags': True,
-        'import_blockers': True,
-    }
-
     @pytest.fixture
     def service(self):
-        return get_mock_service(PivotalTrackerService, self.SERVICE_CONFIG)
+        return get_mock_service(PivotalTrackerService, SERVICE_CONFIG)
 
     @pytest.fixture(autouse=True)
     def mock_api(self):

--- a/tests/services/test_pivotaltracker.py
+++ b/tests/services/test_pivotaltracker.py
@@ -1,11 +1,13 @@
 from datetime import datetime, timezone
 
+import pytest
 import responses
 
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.pivotaltracker import PivotalTrackerService
 
-from .base import ConfigTest, ServiceIssueTest
+from ..base import validate
+from .base import get_mock_service
 
 PROJECT = {
     'account_id': 100,
@@ -155,38 +157,38 @@ EXTRA = {
 }
 
 
-class TestPivotalTrackerServiceConfig(ConfigTest):
-    def setUp(self):
-        super().setUp()
-        self.config = {
+class TestPivotalTrackerServiceConfig:
+    @pytest.fixture
+    def config(self):
+        return {
             'general': {'targets': ['pivotal']},
             'pivotal': {'service': 'pivotaltracker'},
         }
 
-    def test_validate_config(self):
-        self.config['pivotal'].update(
+    def test_validate_config(self, config):
+        config['pivotal'].update(
             {'account_ids': '12345', 'user_id': '12345', 'token': '12345'}
         )
 
-        self.validate()
+        validate(config)
 
-    def test_validate_config_no_account_ids(self):
-        self.config['pivotal'].update({'token': '123', 'user_id': '12345'})
+    def test_validate_config_no_account_ids(self, config, assert_validation_error):
+        config['pivotal'].update({'token': '123', 'user_id': '12345'})
 
-        self.assertValidationError('[pivotal]\naccount_ids  <- Field required')
+        assert_validation_error(config, '[pivotal]\naccount_ids  <- Field required')
 
-    def test_validate_config_no_user_id(self):
-        self.config['pivotal'].update({'account_ids': '12345', 'token': '123'})
+    def test_validate_config_no_user_id(self, config, assert_validation_error):
+        config['pivotal'].update({'account_ids': '12345', 'token': '123'})
 
-        self.assertValidationError('[pivotal]\nuser_id  <- Field required')
+        assert_validation_error(config, '[pivotal]\nuser_id  <- Field required')
 
-    def test_validate_config_token(self):
-        self.config['pivotal'].update({'account_ids': '12345', 'user_id': '12345'})
+    def test_validate_config_token(self, config, assert_validation_error):
+        config['pivotal'].update({'account_ids': '12345', 'user_id': '12345'})
 
-        self.assertValidationError('[pivotal]\ntoken  <- Field required')
+        assert_validation_error(config, '[pivotal]\ntoken  <- Field required')
 
-    def test_validate_config_invalid_endpoint(self):
-        self.config['pivotal'].update(
+    def test_validate_config_invalid_endpoint(self, config, assert_validation_error):
+        config['pivotal'].update(
             {
                 'account_ids': '12345',
                 'token': '123',
@@ -195,12 +197,12 @@ class TestPivotalTrackerServiceConfig(ConfigTest):
             }
         )
 
-        self.assertValidationError(
-            "[pivotal]\nversion = v1  <- Input should be 'v5' or 'edge'"
+        assert_validation_error(
+            config, "[pivotal]\nversion = v1  <- Input should be 'v5' or 'edge'"
         )
 
 
-class TestPivotalTrackerIssue(ServiceIssueTest):
+class TestPivotalTrackerIssue:
     SERVICE_CONFIG = {
         'service': 'pivotaltracker',
         'token': '123456',
@@ -210,37 +212,42 @@ class TestPivotalTrackerIssue(ServiceIssueTest):
         'import_blockers': True,
     }
 
-    def setUp(self):
-        super().setUp()
-        self.service = self.get_mock_service(PivotalTrackerService)
-        responses.add(
-            responses.GET,
-            'https://www.pivotaltracker.com/services/v5/projects?account_ids=100',
-            json=[PROJECT],
-        )
-        responses.add(
-            responses.GET,
-            'https://www.pivotaltracker.com/services/v5/projects/99/search?query=mywork:106',
-            json=QUERY,
-        )
-        responses.add(
-            responses.GET,
-            'https://www.pivotaltracker.com/services/v5/projects/99/stories/561/tasks',
-            json=TASKS,
-        )
-        responses.add(
-            responses.GET,
-            'https://www.pivotaltracker.com/services/v5/projects/99/stories/561/blockers',
-            json=BLOCKERS,
-        )
-        responses.add(
-            responses.GET,
-            'https://www.pivotaltracker.com/services/v5/projects/99/memberships',
-            json=USER,
-        )
+    @pytest.fixture
+    def service(self):
+        return get_mock_service(PivotalTrackerService, self.SERVICE_CONFIG)
 
-    def test_to_taskwarrior(self):
-        story = self.service.get_issue_for_record(STORY, EXTRA)
+    @pytest.fixture(autouse=True)
+    def mock_api(self):
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+            rsps.add(
+                responses.GET,
+                'https://www.pivotaltracker.com/services/v5/projects?account_ids=100',
+                json=[PROJECT],
+            )
+            rsps.add(
+                responses.GET,
+                'https://www.pivotaltracker.com/services/v5/projects/99/search?query=mywork:106',
+                json=QUERY,
+            )
+            rsps.add(
+                responses.GET,
+                'https://www.pivotaltracker.com/services/v5/projects/99/stories/561/tasks',
+                json=TASKS,
+            )
+            rsps.add(
+                responses.GET,
+                'https://www.pivotaltracker.com/services/v5/projects/99/stories/561/blockers',
+                json=BLOCKERS,
+            )
+            rsps.add(
+                responses.GET,
+                'https://www.pivotaltracker.com/services/v5/projects/99/memberships',
+                json=USER,
+            )
+            yield rsps
+
+    def test_to_taskwarrior(self, service):
+        story = service.get_issue_for_record(STORY, EXTRA)
 
         expected_output = {
             'annotations': [
@@ -296,9 +303,8 @@ class TestPivotalTrackerIssue(ServiceIssueTest):
         actual_output = story.to_taskwarrior()
         assert actual_output == expected_output
 
-    @responses.activate
-    def test_issues(self):
-        story = next(self.service.issues())
+    def test_issues(self, service):
+        story = next(service.issues())
         story_date = datetime(2019, 5, 14, 12, 0, tzinfo=timezone.utc)
         expected = {
             'annotations': [

--- a/tests/services/test_pivotaltracker.py
+++ b/tests/services/test_pivotaltracker.py
@@ -7,7 +7,6 @@ from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.pivotaltracker import PivotalTrackerService
 
 from ..base import validate
-from .base import get_mock_service
 
 PROJECT = {
     'account_id': 100,
@@ -157,6 +156,8 @@ EXTRA = {
 }
 
 
+SERVICE_CLASS = PivotalTrackerService
+
 SERVICE_CONFIG = {
     'service': 'pivotaltracker',
     'token': '123456',
@@ -213,10 +214,6 @@ class TestPivotalTrackerConfig:
 
 
 class TestPivotalTrackerIssue:
-    @pytest.fixture
-    def service(self):
-        return get_mock_service(PivotalTrackerService, SERVICE_CONFIG)
-
     @pytest.fixture(autouse=True)
     def mock_api(self):
         with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:

--- a/tests/services/test_pivotaltracker.py
+++ b/tests/services/test_pivotaltracker.py
@@ -167,38 +167,38 @@ SERVICE_CONFIG = {
 }
 
 
-class TestPivotalTrackerServiceConfig:
+class TestPivotalTrackerConfig:
     @pytest.fixture
     def config(self):
         return {
-            'general': {'targets': ['pivotal']},
-            'pivotal': {'service': 'pivotaltracker'},
+            'general': {'targets': ['myservice']},
+            'myservice': {'service': 'pivotaltracker'},
         }
 
     def test_validate_config(self, config):
-        config['pivotal'].update(
+        config['myservice'].update(
             {'account_ids': '12345', 'user_id': '12345', 'token': '12345'}
         )
 
         validate(config)
 
     def test_validate_config_no_account_ids(self, config, assert_validation_error):
-        config['pivotal'].update({'token': '123', 'user_id': '12345'})
+        config['myservice'].update({'token': '123', 'user_id': '12345'})
 
-        assert_validation_error(config, '[pivotal]\naccount_ids  <- Field required')
+        assert_validation_error(config, '[myservice]\naccount_ids  <- Field required')
 
     def test_validate_config_no_user_id(self, config, assert_validation_error):
-        config['pivotal'].update({'account_ids': '12345', 'token': '123'})
+        config['myservice'].update({'account_ids': '12345', 'token': '123'})
 
-        assert_validation_error(config, '[pivotal]\nuser_id  <- Field required')
+        assert_validation_error(config, '[myservice]\nuser_id  <- Field required')
 
     def test_validate_config_token(self, config, assert_validation_error):
-        config['pivotal'].update({'account_ids': '12345', 'user_id': '12345'})
+        config['myservice'].update({'account_ids': '12345', 'user_id': '12345'})
 
-        assert_validation_error(config, '[pivotal]\ntoken  <- Field required')
+        assert_validation_error(config, '[myservice]\ntoken  <- Field required')
 
     def test_validate_config_invalid_endpoint(self, config, assert_validation_error):
-        config['pivotal'].update(
+        config['myservice'].update(
             {
                 'account_ids': '12345',
                 'token': '123',
@@ -208,7 +208,7 @@ class TestPivotalTrackerServiceConfig:
         )
 
         assert_validation_error(
-            config, "[pivotal]\nversion = v1  <- Input should be 'v5' or 'edge'"
+            config, "[myservice]\nversion = v1  <- Input should be 'v5' or 'edge'"
         )
 
 

--- a/tests/services/test_redmine.py
+++ b/tests/services/test_redmine.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -17,13 +18,14 @@ SERVICE_CONFIG = {
 }
 
 
-class TestRedmineIssue:
-    arbitrary_created = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(1)
-    arbitrary_updated = datetime.now(timezone.utc).replace(microsecond=0)
-    arbitrary_issue = {
+@pytest.fixture
+def data():
+    created = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(1)
+    updated = datetime.now(timezone.utc).replace(microsecond=0)
+    record = {
         "assigned_to": {"id": 35546, "name": "Adam Coddington"},
         "author": {"id": 35546, "name": "Adam Coddington"},
-        "created_on": arbitrary_created.isoformat(),
+        "created_on": created.isoformat(),
         "due_on": "2016-12-30T16:40:29Z",
         "description": "This is a test issue.",
         "done_ratio": 0,
@@ -33,35 +35,38 @@ class TestRedmineIssue:
         "status": {"id": 1, "name": "New"},
         "subject": "Biscuits",
         "tracker": {"id": 4, "name": "Task"},
-        "updated_on": arbitrary_updated.isoformat(),
+        "updated_on": updated.isoformat(),
     }
+    return SimpleNamespace(created=created, updated=updated, record=record)
 
+
+class TestRedmineIssue:
     @pytest.fixture
     def service(self):
         return get_mock_service(RedMineService, SERVICE_CONFIG)
 
-    def test_to_taskwarrior(self, service):
+    def test_to_taskwarrior(self, service, data):
         arbitrary_url = 'http://lkjlj.com'
 
-        issue = service.get_issue_for_record(self.arbitrary_issue)
+        issue = service.get_issue_for_record(data.record)
 
         expected_output = {
             'annotations': [],
             'project': issue.get_project_name(),
             'priority': 'H',
             issue.DUEDATE: None,
-            issue.ASSIGNED_TO: self.arbitrary_issue['assigned_to']['name'],
-            issue.AUTHOR: self.arbitrary_issue['author']['name'],
+            issue.ASSIGNED_TO: data.record['assigned_to']['name'],
+            issue.AUTHOR: data.record['author']['name'],
             issue.CATEGORY: None,
-            issue.DESCRIPTION: self.arbitrary_issue['description'],
+            issue.DESCRIPTION: data.record['description'],
             issue.ESTIMATED_HOURS: None,
             issue.STATUS: 'New',
             issue.URL: arbitrary_url,
-            issue.SUBJECT: self.arbitrary_issue['subject'],
+            issue.SUBJECT: data.record['subject'],
             issue.TRACKER: 'Task',
-            issue.CREATED_ON: self.arbitrary_created,
-            issue.UPDATED_ON: self.arbitrary_updated,
-            issue.ID: self.arbitrary_issue['id'],
+            issue.CREATED_ON: data.created,
+            issue.UPDATED_ON: data.updated,
+            issue.ID: data.record['id'],
             issue.PROJECT_NAME: 'Boiled Cabbage - Yum',
             issue.SPENT_HOURS: None,
             issue.START_DATE: None,
@@ -76,10 +81,9 @@ class TestRedmineIssue:
         assert actual_output == expected_output
 
     @responses.activate
-    def test_issues(self, service):
+    def test_issues(self, service, data):
         responses.get(
-            'https://something/issues.json?limit=100',
-            json={'issues': [self.arbitrary_issue]},
+            'https://something/issues.json?limit=100', json={'issues': [data.record]}
         )
 
         issue = next(service.issues())
@@ -97,13 +101,13 @@ class TestRedmineIssue:
             'redmineassignedto': 'Adam Coddington',
             'redmineauthor': 'Adam Coddington',
             issue.CATEGORY: None,
-            issue.DESCRIPTION: self.arbitrary_issue['description'],
+            issue.DESCRIPTION: data.record['description'],
             issue.ESTIMATED_HOURS: None,
             issue.STATUS: 'New',
             'redminesubject': 'Biscuits',
             'redminetracker': 'Task',
-            issue.CREATED_ON: self.arbitrary_created,
-            issue.UPDATED_ON: self.arbitrary_updated,
+            issue.CREATED_ON: data.created,
+            issue.UPDATED_ON: data.updated,
             'redmineurl': 'https://something/issues/363901',
             'tags': [],
         }

--- a/tests/services/test_redmine.py
+++ b/tests/services/test_redmine.py
@@ -8,7 +8,7 @@ import responses
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.redmine import RedMineService
 
-from .base import get_mock_service
+SERVICE_CLASS = RedMineService
 
 SERVICE_CONFIG = {
     'service': 'redmine',
@@ -41,10 +41,6 @@ def data():
 
 
 class TestRedmineIssue:
-    @pytest.fixture
-    def service(self):
-        return get_mock_service(RedMineService, SERVICE_CONFIG)
-
     def test_to_taskwarrior(self, service, data):
         arbitrary_url = 'http://lkjlj.com'
 

--- a/tests/services/test_redmine.py
+++ b/tests/services/test_redmine.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta, timezone
-from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -18,14 +17,16 @@ SERVICE_CONFIG = {
 }
 
 
+CREATED = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(1)
+UPDATED = datetime.now(timezone.utc).replace(microsecond=0)
+
+
 @pytest.fixture
-def data():
-    created = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(1)
-    updated = datetime.now(timezone.utc).replace(microsecond=0)
-    record = {
+def record():
+    return {
         "assigned_to": {"id": 35546, "name": "Adam Coddington"},
         "author": {"id": 35546, "name": "Adam Coddington"},
-        "created_on": created.isoformat(),
+        "created_on": CREATED.isoformat(),
         "due_on": "2016-12-30T16:40:29Z",
         "description": "This is a test issue.",
         "done_ratio": 0,
@@ -35,34 +36,33 @@ def data():
         "status": {"id": 1, "name": "New"},
         "subject": "Biscuits",
         "tracker": {"id": 4, "name": "Task"},
-        "updated_on": updated.isoformat(),
+        "updated_on": UPDATED.isoformat(),
     }
-    return SimpleNamespace(created=created, updated=updated, record=record)
 
 
 class TestRedmineIssue:
-    def test_to_taskwarrior(self, service, data):
+    def test_to_taskwarrior(self, service, record):
         arbitrary_url = 'http://lkjlj.com'
 
-        issue = service.get_issue_for_record(data.record)
+        issue = service.get_issue_for_record(record)
 
         expected_output = {
             'annotations': [],
             'project': issue.get_project_name(),
             'priority': 'H',
             issue.DUEDATE: None,
-            issue.ASSIGNED_TO: data.record['assigned_to']['name'],
-            issue.AUTHOR: data.record['author']['name'],
+            issue.ASSIGNED_TO: record['assigned_to']['name'],
+            issue.AUTHOR: record['author']['name'],
             issue.CATEGORY: None,
-            issue.DESCRIPTION: data.record['description'],
+            issue.DESCRIPTION: record['description'],
             issue.ESTIMATED_HOURS: None,
             issue.STATUS: 'New',
             issue.URL: arbitrary_url,
-            issue.SUBJECT: data.record['subject'],
+            issue.SUBJECT: record['subject'],
             issue.TRACKER: 'Task',
-            issue.CREATED_ON: data.created,
-            issue.UPDATED_ON: data.updated,
-            issue.ID: data.record['id'],
+            issue.CREATED_ON: CREATED,
+            issue.UPDATED_ON: UPDATED,
+            issue.ID: record['id'],
             issue.PROJECT_NAME: 'Boiled Cabbage - Yum',
             issue.SPENT_HOURS: None,
             issue.START_DATE: None,
@@ -77,9 +77,9 @@ class TestRedmineIssue:
         assert actual_output == expected_output
 
     @responses.activate
-    def test_issues(self, service, data):
+    def test_issues(self, service, record):
         responses.get(
-            'https://something/issues.json?limit=100', json={'issues': [data.record]}
+            'https://something/issues.json?limit=100', json={'issues': [record]}
         )
 
         issue = next(service.issues())
@@ -97,13 +97,13 @@ class TestRedmineIssue:
             'redmineassignedto': 'Adam Coddington',
             'redmineauthor': 'Adam Coddington',
             issue.CATEGORY: None,
-            issue.DESCRIPTION: data.record['description'],
+            issue.DESCRIPTION: record['description'],
             issue.ESTIMATED_HOURS: None,
             issue.STATUS: 'New',
             'redminesubject': 'Biscuits',
             'redminetracker': 'Task',
-            issue.CREATED_ON: data.created,
-            issue.UPDATED_ON: data.updated,
+            issue.CREATED_ON: CREATED,
+            issue.UPDATED_ON: UPDATED,
             'redmineurl': 'https://something/issues/363901',
             'tags': [],
         }

--- a/tests/services/test_redmine.py
+++ b/tests/services/test_redmine.py
@@ -1,15 +1,16 @@
 from datetime import datetime, timedelta, timezone
 from unittest import mock
 
+import pytest
 import responses
 
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.redmine import RedMineService
 
-from .base import ServiceIssueTest
+from .base import get_mock_service
 
 
-class TestRedmineIssue(ServiceIssueTest):
+class TestRedmineIssue:
     SERVICE_CONFIG = {
         'service': 'redmine',
         'url': 'https://something',
@@ -34,14 +35,14 @@ class TestRedmineIssue(ServiceIssueTest):
         "updated_on": arbitrary_updated.isoformat(),
     }
 
-    def setUp(self):
-        super().setUp()
-        self.service = self.get_mock_service(RedMineService)
+    @pytest.fixture
+    def service(self):
+        return get_mock_service(RedMineService, self.SERVICE_CONFIG)
 
-    def test_to_taskwarrior(self):
+    def test_to_taskwarrior(self, service):
         arbitrary_url = 'http://lkjlj.com'
 
-        issue = self.service.get_issue_for_record(self.arbitrary_issue)
+        issue = service.get_issue_for_record(self.arbitrary_issue)
 
         expected_output = {
             'annotations': [],
@@ -74,13 +75,13 @@ class TestRedmineIssue(ServiceIssueTest):
         assert actual_output == expected_output
 
     @responses.activate
-    def test_issues(self):
+    def test_issues(self, service):
         responses.get(
             'https://something/issues.json?limit=100',
             json={'issues': [self.arbitrary_issue]},
         )
 
-        issue = next(self.service.issues())
+        issue = next(service.issues())
 
         expected = {
             'annotations': [],

--- a/tests/services/test_redmine.py
+++ b/tests/services/test_redmine.py
@@ -9,14 +9,15 @@ from bugwarrior.services.redmine import RedMineService
 
 from .base import get_mock_service
 
+SERVICE_CONFIG = {
+    'service': 'redmine',
+    'url': 'https://something',
+    'key': 'something_else',
+    'issue_limit': '100',
+}
+
 
 class TestRedmineIssue:
-    SERVICE_CONFIG = {
-        'service': 'redmine',
-        'url': 'https://something',
-        'key': 'something_else',
-        'issue_limit': '100',
-    }
     arbitrary_created = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(1)
     arbitrary_updated = datetime.now(timezone.utc).replace(microsecond=0)
     arbitrary_issue = {
@@ -37,7 +38,7 @@ class TestRedmineIssue:
 
     @pytest.fixture
     def service(self):
-        return get_mock_service(RedMineService, self.SERVICE_CONFIG)
+        return get_mock_service(RedMineService, SERVICE_CONFIG)
 
     def test_to_taskwarrior(self, service):
         arbitrary_url = 'http://lkjlj.com'

--- a/tests/services/test_taiga.py
+++ b/tests/services/test_taiga.py
@@ -6,13 +6,10 @@ from bugwarrior.services.taiga import TaigaService
 
 from .base import get_mock_service
 
+SERVICE_CONFIG = {'service': 'taiga', 'base_uri': 'https://one', 'auth_token': 'two'}
+
 
 class TestTaigaIssue:
-    SERVICE_CONFIG = {
-        'service': 'taiga',
-        'base_uri': 'https://one',
-        'auth_token': 'two',
-    }
     record = {
         'id': 400,
         'project': 4,
@@ -24,7 +21,7 @@ class TestTaigaIssue:
 
     @pytest.fixture
     def service(self):
-        return get_mock_service(TaigaService, self.SERVICE_CONFIG)
+        return get_mock_service(TaigaService, SERVICE_CONFIG)
 
     def test_to_taskwarrior(self, service):
         extra = {

--- a/tests/services/test_taiga.py
+++ b/tests/services/test_taiga.py
@@ -1,12 +1,13 @@
+import pytest
 import responses
 
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.taiga import TaigaService
 
-from .base import ServiceIssueTest
+from .base import get_mock_service
 
 
-class TestTaigaIssue(ServiceIssueTest):
+class TestTaigaIssue:
     SERVICE_CONFIG = {
         'service': 'taiga',
         'base_uri': 'https://one',
@@ -21,11 +22,11 @@ class TestTaigaIssue(ServiceIssueTest):
         'due_date': '2026-05-18',
     }
 
-    def setUp(self):
-        super().setUp()
-        self.service = self.get_mock_service(TaigaService)
+    @pytest.fixture
+    def service(self):
+        return get_mock_service(TaigaService, self.SERVICE_CONFIG)
 
-    def test_to_taskwarrior(self):
+    def test_to_taskwarrior(self, service):
         extra = {
             'project': 'awesome',
             'annotations': [
@@ -34,7 +35,7 @@ class TestTaigaIssue(ServiceIssueTest):
             'url': 'this is a url',
         }
 
-        issue = self.service.get_issue_for_record(self.record, extra)
+        issue = service.get_issue_for_record(self.record, extra)
         actual = issue.to_taskwarrior()
         expected = {
             'annotations': [],
@@ -50,7 +51,7 @@ class TestTaigaIssue(ServiceIssueTest):
         assert actual == expected
 
     @responses.activate
-    def test_issues(self):
+    def test_issues(self, service):
         userid = 1
 
         responses.get('https://one/api/v1/users/me', json={'id': userid})
@@ -72,7 +73,7 @@ class TestTaigaIssue(ServiceIssueTest):
             json=[{'user': {'username': 'you'}, 'comment': 'Blah blah blah!'}],
         )
 
-        issue = next(self.service.issues())
+        issue = next(service.issues())
 
         expected = {
             'annotations': ['@you - Blah blah blah!'],

--- a/tests/services/test_taiga.py
+++ b/tests/services/test_taiga.py
@@ -4,7 +4,7 @@ import responses
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.taiga import TaigaService
 
-from .base import get_mock_service
+SERVICE_CLASS = TaigaService
 
 SERVICE_CONFIG = {'service': 'taiga', 'base_uri': 'https://one', 'auth_token': 'two'}
 
@@ -22,10 +22,6 @@ def record():
 
 
 class TestTaigaIssue:
-    @pytest.fixture
-    def service(self):
-        return get_mock_service(TaigaService, SERVICE_CONFIG)
-
     def test_to_taskwarrior(self, service, record):
         extra = {
             'project': 'awesome',

--- a/tests/services/test_taiga.py
+++ b/tests/services/test_taiga.py
@@ -9,8 +9,9 @@ from .base import get_mock_service
 SERVICE_CONFIG = {'service': 'taiga', 'base_uri': 'https://one', 'auth_token': 'two'}
 
 
-class TestTaigaIssue:
-    record = {
+@pytest.fixture
+def record():
+    return {
         'id': 400,
         'project': 4,
         'ref': 40,
@@ -19,11 +20,13 @@ class TestTaigaIssue:
         'due_date': '2026-05-18',
     }
 
+
+class TestTaigaIssue:
     @pytest.fixture
     def service(self):
         return get_mock_service(TaigaService, SERVICE_CONFIG)
 
-    def test_to_taskwarrior(self, service):
+    def test_to_taskwarrior(self, service, record):
         extra = {
             'project': 'awesome',
             'annotations': [
@@ -32,7 +35,7 @@ class TestTaigaIssue:
             'url': 'this is a url',
         }
 
-        issue = service.get_issue_for_record(self.record, extra)
+        issue = service.get_issue_for_record(record, extra)
         actual = issue.to_taskwarrior()
         expected = {
             'annotations': [],
@@ -48,7 +51,7 @@ class TestTaigaIssue:
         assert actual == expected
 
     @responses.activate
-    def test_issues(self, service):
+    def test_issues(self, service, record):
         userid = 1
 
         responses.get('https://one/api/v1/users/me', json={'id': userid})
@@ -57,16 +60,16 @@ class TestTaigaIssue:
             'https://one/api/v1/userstories?status__is_closed=false&assigned_to={}'.format(
                 userid
             ),
-            json=[self.record],
+            json=[record],
         )
 
         responses.get(
-            'https://one/api/v1/projects/{}'.format(self.record['project']),
+            'https://one/api/v1/projects/{}'.format(record['project']),
             json={'slug': 'something'},
         )
 
         responses.get(
-            'https://one/api/v1/history/userstory/{}'.format(self.record['id']),
+            'https://one/api/v1/history/userstory/{}'.format(record['id']),
             json=[{'user': {'username': 'you'}, 'comment': 'Blah blah blah!'}],
         )
 

--- a/tests/services/test_teamwork_projects.py
+++ b/tests/services/test_teamwork_projects.py
@@ -15,8 +15,9 @@ SERVICE_CONFIG = {
 }
 
 
-class TestTeamworkIssue:
-    arbitrary_issue = {
+@pytest.fixture
+def record():
+    return {
         "todo-items": [
             {
                 "id": 5,
@@ -48,11 +49,19 @@ class TestTeamworkIssue:
             }
         ]
     }
-    arbitrary_extra = {
+
+
+@pytest.fixture
+def extra():
+    return {
         "host": "https://test.teamwork_projects.com",
         "annotations": [("Greg McCoy", "Test comment"), ("Bob Test", "testing")],
     }
-    arbitrary_comments = {
+
+
+@pytest.fixture
+def comments():
+    return {
         "comments": [
             {
                 "project-id": "999",
@@ -73,6 +82,8 @@ class TestTeamworkIssue:
         ]
     }
 
+
+class TestTeamworkIssue:
     @pytest.fixture
     def service(self):
         # The HTTP mock must be active while the service is constructed since
@@ -87,11 +98,9 @@ class TestTeamworkIssue:
             return get_mock_service(TeamworkService, SERVICE_CONFIG)
 
     @responses.activate
-    def test_to_taskwarrior(self, service):
-        issue = service.get_issue_for_record(
-            self.arbitrary_issue["todo-items"][0], self.arbitrary_extra
-        )
-        data = self.arbitrary_issue["todo-items"][0]
+    def test_to_taskwarrior(self, service, record, extra):
+        issue = service.get_issue_for_record(record["todo-items"][0], extra)
+        data = record["todo-items"][0]
         expected_data = {
             'project': data["project-name"],
             'priority': "H",
@@ -111,16 +120,13 @@ class TestTeamworkIssue:
         assert actual_output == expected_data
 
     @responses.activate
-    def test_issues(self, service):
+    def test_issues(self, service, record, comments):
         responses.get(
-            'https://test.teamwork_projects.com/tasks/5/comments.json',
-            json=self.arbitrary_comments,
+            'https://test.teamwork_projects.com/tasks/5/comments.json', json=comments
         )
-        responses.get(
-            'https://test.teamwork_projects.com/tasks.json', json=self.arbitrary_issue
-        )
+        responses.get('https://test.teamwork_projects.com/tasks.json', json=record)
         issue = next(service.issues())
-        data = self.arbitrary_issue["todo-items"][0]
+        data = record["todo-items"][0]
         expected_data = {
             'project': data["project-name"],
             'priority': "H",

--- a/tests/services/test_teamwork_projects.py
+++ b/tests/services/test_teamwork_projects.py
@@ -6,7 +6,7 @@ import responses
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.teamwork_projects import TeamworkService
 
-from .base import get_mock_service
+SERVICE_CLASS = TeamworkService
 
 SERVICE_CONFIG = {
     'service': 'teamwork_projects',
@@ -85,7 +85,7 @@ def comments():
 
 class TestTeamworkIssue:
     @pytest.fixture
-    def service(self):
+    def service(self, make_service):
         # The HTTP mock must be active while the service is constructed since
         # construction hits the authentication endpoint.
         with responses.mock:
@@ -95,7 +95,7 @@ class TestTeamworkIssue:
                     'account': {'userId': 5, 'firstname': 'Greg', 'lastname': 'McCoy'}
                 },
             )
-            return get_mock_service(TeamworkService, SERVICE_CONFIG)
+            return make_service()
 
     @responses.activate
     def test_to_taskwarrior(self, service, record, extra):

--- a/tests/services/test_teamwork_projects.py
+++ b/tests/services/test_teamwork_projects.py
@@ -1,88 +1,94 @@
 from datetime import datetime, timezone
 
+import pytest
 import responses
 
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.teamwork_projects import TeamworkService
 
-from .base import ServiceIssueTest
+from .base import get_mock_service
 
 
-class TestTeamworkIssue(ServiceIssueTest):
+class TestTeamworkIssue:
     SERVICE_CONFIG = {
         'service': 'teamwork_projects',
         'host': 'https://test.teamwork_projects.com',
         'token': 'arbitrary_token',
     }
 
-    @responses.activate
-    def setUp(self):
-        super().setUp()
-        responses.get(
-            'https://test.teamwork_projects.com/authenticate.json',
-            json={'account': {'userId': 5, 'firstname': 'Greg', 'lastname': 'McCoy'}},
-        )
-        self.service = self.get_mock_service(TeamworkService)
-        self.arbitrary_issue = {
-            "todo-items": [
-                {
-                    "id": 5,
-                    "comments-count": 2,
-                    "description": "This issue is meant for testing",
-                    "content": "This is a test issue",
-                    "project-id": 1,
-                    "project-name": "Test Project",
-                    "status": "new",
-                    "company-name": "Test Company",
-                    "company-id": 1,
-                    "creator-id": 1,
-                    "creator-firstname": "Greg",
-                    "creator-lastname": "McCoy",
-                    "updater-id": 0,
-                    "updater-firstname": "",
-                    "updater-lastname": "",
-                    "completed": False,
-                    "start-date": "",
-                    "due-date": "2019-12-12T10:06:31Z",
-                    "created-on": "2018-12-12T10:06:31Z",
-                    "last-changed-on": "2019-01-16T11:00:44Z",
-                    "priority": "high",
-                    "parentTaskId": "",
-                    "userFollowingComments": True,
-                    "userFollowingChanges": True,
-                    "DLM": 0,
-                    "responsible-party-ids": ["5"],
-                }
-            ]
-        }
-        self.arbitrary_extra = {
-            "host": "https://test.teamwork_projects.com",
-            "annotations": [("Greg McCoy", "Test comment"), ("Bob Test", "testing")],
-        }
-        self.arbitrary_comments = {
-            "comments": [
-                {
-                    "project-id": "999",
-                    "author-lastname": "User",
-                    "datetime": "2014-03-31T13:03:29Z",
-                    "author_id": "999",
-                    "id": "999",
-                    "company-name": "Test Company",
-                    "last-changed-on": "",
-                    "company-id": "999",
-                    "project-name": "demo",
-                    "body": "A test comment",
-                    "commentNo": "1",
-                    "author-firstname": "Demo",
-                    "comment-link": "tasks/436523?c=93",
-                    "author-id": "999",
-                }
-            ]
-        }
+    arbitrary_issue = {
+        "todo-items": [
+            {
+                "id": 5,
+                "comments-count": 2,
+                "description": "This issue is meant for testing",
+                "content": "This is a test issue",
+                "project-id": 1,
+                "project-name": "Test Project",
+                "status": "new",
+                "company-name": "Test Company",
+                "company-id": 1,
+                "creator-id": 1,
+                "creator-firstname": "Greg",
+                "creator-lastname": "McCoy",
+                "updater-id": 0,
+                "updater-firstname": "",
+                "updater-lastname": "",
+                "completed": False,
+                "start-date": "",
+                "due-date": "2019-12-12T10:06:31Z",
+                "created-on": "2018-12-12T10:06:31Z",
+                "last-changed-on": "2019-01-16T11:00:44Z",
+                "priority": "high",
+                "parentTaskId": "",
+                "userFollowingComments": True,
+                "userFollowingChanges": True,
+                "DLM": 0,
+                "responsible-party-ids": ["5"],
+            }
+        ]
+    }
+    arbitrary_extra = {
+        "host": "https://test.teamwork_projects.com",
+        "annotations": [("Greg McCoy", "Test comment"), ("Bob Test", "testing")],
+    }
+    arbitrary_comments = {
+        "comments": [
+            {
+                "project-id": "999",
+                "author-lastname": "User",
+                "datetime": "2014-03-31T13:03:29Z",
+                "author_id": "999",
+                "id": "999",
+                "company-name": "Test Company",
+                "last-changed-on": "",
+                "company-id": "999",
+                "project-name": "demo",
+                "body": "A test comment",
+                "commentNo": "1",
+                "author-firstname": "Demo",
+                "comment-link": "tasks/436523?c=93",
+                "author-id": "999",
+            }
+        ]
+    }
+
+    @pytest.fixture
+    def service(self):
+        # The HTTP mock must be active while the service is constructed since
+        # construction hits the authentication endpoint.
+        with responses.mock:
+            responses.get(
+                'https://test.teamwork_projects.com/authenticate.json',
+                json={
+                    'account': {'userId': 5, 'firstname': 'Greg', 'lastname': 'McCoy'}
+                },
+            )
+            return get_mock_service(TeamworkService, self.SERVICE_CONFIG)
 
     @responses.activate
-    def test_to_taskwarrior(self):
-        issue = self.service.get_issue_for_record(
+    def test_to_taskwarrior(self, service):
+        issue = service.get_issue_for_record(
             self.arbitrary_issue["todo-items"][0], self.arbitrary_extra
         )
         data = self.arbitrary_issue["todo-items"][0]
@@ -105,7 +111,7 @@ class TestTeamworkIssue(ServiceIssueTest):
         assert actual_output == expected_data
 
     @responses.activate
-    def test_issues(self):
+    def test_issues(self, service):
         responses.get(
             'https://test.teamwork_projects.com/tasks/5/comments.json',
             json=self.arbitrary_comments,
@@ -113,7 +119,7 @@ class TestTeamworkIssue(ServiceIssueTest):
         responses.get(
             'https://test.teamwork_projects.com/tasks.json', json=self.arbitrary_issue
         )
-        issue = next(self.service.issues())
+        issue = next(service.issues())
         data = self.arbitrary_issue["todo-items"][0]
         expected_data = {
             'project': data["project-name"],

--- a/tests/services/test_teamwork_projects.py
+++ b/tests/services/test_teamwork_projects.py
@@ -8,14 +8,14 @@ from bugwarrior.services.teamwork_projects import TeamworkService
 
 from .base import get_mock_service
 
+SERVICE_CONFIG = {
+    'service': 'teamwork_projects',
+    'host': 'https://test.teamwork_projects.com',
+    'token': 'arbitrary_token',
+}
+
 
 class TestTeamworkIssue:
-    SERVICE_CONFIG = {
-        'service': 'teamwork_projects',
-        'host': 'https://test.teamwork_projects.com',
-        'token': 'arbitrary_token',
-    }
-
     arbitrary_issue = {
         "todo-items": [
             {
@@ -84,7 +84,7 @@ class TestTeamworkIssue:
                     'account': {'userId': 5, 'firstname': 'Greg', 'lastname': 'McCoy'}
                 },
             )
-            return get_mock_service(TeamworkService, self.SERVICE_CONFIG)
+            return get_mock_service(TeamworkService, SERVICE_CONFIG)
 
     @responses.activate
     def test_to_taskwarrior(self, service):

--- a/tests/services/test_todoist.py
+++ b/tests/services/test_todoist.py
@@ -15,7 +15,7 @@ from todoist_api_python.models import (
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.todoist import TodoistClient, TodoistService
 
-from .base import get_mock_service
+SERVICE_CLASS = TodoistService
 
 SERVICE_CONFIG = {"service": "todoist", "token": "TESTTOKEN"}
 
@@ -107,8 +107,8 @@ def users():
 
 class TestTodoistIssue:
     @pytest.fixture
-    def service(self):
-        service = get_mock_service(TodoistService, SERVICE_CONFIG)
+    def service(self, make_service):
+        service = make_service()
         service.client = mock.MagicMock(spec=TodoistClient)
         return service
 
@@ -141,10 +141,10 @@ class TestTodoistIssue:
 
         assert actual == expected
 
-    def test_to_taskwarrior_with_labels(self, record, extra):
+    def test_to_taskwarrior_with_labels(self, make_service, record, extra):
         # Test lables when `import_labels_as_tags` is enabled
         overrides = {"import_labels_as_tags": "True"}
-        service = get_mock_service(TodoistService, {**SERVICE_CONFIG, **overrides})
+        service = make_service(**overrides)
         issue = service.get_issue_for_record(record, extra)
         actual = issue.to_taskwarrior()
         assert actual.get("tags") == ["TESTLABEL"]

--- a/tests/services/test_todoist.py
+++ b/tests/services/test_todoist.py
@@ -2,6 +2,7 @@ import copy
 from datetime import datetime
 from unittest import mock
 
+import pytest
 from todoist_api_python.models import (
     Collaborator,
     Deadline,
@@ -15,10 +16,10 @@ from todoist_api_python.models import (
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.todoist import TodoistClient, TodoistService
 
-from .base import ServiceIssueTest
+from .base import get_mock_service
 
 
-class TestTodoistIssue(ServiceIssueTest):
+class TestTodoistIssue:
     SERVICE_CONFIG = {"service": "todoist", "token": "TESTTOKEN"}
 
     # Base test record
@@ -91,14 +92,14 @@ class TestTodoistIssue(ServiceIssueTest):
         id="6666666666666666", name="TESTUSER2", email="testuser2@example.com"
     )
 
-    def setUp(self):
-        super().setUp()
+    @pytest.fixture
+    def service(self):
+        service = get_mock_service(TodoistService, self.SERVICE_CONFIG)
+        service.client = mock.MagicMock(spec=TodoistClient)
+        return service
 
-        self.service = self.get_mock_service(TodoistService)
-        self.service.client = mock.MagicMock(spec=TodoistClient)
-
-    def test_to_taskwarrior(self):
-        issue = self.service.get_issue_for_record(self.test_record, self.test_extra)
+    def test_to_taskwarrior(self, service):
+        issue = service.get_issue_for_record(self.test_record, self.test_extra)
 
         expected = {
             "annotations": [],
@@ -129,25 +130,27 @@ class TestTodoistIssue(ServiceIssueTest):
     def test_to_taskwarrior_with_labels(self):
         # Test lables when `import_labels_as_tags` is enabled
         overrides = {"import_labels_as_tags": "True"}
-        service = self.get_mock_service(TodoistService, config_overrides=overrides)
+        service = get_mock_service(
+            TodoistService, self.SERVICE_CONFIG, config_overrides=overrides
+        )
         issue = service.get_issue_for_record(self.test_record, self.test_extra)
         actual = issue.to_taskwarrior()
         assert actual.get("tags") == ["TESTLABEL"]
 
-    def test_to_taskwarrior_task_with_low_priority(self):
+    def test_to_taskwarrior_task_with_low_priority(self, service):
         # Test with priority set to lowest (1 in the API, which is P4 on the Todoist UI)
         test_record = copy.copy(self.test_record)
         test_record["priority"] = 1
-        issue = self.service.get_issue_for_record(test_record, self.test_extra)
+        issue = service.get_issue_for_record(test_record, self.test_extra)
         actual = issue.to_taskwarrior()
         assert actual.get("priority") is None
 
-    def test_to_taskwarrior_subtask(self):
+    def test_to_taskwarrior_subtask(self, service):
         # subtasks have a parent id
         test_record = copy.copy(self.test_record)
         test_extras = copy.copy(self.test_extra)
         test_record["parent_id"] = "1212121212121212"
-        issue = self.service.get_issue_for_record(test_record, test_extras)
+        issue = service.get_issue_for_record(test_record, test_extras)
         actual = issue.to_taskwarrior()
         assert actual.get("todoistparentid") == "1212121212121212"
         assert (
@@ -156,12 +159,12 @@ class TestTodoistIssue(ServiceIssueTest):
             " https://app.todoist.com/app/task/testtask-1111111111111111"
         )
 
-    def test_issues(self):
-        self.service.client.get_projects.return_value = [self.test_project]
-        self.service.client.get_sections.return_value = [self.test_section]
-        self.service.client.get_users.return_value = [self.test_user1, self.test_user2]
-        self.service.client.get_issues.return_value = [self.test_record]
-        issue = next(self.service.issues())
+    def test_issues(self, service):
+        service.client.get_projects.return_value = [self.test_project]
+        service.client.get_sections.return_value = [self.test_section]
+        service.client.get_users.return_value = [self.test_user1, self.test_user2]
+        service.client.get_issues.return_value = [self.test_record]
+        issue = next(service.issues())
 
         expected = {
             "annotations": [],

--- a/tests/services/test_todoist.py
+++ b/tests/services/test_todoist.py
@@ -130,9 +130,7 @@ class TestTodoistIssue:
     def test_to_taskwarrior_with_labels(self):
         # Test lables when `import_labels_as_tags` is enabled
         overrides = {"import_labels_as_tags": "True"}
-        service = get_mock_service(
-            TodoistService, self.SERVICE_CONFIG, config_overrides=overrides
-        )
+        service = get_mock_service(TodoistService, {**self.SERVICE_CONFIG, **overrides})
         issue = service.get_issue_for_record(self.test_record, self.test_extra)
         actual = issue.to_taskwarrior()
         assert actual.get("tags") == ["TESTLABEL"]

--- a/tests/services/test_todoist.py
+++ b/tests/services/test_todoist.py
@@ -18,10 +18,10 @@ from bugwarrior.services.todoist import TodoistClient, TodoistService
 
 from .base import get_mock_service
 
+SERVICE_CONFIG = {"service": "todoist", "token": "TESTTOKEN"}
+
 
 class TestTodoistIssue:
-    SERVICE_CONFIG = {"service": "todoist", "token": "TESTTOKEN"}
-
     # Base test record
     test_record = TodoistClient.task_to_dict(
         Task(
@@ -94,7 +94,7 @@ class TestTodoistIssue:
 
     @pytest.fixture
     def service(self):
-        service = get_mock_service(TodoistService, self.SERVICE_CONFIG)
+        service = get_mock_service(TodoistService, SERVICE_CONFIG)
         service.client = mock.MagicMock(spec=TodoistClient)
         return service
 
@@ -130,7 +130,7 @@ class TestTodoistIssue:
     def test_to_taskwarrior_with_labels(self):
         # Test lables when `import_labels_as_tags` is enabled
         overrides = {"import_labels_as_tags": "True"}
-        service = get_mock_service(TodoistService, {**self.SERVICE_CONFIG, **overrides})
+        service = get_mock_service(TodoistService, {**SERVICE_CONFIG, **overrides})
         issue = service.get_issue_for_record(self.test_record, self.test_extra)
         actual = issue.to_taskwarrior()
         assert actual.get("tags") == ["TESTLABEL"]

--- a/tests/services/test_todoist.py
+++ b/tests/services/test_todoist.py
@@ -1,4 +1,3 @@
-import copy
 from datetime import datetime
 from unittest import mock
 
@@ -21,9 +20,9 @@ from .base import get_mock_service
 SERVICE_CONFIG = {"service": "todoist", "token": "TESTTOKEN"}
 
 
-class TestTodoistIssue:
-    # Base test record
-    test_record = TodoistClient.task_to_dict(
+@pytest.fixture
+def record():
+    return TodoistClient.task_to_dict(
         Task(
             id="1111111111111111",
             content="TESTTASK",
@@ -52,7 +51,10 @@ class TestTodoistIssue:
         )
     )
 
-    test_extra = {
+
+@pytest.fixture
+def extra():
+    return {
         "project": "TESTPROJECT",
         "section": "TESTSECTION",
         "assignee": "TESTUSER1 <testuser1@example.com>",
@@ -60,7 +62,10 @@ class TestTodoistIssue:
         "duration": "15 minute",
     }
 
-    test_project = Project(
+
+@pytest.fixture
+def project():
+    return Project(
         id="2222222222222222",
         name="TESTPROJECT",
         description="TESTPROJECTDESCRIPTION",
@@ -76,7 +81,10 @@ class TestTodoistIssue:
         updated_at=datetime(year=2025, month=7, day=2, hour=8, minute=0, second=0),
     )
 
-    test_section = Section(
+
+@pytest.fixture
+def section():
+    return Section(
         id="4444444444444444",
         name="TESTSECTION",
         project_id="2222222222222222",
@@ -84,22 +92,28 @@ class TestTodoistIssue:
         order=1,
     )
 
-    test_user1 = Collaborator(
-        id="5555555555555555", name="TESTUSER1", email="testuser1@example.com"
-    )
 
-    test_user2 = Collaborator(
-        id="6666666666666666", name="TESTUSER2", email="testuser2@example.com"
-    )
+@pytest.fixture
+def users():
+    return [
+        Collaborator(
+            id="5555555555555555", name="TESTUSER1", email="testuser1@example.com"
+        ),
+        Collaborator(
+            id="6666666666666666", name="TESTUSER2", email="testuser2@example.com"
+        ),
+    ]
 
+
+class TestTodoistIssue:
     @pytest.fixture
     def service(self):
         service = get_mock_service(TodoistService, SERVICE_CONFIG)
         service.client = mock.MagicMock(spec=TodoistClient)
         return service
 
-    def test_to_taskwarrior(self, service):
-        issue = service.get_issue_for_record(self.test_record, self.test_extra)
+    def test_to_taskwarrior(self, service, record, extra):
+        issue = service.get_issue_for_record(record, extra)
 
         expected = {
             "annotations": [],
@@ -127,28 +141,25 @@ class TestTodoistIssue:
 
         assert actual == expected
 
-    def test_to_taskwarrior_with_labels(self):
+    def test_to_taskwarrior_with_labels(self, record, extra):
         # Test lables when `import_labels_as_tags` is enabled
         overrides = {"import_labels_as_tags": "True"}
         service = get_mock_service(TodoistService, {**SERVICE_CONFIG, **overrides})
-        issue = service.get_issue_for_record(self.test_record, self.test_extra)
+        issue = service.get_issue_for_record(record, extra)
         actual = issue.to_taskwarrior()
         assert actual.get("tags") == ["TESTLABEL"]
 
-    def test_to_taskwarrior_task_with_low_priority(self, service):
+    def test_to_taskwarrior_task_with_low_priority(self, service, record, extra):
         # Test with priority set to lowest (1 in the API, which is P4 on the Todoist UI)
-        test_record = copy.copy(self.test_record)
-        test_record["priority"] = 1
-        issue = service.get_issue_for_record(test_record, self.test_extra)
+        record["priority"] = 1
+        issue = service.get_issue_for_record(record, extra)
         actual = issue.to_taskwarrior()
         assert actual.get("priority") is None
 
-    def test_to_taskwarrior_subtask(self, service):
+    def test_to_taskwarrior_subtask(self, service, record, extra):
         # subtasks have a parent id
-        test_record = copy.copy(self.test_record)
-        test_extras = copy.copy(self.test_extra)
-        test_record["parent_id"] = "1212121212121212"
-        issue = service.get_issue_for_record(test_record, test_extras)
+        record["parent_id"] = "1212121212121212"
+        issue = service.get_issue_for_record(record, extra)
         actual = issue.to_taskwarrior()
         assert actual.get("todoistparentid") == "1212121212121212"
         assert (
@@ -157,11 +168,11 @@ class TestTodoistIssue:
             " https://app.todoist.com/app/task/testtask-1111111111111111"
         )
 
-    def test_issues(self, service):
-        service.client.get_projects.return_value = [self.test_project]
-        service.client.get_sections.return_value = [self.test_section]
-        service.client.get_users.return_value = [self.test_user1, self.test_user2]
-        service.client.get_issues.return_value = [self.test_record]
+    def test_issues(self, service, record, project, section, users):
+        service.client.get_projects.return_value = [project]
+        service.client.get_sections.return_value = [section]
+        service.client.get_users.return_value = users
+        service.client.get_issues.return_value = [record]
         issue = next(service.issues())
 
         expected = {

--- a/tests/services/test_trac.py
+++ b/tests/services/test_trac.py
@@ -13,6 +13,22 @@ SERVICE_CONFIG = {
 }
 
 
+@pytest.fixture
+def record():
+    return {
+        'url': 'http://some/url.com/',
+        'summary': 'Some Summary',
+        'number': 204,
+        'priority': 'critical',
+        'component': 'testcomponent',
+    }
+
+
+@pytest.fixture
+def extra():
+    return {'annotations': ['alpha', 'beta'], 'project': 'some project'}
+
+
 class FakeTracTicket:
     @staticmethod
     def changeLog(issuenumber):
@@ -38,33 +54,23 @@ class FakeTracLib:
 
 
 class TestTracIssue:
-    arbitrary_issue = {
-        'url': 'http://some/url.com/',
-        'summary': 'Some Summary',
-        'number': 204,
-        'priority': 'critical',
-        'component': 'testcomponent',
-    }
-
     @pytest.fixture
-    def service(self):
+    def service(self, record):
         service = get_mock_service(TracService, SERVICE_CONFIG)
-        service.trac = FakeTracLib(self.arbitrary_issue)
+        service.trac = FakeTracLib(record)
         return service
 
-    def test_to_taskwarrior(self, service):
-        arbitrary_extra = {'annotations': ['alpha', 'beta'], 'project': 'some project'}
-
-        issue = service.get_issue_for_record(self.arbitrary_issue, arbitrary_extra)
+    def test_to_taskwarrior(self, service, record, extra):
+        issue = service.get_issue_for_record(record, extra)
 
         expected_output = {
-            'project': arbitrary_extra['project'],
-            'priority': issue.PRIORITY_MAP[self.arbitrary_issue['priority']],
-            'annotations': arbitrary_extra['annotations'],
-            issue.URL: self.arbitrary_issue['url'],
-            issue.SUMMARY: self.arbitrary_issue['summary'],
-            issue.NUMBER: self.arbitrary_issue['number'],
-            issue.COMPONENT: self.arbitrary_issue['component'],
+            'project': extra['project'],
+            'priority': issue.PRIORITY_MAP[record['priority']],
+            'annotations': extra['annotations'],
+            issue.URL: record['url'],
+            issue.SUMMARY: record['summary'],
+            issue.NUMBER: record['number'],
+            issue.COMPONENT: record['component'],
         }
         actual_output = issue.to_taskwarrior()
 

--- a/tests/services/test_trac.py
+++ b/tests/services/test_trac.py
@@ -1,7 +1,9 @@
+import pytest
+
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.trac import TracService
 
-from .base import ServiceIssueTest
+from .base import get_mock_service
 
 
 class FakeTracTicket:
@@ -28,7 +30,7 @@ class FakeTracLib:
         return (1, None, None, self.record)
 
 
-class TestTracIssue(ServiceIssueTest):
+class TestTracIssue:
     SERVICE_CONFIG = {
         'service': 'trac',
         'base_uri': 'ljlkajsdfl.com',
@@ -43,19 +45,16 @@ class TestTracIssue(ServiceIssueTest):
         'component': 'testcomponent',
     }
 
-    def setUp(self):
-        super().setUp()
-        self.service = self.get_mock_service(TracService)
-
-    def get_mock_service(self, *args, **kwargs):
-        service = super().get_mock_service(*args, **kwargs)
+    @pytest.fixture
+    def service(self):
+        service = get_mock_service(TracService, self.SERVICE_CONFIG)
         service.trac = FakeTracLib(self.arbitrary_issue)
         return service
 
-    def test_to_taskwarrior(self):
+    def test_to_taskwarrior(self, service):
         arbitrary_extra = {'annotations': ['alpha', 'beta'], 'project': 'some project'}
 
-        issue = self.service.get_issue_for_record(self.arbitrary_issue, arbitrary_extra)
+        issue = service.get_issue_for_record(self.arbitrary_issue, arbitrary_extra)
 
         expected_output = {
             'project': arbitrary_extra['project'],
@@ -70,8 +69,8 @@ class TestTracIssue(ServiceIssueTest):
 
         assert actual_output == expected_output
 
-    def test_issues(self):
-        issue = next(self.service.issues())
+    def test_issues(self, service):
+        issue = next(service.issues())
 
         expected = {
             'annotations': [],

--- a/tests/services/test_trac.py
+++ b/tests/services/test_trac.py
@@ -3,7 +3,7 @@ import pytest
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.trac import TracService
 
-from .base import get_mock_service
+SERVICE_CLASS = TracService
 
 SERVICE_CONFIG = {
     'service': 'trac',
@@ -55,8 +55,8 @@ class FakeTracLib:
 
 class TestTracIssue:
     @pytest.fixture
-    def service(self, record):
-        service = get_mock_service(TracService, SERVICE_CONFIG)
+    def service(self, record, make_service):
+        service = make_service()
         service.trac = FakeTracLib(record)
         return service
 

--- a/tests/services/test_trac.py
+++ b/tests/services/test_trac.py
@@ -5,6 +5,13 @@ from bugwarrior.services.trac import TracService
 
 from .base import get_mock_service
 
+SERVICE_CONFIG = {
+    'service': 'trac',
+    'base_uri': 'ljlkajsdfl.com',
+    'username': 'something',
+    'password': 'somepwd',
+}
+
 
 class FakeTracTicket:
     @staticmethod
@@ -31,12 +38,6 @@ class FakeTracLib:
 
 
 class TestTracIssue:
-    SERVICE_CONFIG = {
-        'service': 'trac',
-        'base_uri': 'ljlkajsdfl.com',
-        'username': 'something',
-        'password': 'somepwd',
-    }
     arbitrary_issue = {
         'url': 'http://some/url.com/',
         'summary': 'Some Summary',
@@ -47,7 +48,7 @@ class TestTracIssue:
 
     @pytest.fixture
     def service(self):
-        service = get_mock_service(TracService, self.SERVICE_CONFIG)
+        service = get_mock_service(TracService, SERVICE_CONFIG)
         service.trac = FakeTracLib(self.arbitrary_issue)
         return service
 

--- a/tests/services/test_trello.py
+++ b/tests/services/test_trello.py
@@ -1,14 +1,15 @@
 from dateutil.parser import parse as parse_date
+import pytest
 import responses
 
 from bugwarrior.collect import TaskConstructor, get_service_instances
 from bugwarrior.config.schema import MainSectionConfig
 from bugwarrior.services.trello import TrelloConfig, TrelloIssue
 
-from .base import ConfigTest
+from ..base import validate
 
 
-class TestTrelloIssue(ConfigTest):
+class TestTrelloIssue:
     JSON = {
         "due": "2018-12-02T12:59:00.000Z",
         "id": "542bbb6583d705eb05bbe491",
@@ -21,8 +22,8 @@ class TestTrelloIssue(ConfigTest):
         "desc": "some description",
     }
 
-    def setUp(self):
-        super().setUp()
+    @pytest.fixture
+    def issue(self):
         config = TrelloConfig(
             service='trello',
             api_key='abc123',
@@ -36,22 +37,22 @@ class TestTrelloIssue(ConfigTest):
             targets=[], inline_links=True, description_length=31
         )
         extra = {'boardname': 'Hyperspatial express route', 'listname': 'Something'}
-        self.issue = TrelloIssue(self.JSON, config, main_config, extra)
+        return TrelloIssue(self.JSON, config, main_config, extra)
 
-    def test_default_description(self):
+    def test_default_description(self, issue):
         """Test the generated description"""
         expected_desc = (
             "(bw)#42 - So long, and thanks for all the .. https://trello.com/c/AAaaBBbb"
         )
-        assert expected_desc == self.issue.get_default_description()
+        assert expected_desc == issue.get_default_description()
 
-    def test_to_taskwarrior__project(self):
+    def test_to_taskwarrior__project(self, issue):
         """By default, the project is the board name"""
         expected_project = "Hyperspatial express route"
-        assert expected_project == self.issue.to_taskwarrior().get('project', None)
+        assert expected_project == issue.to_taskwarrior().get('project', None)
 
 
-class TestTrelloService(ConfigTest):
+class TestTrelloService:
     BOARD = {'id': 'B04RD', 'name': 'My Board'}
     CARD1 = {
         'id': 'C4RD',
@@ -80,47 +81,51 @@ class TestTrelloService(ConfigTest):
         "memberCreator": {"username": "mario"},
     }
 
-    def setUp(self):
-        super().setUp()
-        self.config = {
+    @pytest.fixture
+    def config(self):
+        return {
             'general': {'targets': ['mytrello']},
             'mytrello': {'service': 'trello', 'api_key': 'XXXX', 'token': 'YYYY'},
         }
-        responses.add(
-            responses.GET,
-            'https://api.trello.com/1/lists/L15T/cards/open',
-            json=[self.CARD1, self.CARD2, self.CARD3],
-        )
-        responses.add(
-            responses.GET,
-            'https://api.trello.com/1/boards/B04RD/lists/open',
-            json=[self.LIST1, self.LIST2],
-        )
-        responses.add(
-            responses.GET,
-            'https://api.trello.com/1/boards/F00',
-            json={'id': 'F00', 'name': 'Foo Board'},
-        )
-        responses.add(
-            responses.GET,
-            'https://api.trello.com/1/boards/B4R',
-            json={'id': 'B4R', 'name': 'Bar Board'},
-        )
-        responses.add(
-            responses.GET,
-            'https://api.trello.com/1/members/me/boards',
-            json=[self.BOARD],
-        )
-        responses.add(
-            responses.GET,
-            'https://api.trello.com/1/cards/C4RD/actions',
-            json=[self.COMMENT1, self.COMMENT2],
-        )
 
-    @responses.activate
-    def test_get_boards_config(self):
-        self.config['mytrello']['include_boards'] = 'F00, B4R'
-        conf = self.validate()
+    @pytest.fixture(autouse=True)
+    def mock_api(self):
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+            rsps.add(
+                responses.GET,
+                'https://api.trello.com/1/lists/L15T/cards/open',
+                json=[self.CARD1, self.CARD2, self.CARD3],
+            )
+            rsps.add(
+                responses.GET,
+                'https://api.trello.com/1/boards/B04RD/lists/open',
+                json=[self.LIST1, self.LIST2],
+            )
+            rsps.add(
+                responses.GET,
+                'https://api.trello.com/1/boards/F00',
+                json={'id': 'F00', 'name': 'Foo Board'},
+            )
+            rsps.add(
+                responses.GET,
+                'https://api.trello.com/1/boards/B4R',
+                json={'id': 'B4R', 'name': 'Bar Board'},
+            )
+            rsps.add(
+                responses.GET,
+                'https://api.trello.com/1/members/me/boards',
+                json=[self.BOARD],
+            )
+            rsps.add(
+                responses.GET,
+                'https://api.trello.com/1/cards/C4RD/actions',
+                json=[self.COMMENT1, self.COMMENT2],
+            )
+            yield rsps
+
+    def test_get_boards_config(self, config):
+        config['mytrello']['include_boards'] = 'F00, B4R'
+        conf = validate(config)
         service = get_service_instances(conf)[0]
         boards = service.get_boards()
         assert list(boards) == [
@@ -128,79 +133,69 @@ class TestTrelloService(ConfigTest):
             {'id': 'B4R', 'name': 'Bar Board'},
         ]
 
-    @responses.activate
-    def test_get_boards_api(self):
-        conf = self.validate()
+    def test_get_boards_api(self, config):
+        conf = validate(config)
         service = get_service_instances(conf)[0]
         boards = service.get_boards()
         assert list(boards) == [self.BOARD]
 
-    @responses.activate
-    def test_get_lists(self):
-        conf = self.validate()
+    def test_get_lists(self, config):
+        conf = validate(config)
         service = get_service_instances(conf)[0]
         lists = service.get_lists('B04RD')
         assert list(lists) == [self.LIST1, self.LIST2]
 
-    @responses.activate
-    def test_get_lists_include(self):
-        self.config['mytrello']['include_lists'] = 'List 1'
-        conf = self.validate()
+    def test_get_lists_include(self, config):
+        config['mytrello']['include_lists'] = 'List 1'
+        conf = validate(config)
         service = get_service_instances(conf)[0]
         lists = service.get_lists('B04RD')
         assert list(lists) == [self.LIST1]
 
-    @responses.activate
-    def test_get_lists_exclude(self):
-        self.config['mytrello']['exclude_lists'] = 'List 1'
-        conf = self.validate()
+    def test_get_lists_exclude(self, config):
+        config['mytrello']['exclude_lists'] = 'List 1'
+        conf = validate(config)
         service = get_service_instances(conf)[0]
         lists = service.get_lists('B04RD')
         assert list(lists) == [self.LIST2]
 
-    @responses.activate
-    def test_get_cards(self):
-        conf = self.validate()
+    def test_get_cards(self, config):
+        conf = validate(config)
         service = get_service_instances(conf)[0]
         cards = service.get_cards('L15T')
         assert list(cards) == [self.CARD1, self.CARD2, self.CARD3]
 
-    @responses.activate
-    def test_get_cards_assigned(self):
-        self.config['mytrello']['only_if_assigned'] = 'tintin'
-        conf = self.validate()
+    def test_get_cards_assigned(self, config):
+        config['mytrello']['only_if_assigned'] = 'tintin'
+        conf = validate(config)
         service = get_service_instances(conf)[0]
         cards = service.get_cards('L15T')
         assert list(cards) == [self.CARD1]
 
-    @responses.activate
-    def test_get_cards_assigned_unassigned(self):
-        self.config['mytrello'].update(
+    def test_get_cards_assigned_unassigned(self, config):
+        config['mytrello'].update(
             {'only_if_assigned': 'tintin', 'also_unassigned': 'true'}
         )
-        conf = self.validate()
+        conf = validate(config)
         service = get_service_instances(conf)[0]
         cards = service.get_cards('L15T')
         assert list(cards) == [self.CARD1, self.CARD3]
 
-    @responses.activate
-    def test_get_comments(self):
-        conf = self.validate()
+    def test_get_comments(self, config):
+        conf = validate(config)
         service = get_service_instances(conf)[0]
         comments = service.get_comments('C4RD')
         assert list(comments) == [self.COMMENT1, self.COMMENT2]
 
-    @responses.activate
-    def test_annotations(self):
-        conf = self.validate()
+    def test_annotations(self, config):
+        conf = validate(config)
         service = get_service_instances(conf)[0]
         annotations = service.annotations(self.CARD1)
         assert list(annotations) == ["@luidgi - Preums", "@mario - Deuz"]
 
-    @responses.activate
-    def test_annotations_with_link(self):
-        self.config['general']['annotation_links'] = 'true'
-        conf = self.validate()
+    def test_annotations_with_link(self, config):
+        config['general']['annotation_links'] = 'true'
+        conf = validate(config)
         service = get_service_instances(conf)[0]
         annotations = service.annotations(self.CARD1)
         assert list(annotations) == [
@@ -209,12 +204,11 @@ class TestTrelloService(ConfigTest):
             "@mario - Deuz",
         ]
 
-    @responses.activate
-    def test_issues(self):
-        self.config['mytrello'].update(
+    def test_issues(self, config):
+        config['mytrello'].update(
             {'include_lists': 'List 1', 'only_if_assigned': 'tintin'}
         )
-        conf = self.validate()
+        conf = validate(config)
         service = get_service_instances(conf)[0]
         issues = service.issues()
         expected = {
@@ -237,23 +231,21 @@ class TestTrelloService(ConfigTest):
         actual = TaskConstructor(next(issues)).get_taskwarrior_record()
         assert expected == actual
 
-    maxDiff = None
+    def test_validate_config(self, config):
+        validate(config)
 
-    def test_validate_config(self):
-        self.validate()
+    def test_valid_config_no_access_token(self, config, assert_validation_error):
+        del config['mytrello']['token']
 
-    def test_valid_config_no_access_token(self):
-        del self.config['mytrello']['token']
+        assert_validation_error(config, '[mytrello]\ntoken  <- Field required')
 
-        self.assertValidationError('[mytrello]\ntoken  <- Field required')
+    def test_valid_config_no_api_key(self, config, assert_validation_error):
+        del config['mytrello']['api_key']
 
-    def test_valid_config_no_api_key(self):
-        del self.config['mytrello']['api_key']
+        assert_validation_error(config, '[mytrello]\napi_key  <- Field required')
 
-        self.assertValidationError('[mytrello]\napi_key  <- Field required')
-
-    def test_keyring_service(self):
+    def test_keyring_service(self, config):
         """Checks that the keyring service name"""
-        conf = self.validate()
+        conf = validate(config)
         keyring_service = conf.service_configs[0].keyring_service
         assert "trello://XXXX@trello.com" == keyring_service

--- a/tests/services/test_trello.py
+++ b/tests/services/test_trello.py
@@ -2,11 +2,13 @@ from dateutil.parser import parse as parse_date
 import pytest
 import responses
 
-from bugwarrior.collect import TaskConstructor, get_service_instances
+from bugwarrior.collect import TaskConstructor
 from bugwarrior.config.schema import MainSectionConfig
 from bugwarrior.services.trello import TrelloConfig, TrelloIssue
 
-from ..base import validate
+from ..base import get_validated_service, validate
+
+SERVICE_CONFIG = {'service': 'trello', 'api_key': 'XXXX', 'token': 'YYYY'}
 
 
 class TestTrelloIssue:
@@ -83,10 +85,7 @@ class TestTrelloService:
 
     @pytest.fixture
     def config(self):
-        return {
-            'general': {'targets': ['mytrello']},
-            'mytrello': {'service': 'trello', 'api_key': 'XXXX', 'token': 'YYYY'},
-        }
+        return {'general': {'targets': ['mytrello']}, 'mytrello': {**SERVICE_CONFIG}}
 
     @pytest.fixture(autouse=True)
     def mock_api(self):
@@ -125,8 +124,7 @@ class TestTrelloService:
 
     def test_get_boards_config(self, config):
         config['mytrello']['include_boards'] = 'F00, B4R'
-        conf = validate(config)
-        service = get_service_instances(conf)[0]
+        service = get_validated_service(config)
         boards = service.get_boards()
         assert list(boards) == [
             {'id': 'F00', 'name': 'Foo Board'},
@@ -134,41 +132,35 @@ class TestTrelloService:
         ]
 
     def test_get_boards_api(self, config):
-        conf = validate(config)
-        service = get_service_instances(conf)[0]
+        service = get_validated_service(config)
         boards = service.get_boards()
         assert list(boards) == [self.BOARD]
 
     def test_get_lists(self, config):
-        conf = validate(config)
-        service = get_service_instances(conf)[0]
+        service = get_validated_service(config)
         lists = service.get_lists('B04RD')
         assert list(lists) == [self.LIST1, self.LIST2]
 
     def test_get_lists_include(self, config):
         config['mytrello']['include_lists'] = 'List 1'
-        conf = validate(config)
-        service = get_service_instances(conf)[0]
+        service = get_validated_service(config)
         lists = service.get_lists('B04RD')
         assert list(lists) == [self.LIST1]
 
     def test_get_lists_exclude(self, config):
         config['mytrello']['exclude_lists'] = 'List 1'
-        conf = validate(config)
-        service = get_service_instances(conf)[0]
+        service = get_validated_service(config)
         lists = service.get_lists('B04RD')
         assert list(lists) == [self.LIST2]
 
     def test_get_cards(self, config):
-        conf = validate(config)
-        service = get_service_instances(conf)[0]
+        service = get_validated_service(config)
         cards = service.get_cards('L15T')
         assert list(cards) == [self.CARD1, self.CARD2, self.CARD3]
 
     def test_get_cards_assigned(self, config):
         config['mytrello']['only_if_assigned'] = 'tintin'
-        conf = validate(config)
-        service = get_service_instances(conf)[0]
+        service = get_validated_service(config)
         cards = service.get_cards('L15T')
         assert list(cards) == [self.CARD1]
 
@@ -176,27 +168,23 @@ class TestTrelloService:
         config['mytrello'].update(
             {'only_if_assigned': 'tintin', 'also_unassigned': 'true'}
         )
-        conf = validate(config)
-        service = get_service_instances(conf)[0]
+        service = get_validated_service(config)
         cards = service.get_cards('L15T')
         assert list(cards) == [self.CARD1, self.CARD3]
 
     def test_get_comments(self, config):
-        conf = validate(config)
-        service = get_service_instances(conf)[0]
+        service = get_validated_service(config)
         comments = service.get_comments('C4RD')
         assert list(comments) == [self.COMMENT1, self.COMMENT2]
 
     def test_annotations(self, config):
-        conf = validate(config)
-        service = get_service_instances(conf)[0]
+        service = get_validated_service(config)
         annotations = service.annotations(self.CARD1)
         assert list(annotations) == ["@luidgi - Preums", "@mario - Deuz"]
 
     def test_annotations_with_link(self, config):
         config['general']['annotation_links'] = 'true'
-        conf = validate(config)
-        service = get_service_instances(conf)[0]
+        service = get_validated_service(config)
         annotations = service.annotations(self.CARD1)
         assert list(annotations) == [
             "https://trello.com/c/AAaaBBbb",
@@ -208,8 +196,7 @@ class TestTrelloService:
         config['mytrello'].update(
             {'include_lists': 'List 1', 'only_if_assigned': 'tintin'}
         )
-        conf = validate(config)
-        service = get_service_instances(conf)[0]
+        service = get_validated_service(config)
         issues = service.issues()
         expected = {
             'due': parse_date('2018-12-02T12:59:00.000Z'),

--- a/tests/services/test_trello.py
+++ b/tests/services/test_trello.py
@@ -11,8 +11,9 @@ from ..base import get_validated_service, validate
 SERVICE_CONFIG = {'service': 'trello', 'api_key': 'XXXX', 'token': 'YYYY'}
 
 
-class TestTrelloIssue:
-    JSON = {
+@pytest.fixture
+def record():
+    return {
         "due": "2018-12-02T12:59:00.000Z",
         "id": "542bbb6583d705eb05bbe491",
         "idShort": 42,
@@ -24,8 +25,10 @@ class TestTrelloIssue:
         "desc": "some description",
     }
 
+
+class TestTrelloIssue:
     @pytest.fixture
-    def issue(self):
+    def issue(self, record):
         config = TrelloConfig(
             service='trello',
             api_key='abc123',
@@ -39,7 +42,7 @@ class TestTrelloIssue:
             targets=[], inline_links=True, description_length=31
         )
         extra = {'boardname': 'Hyperspatial express route', 'listname': 'Something'}
-        return TrelloIssue(self.JSON, config, main_config, extra)
+        return TrelloIssue(record, config, main_config, extra)
 
     def test_default_description(self, issue):
         """Test the generated description"""
@@ -54,51 +57,69 @@ class TestTrelloIssue:
         assert expected_project == issue.to_taskwarrior().get('project', None)
 
 
-class TestTrelloService:
-    BOARD = {'id': 'B04RD', 'name': 'My Board'}
-    CARD1 = {
-        'id': 'C4RD',
-        'name': 'Card 1',
-        'members': [{'username': 'tintin'}],
-        'due': '2018-12-02T12:59:00.000Z',
-        'idShort': 1,
-        'shortLink': 'abcd',
-        'shortUrl': 'https://trello.com/c/AAaaBBbb',
-        'labels': [{'name': 'foo'}, {'name': 'bar'}],
-        'desc': 'some description',
-        'url': 'https://trello.com/c/AAaBBbb/42-so-long',
-    }
-    CARD2 = {'id': 'kard', 'name': 'Card 2', 'members': [{'username': 'mario'}]}
-    CARD3 = {'id': 'K4rD', 'name': 'Card 3', 'members': []}
-    LIST1 = {'id': 'L15T', 'name': 'List 1'}
-    LIST2 = {'id': 'ZZZZ', 'name': 'List 2'}
-    COMMENT1 = {
-        "type": "commentCard",
-        "data": {"text": "Preums"},
-        "memberCreator": {"username": "luidgi"},
-    }
-    COMMENT2 = {
-        "type": "commentCard",
-        "data": {"text": "Deuz"},
-        "memberCreator": {"username": "mario"},
-    }
+@pytest.fixture
+def board():
+    return {'id': 'B04RD', 'name': 'My Board'}
 
+
+@pytest.fixture
+def cards():
+    return [
+        {
+            'id': 'C4RD',
+            'name': 'Card 1',
+            'members': [{'username': 'tintin'}],
+            'due': '2018-12-02T12:59:00.000Z',
+            'idShort': 1,
+            'shortLink': 'abcd',
+            'shortUrl': 'https://trello.com/c/AAaaBBbb',
+            'labels': [{'name': 'foo'}, {'name': 'bar'}],
+            'desc': 'some description',
+            'url': 'https://trello.com/c/AAaBBbb/42-so-long',
+        },
+        {'id': 'kard', 'name': 'Card 2', 'members': [{'username': 'mario'}]},
+        {'id': 'K4rD', 'name': 'Card 3', 'members': []},
+    ]
+
+
+@pytest.fixture
+def lists():
+    return [{'id': 'L15T', 'name': 'List 1'}, {'id': 'ZZZZ', 'name': 'List 2'}]
+
+
+@pytest.fixture
+def comments():
+    return [
+        {
+            "type": "commentCard",
+            "data": {"text": "Preums"},
+            "memberCreator": {"username": "luidgi"},
+        },
+        {
+            "type": "commentCard",
+            "data": {"text": "Deuz"},
+            "memberCreator": {"username": "mario"},
+        },
+    ]
+
+
+class TestTrelloService:
     @pytest.fixture
     def config(self):
         return {'general': {'targets': ['mytrello']}, 'mytrello': {**SERVICE_CONFIG}}
 
     @pytest.fixture(autouse=True)
-    def mock_api(self):
+    def mock_api(self, board, cards, lists, comments):
         with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
             rsps.add(
                 responses.GET,
                 'https://api.trello.com/1/lists/L15T/cards/open',
-                json=[self.CARD1, self.CARD2, self.CARD3],
+                json=cards,
             )
             rsps.add(
                 responses.GET,
                 'https://api.trello.com/1/boards/B04RD/lists/open',
-                json=[self.LIST1, self.LIST2],
+                json=lists,
             )
             rsps.add(
                 responses.GET,
@@ -113,12 +134,12 @@ class TestTrelloService:
             rsps.add(
                 responses.GET,
                 'https://api.trello.com/1/members/me/boards',
-                json=[self.BOARD],
+                json=[board],
             )
             rsps.add(
                 responses.GET,
                 'https://api.trello.com/1/cards/C4RD/actions',
-                json=[self.COMMENT1, self.COMMENT2],
+                json=comments,
             )
             yield rsps
 
@@ -131,61 +152,54 @@ class TestTrelloService:
             {'id': 'B4R', 'name': 'Bar Board'},
         ]
 
-    def test_get_boards_api(self, config):
+    def test_get_boards_api(self, config, board):
         service = get_validated_service(config)
         boards = service.get_boards()
-        assert list(boards) == [self.BOARD]
+        assert list(boards) == [board]
 
-    def test_get_lists(self, config):
+    def test_get_lists(self, config, lists):
         service = get_validated_service(config)
-        lists = service.get_lists('B04RD')
-        assert list(lists) == [self.LIST1, self.LIST2]
+        assert list(service.get_lists('B04RD')) == lists
 
-    def test_get_lists_include(self, config):
+    def test_get_lists_include(self, config, lists):
         config['mytrello']['include_lists'] = 'List 1'
         service = get_validated_service(config)
-        lists = service.get_lists('B04RD')
-        assert list(lists) == [self.LIST1]
+        assert list(service.get_lists('B04RD')) == [lists[0]]
 
-    def test_get_lists_exclude(self, config):
+    def test_get_lists_exclude(self, config, lists):
         config['mytrello']['exclude_lists'] = 'List 1'
         service = get_validated_service(config)
-        lists = service.get_lists('B04RD')
-        assert list(lists) == [self.LIST2]
+        assert list(service.get_lists('B04RD')) == [lists[1]]
 
-    def test_get_cards(self, config):
+    def test_get_cards(self, config, cards):
         service = get_validated_service(config)
-        cards = service.get_cards('L15T')
-        assert list(cards) == [self.CARD1, self.CARD2, self.CARD3]
+        assert list(service.get_cards('L15T')) == cards
 
-    def test_get_cards_assigned(self, config):
+    def test_get_cards_assigned(self, config, cards):
         config['mytrello']['only_if_assigned'] = 'tintin'
         service = get_validated_service(config)
-        cards = service.get_cards('L15T')
-        assert list(cards) == [self.CARD1]
+        assert list(service.get_cards('L15T')) == [cards[0]]
 
-    def test_get_cards_assigned_unassigned(self, config):
+    def test_get_cards_assigned_unassigned(self, config, cards):
         config['mytrello'].update(
             {'only_if_assigned': 'tintin', 'also_unassigned': 'true'}
         )
         service = get_validated_service(config)
-        cards = service.get_cards('L15T')
-        assert list(cards) == [self.CARD1, self.CARD3]
+        assert list(service.get_cards('L15T')) == [cards[0], cards[2]]
 
-    def test_get_comments(self, config):
+    def test_get_comments(self, config, comments):
         service = get_validated_service(config)
-        comments = service.get_comments('C4RD')
-        assert list(comments) == [self.COMMENT1, self.COMMENT2]
+        assert list(service.get_comments('C4RD')) == comments
 
-    def test_annotations(self, config):
+    def test_annotations(self, config, cards):
         service = get_validated_service(config)
-        annotations = service.annotations(self.CARD1)
+        annotations = service.annotations(cards[0])
         assert list(annotations) == ["@luidgi - Preums", "@mario - Deuz"]
 
-    def test_annotations_with_link(self, config):
+    def test_annotations_with_link(self, config, cards):
         config['general']['annotation_links'] = 'true'
         service = get_validated_service(config)
-        annotations = service.annotations(self.CARD1)
+        annotations = service.annotations(cards[0])
         assert list(annotations) == [
             "https://trello.com/c/AAaaBBbb",
             "@luidgi - Preums",

--- a/tests/services/test_trello.py
+++ b/tests/services/test_trello.py
@@ -106,7 +106,7 @@ def comments():
 class TestTrelloService:
     @pytest.fixture
     def config(self):
-        return {'general': {'targets': ['mytrello']}, 'mytrello': {**SERVICE_CONFIG}}
+        return {'general': {'targets': ['myservice']}, 'myservice': {**SERVICE_CONFIG}}
 
     @pytest.fixture(autouse=True)
     def mock_api(self, board, cards, lists, comments):
@@ -144,7 +144,7 @@ class TestTrelloService:
             yield rsps
 
     def test_get_boards_config(self, config):
-        config['mytrello']['include_boards'] = 'F00, B4R'
+        config['myservice']['include_boards'] = 'F00, B4R'
         service = get_validated_service(config)
         boards = service.get_boards()
         assert list(boards) == [
@@ -162,12 +162,12 @@ class TestTrelloService:
         assert list(service.get_lists('B04RD')) == lists
 
     def test_get_lists_include(self, config, lists):
-        config['mytrello']['include_lists'] = 'List 1'
+        config['myservice']['include_lists'] = 'List 1'
         service = get_validated_service(config)
         assert list(service.get_lists('B04RD')) == [lists[0]]
 
     def test_get_lists_exclude(self, config, lists):
-        config['mytrello']['exclude_lists'] = 'List 1'
+        config['myservice']['exclude_lists'] = 'List 1'
         service = get_validated_service(config)
         assert list(service.get_lists('B04RD')) == [lists[1]]
 
@@ -176,12 +176,12 @@ class TestTrelloService:
         assert list(service.get_cards('L15T')) == cards
 
     def test_get_cards_assigned(self, config, cards):
-        config['mytrello']['only_if_assigned'] = 'tintin'
+        config['myservice']['only_if_assigned'] = 'tintin'
         service = get_validated_service(config)
         assert list(service.get_cards('L15T')) == [cards[0]]
 
     def test_get_cards_assigned_unassigned(self, config, cards):
-        config['mytrello'].update(
+        config['myservice'].update(
             {'only_if_assigned': 'tintin', 'also_unassigned': 'true'}
         )
         service = get_validated_service(config)
@@ -207,7 +207,7 @@ class TestTrelloService:
         ]
 
     def test_issues(self, config):
-        config['mytrello'].update(
+        config['myservice'].update(
             {'include_lists': 'List 1', 'only_if_assigned': 'tintin'}
         )
         service = get_validated_service(config)
@@ -236,14 +236,14 @@ class TestTrelloService:
         validate(config)
 
     def test_valid_config_no_access_token(self, config, assert_validation_error):
-        del config['mytrello']['token']
+        del config['myservice']['token']
 
-        assert_validation_error(config, '[mytrello]\ntoken  <- Field required')
+        assert_validation_error(config, '[myservice]\ntoken  <- Field required')
 
     def test_valid_config_no_api_key(self, config, assert_validation_error):
-        del config['mytrello']['api_key']
+        del config['myservice']['api_key']
 
-        assert_validation_error(config, '[mytrello]\napi_key  <- Field required')
+        assert_validation_error(config, '[myservice]\napi_key  <- Field required')
 
     def test_keyring_service(self, config):
         """Checks that the keyring service name"""

--- a/tests/services/test_youtrak.py
+++ b/tests/services/test_youtrak.py
@@ -7,6 +7,14 @@ from bugwarrior.services.youtrack import YoutrackService
 from ..base import validate
 from .base import get_mock_service
 
+SERVICE_CONFIG = {
+    'service': 'youtrack',
+    'host': 'youtrack.example.com',
+    'login': 'arbitrary_login',
+    'token': 'arbitrary_token',
+    'anonymous': True,
+}
+
 
 class TestYoutrackService:
     @pytest.fixture
@@ -25,14 +33,6 @@ class TestYoutrackService:
 
 
 class TestYoutrackIssue:
-    SERVICE_CONFIG = {
-        'service': 'youtrack',
-        'host': 'youtrack.example.com',
-        'login': 'arbitrary_login',
-        'token': 'arbitrary_token',
-        'anonymous': True,
-    }
-
     arbitrary_issue = {
         "id": "2-1",
         "$type": "Issue",
@@ -48,16 +48,12 @@ class TestYoutrackIssue:
 
     @pytest.fixture
     def service(self):
-        return get_mock_service(YoutrackService, self.SERVICE_CONFIG)
+        return get_mock_service(YoutrackService, SERVICE_CONFIG)
 
     def test_get_tags_from_labels_uses_legacy_tag_options(self, caplog):
         service = get_mock_service(
             YoutrackService,
-            {
-                **self.SERVICE_CONFIG,
-                'import_tags': True,
-                'tag_template': 'yt_{{tag|lower}}',
-            },
+            {**SERVICE_CONFIG, 'import_tags': True, 'tag_template': 'yt_{{tag|lower}}'},
         )
         issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
 
@@ -75,11 +71,7 @@ class TestYoutrackIssue:
     def test_refine_record_does_not_apply_legacy_tag_template_as_field_template(self):
         service = get_mock_service(
             YoutrackService,
-            {
-                **self.SERVICE_CONFIG,
-                'import_tags': True,
-                'tag_template': 'yt_{{tag|lower}}',
-            },
+            {**SERVICE_CONFIG, 'import_tags': True, 'tag_template': 'yt_{{tag|lower}}'},
         )
         issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
 

--- a/tests/services/test_youtrak.py
+++ b/tests/services/test_youtrak.py
@@ -52,16 +52,24 @@ class TestYoutrackService:
         )
 
 
-class TestYoutrackIssue:
-    @pytest.fixture
-    def service(self):
-        return get_mock_service(YoutrackService, SERVICE_CONFIG)
+@pytest.fixture
+def make_service():
+    def make(**overrides):
+        return get_mock_service(YoutrackService, {**SERVICE_CONFIG, **overrides})
 
-    def test_get_tags_from_labels_uses_legacy_tag_options(self, caplog, record, extra):
-        service = get_mock_service(
-            YoutrackService,
-            {**SERVICE_CONFIG, 'import_tags': True, 'tag_template': 'yt_{{tag|lower}}'},
-        )
+    return make
+
+
+@pytest.fixture
+def service(make_service):
+    return make_service()
+
+
+class TestYoutrackIssue:
+    def test_get_tags_from_labels_uses_legacy_tag_options(
+        self, caplog, make_service, record, extra
+    ):
+        service = make_service(import_tags=True, tag_template='yt_{{tag|lower}}')
         issue = service.get_issue_for_record(record, extra)
 
         assert service.config.label_template == 'yt_{{label|lower}}'
@@ -76,12 +84,9 @@ class TestYoutrackIssue:
         )
 
     def test_refine_record_does_not_apply_legacy_tag_template_as_field_template(
-        self, record, extra
+        self, make_service, record, extra
     ):
-        service = get_mock_service(
-            YoutrackService,
-            {**SERVICE_CONFIG, 'import_tags': True, 'tag_template': 'yt_{{tag|lower}}'},
-        )
+        service = make_service(import_tags=True, tag_template='yt_{{tag|lower}}')
         issue = service.get_issue_for_record(record, extra)
 
         assert service.config.templates == {}

--- a/tests/services/test_youtrak.py
+++ b/tests/services/test_youtrak.py
@@ -16,6 +16,26 @@ SERVICE_CONFIG = {
 }
 
 
+@pytest.fixture
+def record():
+    return {
+        "id": "2-1",
+        "$type": "Issue",
+        "numberInProject": 1,
+        "summary": "Hello World",
+        "project": {"shortName": "TEST", "$type": "Project"},
+        "tags": [
+            {"$type": "IssueTag", "name": "bug"},
+            {"$type": "IssueTag", "name": "New Feature"},
+        ],
+    }
+
+
+@pytest.fixture
+def extra():
+    return {}
+
+
 class TestYoutrackService:
     @pytest.fixture
     def config(self):
@@ -33,29 +53,16 @@ class TestYoutrackService:
 
 
 class TestYoutrackIssue:
-    arbitrary_issue = {
-        "id": "2-1",
-        "$type": "Issue",
-        "numberInProject": 1,
-        "summary": "Hello World",
-        "project": {"shortName": "TEST", "$type": "Project"},
-        "tags": [
-            {"$type": "IssueTag", "name": "bug"},
-            {"$type": "IssueTag", "name": "New Feature"},
-        ],
-    }
-    arbitrary_extra = {}
-
     @pytest.fixture
     def service(self):
         return get_mock_service(YoutrackService, SERVICE_CONFIG)
 
-    def test_get_tags_from_labels_uses_legacy_tag_options(self, caplog):
+    def test_get_tags_from_labels_uses_legacy_tag_options(self, caplog, record, extra):
         service = get_mock_service(
             YoutrackService,
             {**SERVICE_CONFIG, 'import_tags': True, 'tag_template': 'yt_{{tag|lower}}'},
         )
-        issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
+        issue = service.get_issue_for_record(record, extra)
 
         assert service.config.label_template == 'yt_{{label|lower}}'
         assert issue.get_tags() == ['yt_bug', 'yt_new_feature']
@@ -68,12 +75,14 @@ class TestYoutrackIssue:
             in caplog.text
         )
 
-    def test_refine_record_does_not_apply_legacy_tag_template_as_field_template(self):
+    def test_refine_record_does_not_apply_legacy_tag_template_as_field_template(
+        self, record, extra
+    ):
         service = get_mock_service(
             YoutrackService,
             {**SERVICE_CONFIG, 'import_tags': True, 'tag_template': 'yt_{{tag|lower}}'},
         )
-        issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
+        issue = service.get_issue_for_record(record, extra)
 
         assert service.config.templates == {}
         assert TaskConstructor(issue).get_taskwarrior_record()['tags'] == [
@@ -81,9 +90,9 @@ class TestYoutrackIssue:
             'yt_new_feature',
         ]
 
-    def test_to_taskwarrior(self, service):
+    def test_to_taskwarrior(self, service, record, extra):
         service.import_tags = True
-        issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
+        issue = service.get_issue_for_record(record, extra)
 
         expected_output = {
             'project': 'TEST',
@@ -100,10 +109,10 @@ class TestYoutrackIssue:
         assert actual_output == expected_output
 
     @responses.activate
-    def test_issues(self, service):
+    def test_issues(self, service, record):
         responses.get(
             'https://youtrack.example.com:443/api/issues?query=for%3Ame+%23Unresolved&max=100&fields=id,summary,project(shortName),numberInProject,tags(name)',  # noqa: E501
-            json=[self.arbitrary_issue],
+            json=[record],
         )
 
         issue = next(service.issues())

--- a/tests/services/test_youtrak.py
+++ b/tests/services/test_youtrak.py
@@ -53,8 +53,11 @@ class TestYoutrackIssue:
     def test_get_tags_from_labels_uses_legacy_tag_options(self, caplog):
         service = get_mock_service(
             YoutrackService,
-            self.SERVICE_CONFIG,
-            config_overrides={'import_tags': True, 'tag_template': 'yt_{{tag|lower}}'},
+            {
+                **self.SERVICE_CONFIG,
+                'import_tags': True,
+                'tag_template': 'yt_{{tag|lower}}',
+            },
         )
         issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
 
@@ -72,8 +75,11 @@ class TestYoutrackIssue:
     def test_refine_record_does_not_apply_legacy_tag_template_as_field_template(self):
         service = get_mock_service(
             YoutrackService,
-            self.SERVICE_CONFIG,
-            config_overrides={'import_tags': True, 'tag_template': 'yt_{{tag|lower}}'},
+            {
+                **self.SERVICE_CONFIG,
+                'import_tags': True,
+                'tag_template': 'yt_{{tag|lower}}',
+            },
         )
         issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
 

--- a/tests/services/test_youtrak.py
+++ b/tests/services/test_youtrak.py
@@ -5,7 +5,8 @@ from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.youtrack import YoutrackService
 
 from ..base import validate
-from .base import get_mock_service
+
+SERVICE_CLASS = YoutrackService
 
 SERVICE_CONFIG = {
     'service': 'youtrack',
@@ -50,19 +51,6 @@ class TestYoutrackService:
         assert (
             service_config.keyring_service == 'youtrack://foobar@youtrack.example.com'
         )
-
-
-@pytest.fixture
-def make_service():
-    def make(**overrides):
-        return get_mock_service(YoutrackService, {**SERVICE_CONFIG, **overrides})
-
-    return make
-
-
-@pytest.fixture
-def service(make_service):
-    return make_service()
 
 
 class TestYoutrackIssue:

--- a/tests/services/test_youtrak.py
+++ b/tests/services/test_youtrak.py
@@ -1,28 +1,30 @@
+import pytest
 import responses
 
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.services.youtrack import YoutrackService
 
-from .base import ConfigTest, ServiceIssueTest
+from ..base import validate
+from .base import get_mock_service
 
 
-class TestYoutrackService(ConfigTest):
-    def setUp(self):
-        super().setUp()
-        self.config = {
+class TestYoutrackService:
+    @pytest.fixture
+    def config(self):
+        return {
             'general': {'targets': ['myservice']},
             'myservice': {'service': 'youtrack', 'login': 'foobar', 'token': 'XXXXXX'},
         }
 
-    def test_keyring_service(self):
-        self.config['myservice']['host'] = 'youtrack.example.com'
-        service_config = self.validate().service_configs[0]
+    def test_keyring_service(self, config):
+        config['myservice']['host'] = 'youtrack.example.com'
+        service_config = validate(config).service_configs[0]
         assert (
             service_config.keyring_service == 'youtrack://foobar@youtrack.example.com'
         )
 
 
-class TestYoutrackIssue(ServiceIssueTest):
+class TestYoutrackIssue:
     SERVICE_CONFIG = {
         'service': 'youtrack',
         'host': 'youtrack.example.com',
@@ -44,13 +46,14 @@ class TestYoutrackIssue(ServiceIssueTest):
     }
     arbitrary_extra = {}
 
-    def setUp(self):
-        super().setUp()
-        self.service = self.get_mock_service(YoutrackService)
+    @pytest.fixture
+    def service(self):
+        return get_mock_service(YoutrackService, self.SERVICE_CONFIG)
 
-    def test_get_tags_from_labels_uses_legacy_tag_options(self):
-        service = self.get_mock_service(
+    def test_get_tags_from_labels_uses_legacy_tag_options(self, caplog):
+        service = get_mock_service(
             YoutrackService,
+            self.SERVICE_CONFIG,
             config_overrides={'import_tags': True, 'tag_template': 'yt_{{tag|lower}}'},
         )
         issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
@@ -58,20 +61,18 @@ class TestYoutrackIssue(ServiceIssueTest):
         assert service.config.label_template == 'yt_{{label|lower}}'
         assert issue.get_tags() == ['yt_bug', 'yt_new_feature']
         assert (
-            'import_tags is deprecated in favor of import_labels_as_tags'
-            in self.caplog.text
+            'import_tags is deprecated in favor of import_labels_as_tags' in caplog.text
         )
-        assert (
-            'tag_template is deprecated in favor of label_template' in self.caplog.text
-        )
+        assert 'tag_template is deprecated in favor of label_template' in caplog.text
         assert (
             "The 'tag' variable in YouTrack label templates is deprecated in favor of 'label'."
-            in self.caplog.text
+            in caplog.text
         )
 
     def test_refine_record_does_not_apply_legacy_tag_template_as_field_template(self):
-        service = self.get_mock_service(
+        service = get_mock_service(
             YoutrackService,
+            self.SERVICE_CONFIG,
             config_overrides={'import_tags': True, 'tag_template': 'yt_{{tag|lower}}'},
         )
         issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
@@ -82,15 +83,13 @@ class TestYoutrackIssue(ServiceIssueTest):
             'yt_new_feature',
         ]
 
-    def test_to_taskwarrior(self):
-        self.service.import_tags = True
-        issue = self.service.get_issue_for_record(
-            self.arbitrary_issue, self.arbitrary_extra
-        )
+    def test_to_taskwarrior(self, service):
+        service.import_tags = True
+        issue = service.get_issue_for_record(self.arbitrary_issue, self.arbitrary_extra)
 
         expected_output = {
             'project': 'TEST',
-            'priority': self.service.config.default_priority,
+            'priority': service.config.default_priority,
             'tags': ['bug', 'new_feature'],
             issue.ISSUE: 'TEST-1',
             issue.SUMMARY: 'Hello World',
@@ -103,18 +102,18 @@ class TestYoutrackIssue(ServiceIssueTest):
         assert actual_output == expected_output
 
     @responses.activate
-    def test_issues(self):
+    def test_issues(self, service):
         responses.get(
             'https://youtrack.example.com:443/api/issues?query=for%3Ame+%23Unresolved&max=100&fields=id,summary,project(shortName),numberInProject,tags(name)',  # noqa: E501
             json=[self.arbitrary_issue],
         )
 
-        issue = next(self.service.issues())
+        issue = next(service.issues())
 
         expected = {
             'description': '(bw)Is#TEST-1 - Hello World .. https://youtrack.example.com:443/issue/TEST-1',
             'project': 'TEST',
-            'priority': self.service.config.default_priority,
+            'priority': service.config.default_priority,
             'tags': ['bug', 'new_feature'],
             'youtrackissue': 'TEST-1',
             'youtracksummary': 'Hello World',

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,15 +1,15 @@
 import logging
-import os
 import pathlib
 import typing
 from unittest import mock
 
 from click.testing import CliRunner
+import pytest
 
 from bugwarrior import command
 from bugwarrior.config.load import BugwarriorConfigParser
 
-from .base import ConfigTest, DumbConfig, DumbIssue, DumbService, register_services
+from .base import DumbConfig, DumbIssue, DumbService, register_services
 
 
 class SecondaryConfig(DumbConfig):
@@ -74,79 +74,84 @@ def fake_service(issues, base=DumbService):
     return type('FakeService', (base,), {'issues': issues})
 
 
-class TestPull(ConfigTest):
-    def setUp(self):
-        super().setUp()
+@pytest.fixture
+def runner():
+    return CliRunner()
 
-        self.runner = CliRunner()
-        self.config = BugwarriorConfigParser()
 
-        self.config['general'] = {
+class TestPull:
+    @pytest.fixture
+    def write_rc(self, tmp_path):
+        """
+        Return a factory writing a configparser object to the bugwarriorrc path.
+        """
+
+        def write(conf):
+            rcfile = tmp_path / '.config' / 'bugwarrior' / 'bugwarriorrc'
+            rcfile.parent.mkdir(parents=True, exist_ok=True)
+            with rcfile.open('w') as configfile:
+                conf.write(configfile)
+            return rcfile
+
+        return write
+
+    @pytest.fixture
+    def config(self, config_environment, write_rc):
+        config = BugwarriorConfigParser()
+
+        config['general'] = {
             'targets': 'my_service',
             'static_fields': 'project, priority',
-            'taskrc': self.taskrc,
+            'taskrc': str(config_environment.taskrc),
         }
-        self.config['my_service'] = {'service': 'test'}
+        config['my_service'] = {'service': 'test'}
 
-        self.write_rc(self.config)
+        write_rc(config)
+        return config
 
-    def write_rc(self, conf):
-        """
-        Write configparser object to temporary bugwarriorrc path.
-        """
-        rcfile = os.path.join(self.tempdir, '.config/bugwarrior/bugwarriorrc')
-        if not os.path.exists(os.path.dirname(rcfile)):
-            os.makedirs(os.path.dirname(rcfile))
-        with open(rcfile, 'w') as configfile:
-            conf.write(configfile)
-        return rcfile
-
-    def test_success(self):
+    def test_success(self, runner, config, caplog):
         """
         A normal `bugwarrior pull` invocation.
         """
         with (
             register_services({'test': fake_service(yields_one())}),
-            self.caplog.at_level(logging.INFO),
+            caplog.at_level(logging.INFO),
         ):
-            self.runner.invoke(command.cli, args=('pull', '--debug'))
+            runner.invoke(command.cli, args=('pull', '--debug'))
 
-        logs = [rec.message for rec in self.caplog.records]
+        logs = [rec.message for rec in caplog.records]
 
         assert 'Adding 1 tasks' in logs
         assert 'Updating 0 tasks' in logs
         assert 'Closing 0 tasks' in logs
 
-    def test_failure(self):
+    def test_failure(self, runner, config, caplog):
         """
         A broken `bugwarrior pull` invocation.
         """
         with (
             register_services({'test': fake_service(raises)}),
-            self.caplog.at_level(logging.ERROR),
+            caplog.at_level(logging.ERROR),
         ):
-            self.runner.invoke(command.cli, args=('pull', '--debug'))
+            runner.invoke(command.cli, args=('pull', '--debug'))
 
-        assert self.caplog.records != []
-        assert len(self.caplog.records) == 2
+        assert caplog.records != []
+        assert len(caplog.records) == 2
+        assert caplog.records[0].message == "Worker for [my_service] failed: message"
         assert (
-            self.caplog.records[0].message == "Worker for [my_service] failed: message"
-        )
-        assert (
-            self.caplog.records[1].message
-            == "Aborted [my_service] due to critical error."
+            caplog.records[1].message == "Aborted [my_service] due to critical error."
         )
 
-    def test_partial_failure_survival(self):
+    def test_partial_failure_survival(self, runner, config, caplog, write_rc):
         """
         One service is broken but the other succeeds.
 
         Synchronization should work for succeeding services even if one service
         fails.  See https://github.com/ralphbean/bugwarrior/issues/279.
         """
-        self.config['general']['targets'] = 'my_service,my_broken_service'
-        self.config['my_broken_service'] = {'service': 'secondary'}
-        self.write_rc(self.config)
+        config['general']['targets'] = 'my_service,my_broken_service'
+        config['my_broken_service'] = {'service': 'secondary'}
+        write_rc(config)
 
         with (
             register_services(
@@ -155,23 +160,23 @@ class TestPull(ConfigTest):
                     'secondary': fake_service(raises, base=SecondaryService),
                 }
             ),
-            self.caplog.at_level(logging.INFO),
+            caplog.at_level(logging.INFO),
         ):
-            self.runner.invoke(command.cli, args=('pull', '--debug'))
+            runner.invoke(command.cli, args=('pull', '--debug'))
 
-        logs = [rec.message for rec in self.caplog.records]
+        logs = [rec.message for rec in caplog.records]
         assert 'Aborted [my_broken_service] due to critical error.' in logs
         assert 'Adding 0 tasks' in logs
 
-    def test_partial_failure_database_integrity(self):
+    def test_partial_failure_database_integrity(self, runner, config, caplog, write_rc):
         """
         When a service fails and is terminated, don't close existing tasks.
 
         See https://github.com/ralphbean/bugwarrior/issues/821.
         """
-        self.config['general']['targets'] = 'my_service,my_broken_service'
-        self.config['my_broken_service'] = {'service': 'secondary'}
-        self.write_rc(self.config)
+        config['general']['targets'] = 'my_service,my_broken_service'
+        config['my_broken_service'] = {'service': 'secondary'}
+        write_rc(config)
 
         # Add a task to each service.
         both_working = {
@@ -180,9 +185,9 @@ class TestPull(ConfigTest):
                 yields_one(target_specific_url=True), base=SecondaryService
             ),
         }
-        with register_services(both_working), self.caplog.at_level(logging.DEBUG):
-            self.runner.invoke(command.cli, args=('pull', '--debug'))
-        logs = [rec.message for rec in self.caplog.records]
+        with register_services(both_working), caplog.at_level(logging.DEBUG):
+            runner.invoke(command.cli, args=('pull', '--debug'))
+        logs = [rec.message for rec in caplog.records]
         assert 'Adding 2 tasks' in logs
 
         # Break the secondary service and run pull again.
@@ -190,9 +195,9 @@ class TestPull(ConfigTest):
             'test': fake_service(yields_one(target_specific_url=True)),
             'secondary': fake_service(raises, base=SecondaryService),
         }
-        with register_services(secondary_broken), self.caplog.at_level(logging.INFO):
-            self.runner.invoke(command.cli, args=('pull', '--debug'))
-        logs = [rec.message for rec in self.caplog.records]
+        with register_services(secondary_broken), caplog.at_level(logging.INFO):
+            runner.invoke(command.cli, args=('pull', '--debug'))
+        logs = [rec.message for rec in caplog.records]
 
         # Make sure my_broken_service failed while my_service succeeded.
         assert 'Aborted [my_broken_service] due to critical error.' in logs
@@ -203,27 +208,29 @@ class TestPull(ConfigTest):
         assert 'Completing task' not in logs
 
     @mock.patch('bugwarrior.command.FileLock')
-    def test_locked_repository(self, file_lock):
+    def test_locked_repository(
+        self, file_lock, runner, config, config_environment, caplog
+    ):
         """
         A locked task repository should abort the pull.
         """
-        lockfile_path = pathlib.Path(self.lists_path) / 'bugwarrior.lockfile'
+        lockfile_path = config_environment.lists_path / 'bugwarrior.lockfile'
         file_lock.return_value.__enter__.side_effect = command.Timeout(
             str(lockfile_path)
         )
 
         with (
             register_services({'test': DumbService}),
-            self.caplog.at_level(logging.CRITICAL),
+            caplog.at_level(logging.CRITICAL),
         ):
-            result = self.runner.invoke(command.cli, args=('pull', '--debug'))
+            result = runner.invoke(command.cli, args=('pull', '--debug'))
 
         assert result.exit_code == 1
         file_lock.assert_called_once_with(str(lockfile_path), timeout=10)
-        logs = [rec.message for rec in self.caplog.records]
+        logs = [rec.message for rec in caplog.records]
         assert any('Your taskrc repository is currently locked.' in log for log in logs)
 
-    def test_legacy_cli(self):
+    def test_legacy_cli(self, runner, config, caplog):
         """
         Test that invoking the subcommand function directly still works.
 
@@ -231,11 +238,11 @@ class TestPull(ConfigTest):
         """
         with (
             register_services({'test': fake_service(yields_one())}),
-            self.caplog.at_level(logging.INFO),
+            caplog.at_level(logging.INFO),
         ):
-            self.runner.invoke(command.pull, args=('--debug'))
+            runner.invoke(command.pull, args=('--debug'))
 
-        logs = [rec.message for rec in self.caplog.records]
+        logs = [rec.message for rec in caplog.records]
 
         assert 'Adding 1 tasks' in logs
         assert 'Updating 0 tasks' in logs
@@ -243,9 +250,8 @@ class TestPull(ConfigTest):
 
 
 class TestIni2Toml:
-    def test_bugwarriorrc(self):
+    def test_bugwarriorrc(self, runner):
         basedir = pathlib.Path(__file__).parent
-        runner = CliRunner()
         result = runner.invoke(
             command.cli, args=('ini2toml', str(basedir / 'config/example-bugwarriorrc'))
         )

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,6 +1,7 @@
 import copy
 from types import SimpleNamespace
 
+import pytest
 import taskw.task
 
 from bugwarrior import db
@@ -8,7 +9,7 @@ from bugwarrior.collect import CollectedIssue
 from bugwarrior.config import schema
 from bugwarrior.config.validation import Config
 
-from .base import ConfigTest, DumbConfig, register_services
+from .base import DumbConfig, register_services
 
 
 class TestMergeAnnotations:
@@ -60,21 +61,28 @@ class TestMergeTags:
         assert db.merge_tags(main_conf, {}, {'tags': ['new']}) == ['new']
 
 
-class TestSynchronize(ConfigTest):
-    def setUp(self):
-        super().setUp()
-        self.enterContext(register_services())
-        self.bwconfig = Config(
+class TestSynchronize:
+    @pytest.fixture(autouse=True)
+    def registered_services(self):
+        with register_services():
+            yield
+
+    @pytest.fixture
+    def bwconfig(self, config_environment):
+        return Config(
             service_configs=[DumbConfig(target='my_service')],
             main=schema.MainSectionConfig(
                 targets=['my_service'],
-                taskrc=self.taskrc,
+                taskrc=config_environment.taskrc,
                 static_fields=['project', 'priority'],
             ),
         )
-        self.tw = taskw.TaskWarrior(self.taskrc)
 
-    def synchronize(self, issues_data):
+    @pytest.fixture
+    def tw(self, config_environment):
+        return taskw.TaskWarrior(config_environment.taskrc)
+
+    def synchronize(self, bwconfig, issues_data):
 
         issue_generator = [
             CollectedIssue(
@@ -84,7 +92,7 @@ class TestSynchronize(ConfigTest):
             )
             for issue_data in issues_data
         ]
-        db.synchronize(iter(issue_generator), self.bwconfig)
+        db.synchronize(iter(issue_generator), bwconfig)
 
     def remove_non_deterministic_keys(self, tasks):
         for status in ['pending', 'completed']:
@@ -96,13 +104,13 @@ class TestSynchronize(ConfigTest):
 
         return tasks
 
-    def get_tasks(self):
+    def get_tasks(self, tw):
 
-        return self.remove_non_deterministic_keys(self.tw.load_tasks())
+        return self.remove_non_deterministic_keys(tw.load_tasks())
 
-    def test_synchronize(self):
+    def test_synchronize(self, bwconfig, tw):
 
-        assert self.tw.load_tasks() == {'completed': [], 'pending': []}
+        assert tw.load_tasks() == {'completed': [], 'pending': []}
 
         issue = {
             'description': 'Blah blah blah. ☃',
@@ -121,9 +129,9 @@ class TestSynchronize(ConfigTest):
             # These should be de-duplicated in db.synchronize before
             # writing out to taskwarrior.
             # https://github.com/ralphbean/bugwarrior/issues/601
-            self.synchronize([issue, duplicate_issue])
+            self.synchronize(bwconfig, [issue, duplicate_issue])
 
-            assert self.get_tasks() == {
+            assert self.get_tasks(tw) == {
                 'completed': [],
                 'pending': [
                     {
@@ -145,9 +153,9 @@ class TestSynchronize(ConfigTest):
 
         # Change static field
         issue['project'] = 'other_project'
-        self.synchronize([issue])
+        self.synchronize(bwconfig, [issue])
 
-        assert self.get_tasks() == {
+        assert self.get_tasks(tw) == {
             'completed': [],
             'pending': [
                 {
@@ -165,9 +173,9 @@ class TestSynchronize(ConfigTest):
         }
 
         # TEST CLOSED ISSUE.
-        self.synchronize([])
+        self.synchronize(bwconfig, [])
 
-        completed_tasks = self.tw.load_tasks()
+        completed_tasks = tw.load_tasks()
 
         tasks = self.remove_non_deterministic_keys(copy.deepcopy(completed_tasks))
         del tasks['completed'][0]['end']
@@ -189,9 +197,9 @@ class TestSynchronize(ConfigTest):
         }
 
         # TEST REOPENED ISSUE
-        self.synchronize([issue])
+        self.synchronize(bwconfig, [issue])
 
-        tasks = self.tw.load_tasks()
+        tasks = tw.load_tasks()
         assert completed_tasks['completed'][0]['uuid'] == tasks['pending'][0]['uuid']
 
         tasks = self.remove_non_deterministic_keys(tasks)
@@ -213,13 +221,13 @@ class TestSynchronize(ConfigTest):
         }
 
 
-class TestUDAs(ConfigTest):
-    def test_udas(self):
+class TestUDAs:
+    def test_udas(self, config_environment):
         with register_services():
             conf = Config(
                 service_configs=[DumbConfig(target='my_service')],
                 main=schema.MainSectionConfig(
-                    targets=['my_service'], taskrc=self.taskrc
+                    targets=['my_service'], taskrc=config_environment.taskrc
                 ),
             )
             udas = sorted(db.get_defined_udas_as_strings(conf))

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -13,7 +13,7 @@ import pytest
 DOCS_PATH = pathlib.Path(__file__).parent / '../bugwarrior/docs'
 
 try:
-    socket.create_connection(('1.1.1.1', 80))
+    socket.create_connection(('1.1.1.1', 80)).close()
     INTERNET = True
 except OSError:
     INTERNET = False
@@ -32,7 +32,7 @@ class TestReadme:
             readme = f.read()
 
         readme_document = docutils.core.publish_doctree(readme)
-        service_list_search = readme_document.traverse(condition=is_services)
+        service_list_search = list(readme_document.findall(condition=is_services))
         assert len(service_list_search) == 1
         service_list_element = service_list_search.pop()
         readme_listed_services = set(

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -52,16 +52,39 @@ class TestReadme:
         assert documented_services == readme_listed_services
 
 
+@pytest.fixture(scope='module')
+def doctreedir(tmp_path_factory):
+    # Shared across the html and man builds below so the (expensive) parsing
+    # of the doc sources into doctrees only happens once.
+    return str(tmp_path_factory.mktemp('doctrees'))
+
+
 class TestDocs:
     @pytest.mark.skipif(not INTERNET, reason='no internet')
-    def test_docs_build_without_warning(self):
+    def test_docs_build_without_warning(self, doctreedir):
+        # The dummy builder resolves all cross-references (so still catches
+        # broken refs/links like the html builder would) but writes no
+        # output, skipping HTML rendering and search-index generation, which
+        # this test never inspects anyway.
         with tempfile.TemporaryDirectory() as buildDir:
             subprocess.run(
-                ['sphinx-build', '-n', '-W', '-v', str(DOCS_PATH), buildDir], check=True
+                [
+                    'sphinx-build',
+                    '-b',
+                    'dummy',
+                    '-n',
+                    '-W',
+                    '-v',
+                    '-d',
+                    doctreedir,
+                    str(DOCS_PATH),
+                    buildDir,
+                ],
+                check=True,
             )
 
     @pytest.mark.skipif(not INTERNET, reason='no internet')
-    def test_manpage_build_without_warning(self):
+    def test_manpage_build_without_warning(self, doctreedir):
         with tempfile.TemporaryDirectory() as buildDir:
             subprocess.run(
                 [
@@ -71,6 +94,8 @@ class TestDocs:
                     '-n',
                     '-W',
                     '-v',
+                    '-d',
+                    doctreedir,
                     str(DOCS_PATH),
                     buildDir,
                 ],

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -9,7 +9,8 @@ import pytest
 from bugwarrior import services
 from bugwarrior.config import ServiceConfig
 
-from .base import DumbService, make_issue, make_service
+from .base import DumbService, make_issue
+from .services.base import get_mock_service
 
 LONG_MESSAGE = """\
 Some message that is over 100 characters. This message is so long it's
@@ -41,7 +42,7 @@ class TestService:
         check_architecture(services.Service)
 
     def test_build_annotations_default(self):
-        service = make_service()
+        service = get_mock_service(DumbService)
 
         annotations = service.build_annotations(
             (('some_author', LONG_MESSAGE),), 'example.com'
@@ -51,7 +52,9 @@ class TestService:
         ]
 
     def test_build_annotations_limited(self):
-        service = make_service(general_overrides={'annotation_length': '20'})
+        service = get_mock_service(
+            DumbService, general_overrides={'annotation_length': '20'}
+        )
 
         annotations = service.build_annotations(
             (('some_author', LONG_MESSAGE),), 'example.com'
@@ -59,7 +62,9 @@ class TestService:
         assert annotations == ['@some_author - Some message that is...']
 
     def test_build_annotations_limitless(self):
-        service = make_service(general_overrides={'annotation_length': None})
+        service = get_mock_service(
+            DumbService, general_overrides={'annotation_length': None}
+        )
 
         annotations = service.build_annotations(
             (('some_author', LONG_MESSAGE),), 'example.com'
@@ -71,7 +76,7 @@ class TestService:
             DumbService, 'API_VERSION', new=services.LATEST_API_VERSION + 1
         ):
             with pytest.raises(ValueError, match="Incompatible Service"):
-                make_service()
+                get_mock_service(DumbService)
 
     def test_api_latest_version(self):
         basedir = pathlib.Path(__file__).parent.parent

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -9,7 +9,7 @@ import pytest
 from bugwarrior import services
 from bugwarrior.config import ServiceConfig, schema
 
-from .base import ConfigTest, DumbConfig, DumbService
+from .base import DumbConfig, DumbService
 
 LONG_MESSAGE = """\
 Some message that is over 100 characters. This message is so long it's
@@ -17,43 +17,44 @@ going to fill up your floppy disk taskwarrior backup. Actually it's not
 that long.""".replace('\n', ' ')
 
 
-class ServiceBase(ConfigTest):
-    def makeService(self, general_overrides=None, config_overrides=None):
-        main_config = schema.MainSectionConfig(
-            targets=['test'], **(general_overrides or {})
-        )
-        service_config = DumbConfig(target='test', **(config_overrides or {}))
-        return DumbService(service_config, main_config)
-
-    def makeIssue(self, general_overrides=None, config_overrides=None):
-        service = self.makeService(general_overrides, config_overrides)
-        return service.get_issue_for_record({})
-
-    def checkArchitecture(self, klass: abc.ABCMeta):
-        """
-        Bidirectional communication between the base classes and their children
-        has been a source of complication as changes to any part of the
-        circular data flow can create unpredictable side-effects. The concrete
-        methods of the base classes exist as utilities for children to call;
-        they should not call the abstract methods which children implement.
-
-        Here, we cheaply check that the names of the abstract methods only
-        appear once. This should ensure that these methods are declared here
-        but not called.
-        """
-        base = Path(services.__file__).read_text()
-
-        for method in klass.__abstractmethods__:
-            references = re.findall(rf'{method}\(', base)
-            assert len(references) == 1, references
+def make_service(general_overrides=None, config_overrides=None):
+    main_config = schema.MainSectionConfig(
+        targets=['test'], **(general_overrides or {})
+    )
+    service_config = DumbConfig(target='test', **(config_overrides or {}))
+    return DumbService(service_config, main_config)
 
 
-class TestService(ServiceBase):
+def make_issue(general_overrides=None, config_overrides=None):
+    service = make_service(general_overrides, config_overrides)
+    return service.get_issue_for_record({})
+
+
+def check_architecture(klass: abc.ABCMeta):
+    """
+    Bidirectional communication between the base classes and their children
+    has been a source of complication as changes to any part of the
+    circular data flow can create unpredictable side-effects. The concrete
+    methods of the base classes exist as utilities for children to call;
+    they should not call the abstract methods which children implement.
+
+    Here, we cheaply check that the names of the abstract methods only
+    appear once. This should ensure that these methods are declared here
+    but not called.
+    """
+    base = Path(services.__file__).read_text()
+
+    for method in klass.__abstractmethods__:
+        references = re.findall(rf'{method}\(', base)
+        assert len(references) == 1, references
+
+
+class TestService:
     def test_architecture(self):
-        self.checkArchitecture(services.Service)
+        check_architecture(services.Service)
 
     def test_build_annotations_default(self):
-        service = self.makeService()
+        service = make_service()
 
         annotations = service.build_annotations(
             (('some_author', LONG_MESSAGE),), 'example.com'
@@ -63,7 +64,7 @@ class TestService(ServiceBase):
         ]
 
     def test_build_annotations_limited(self):
-        service = self.makeService(general_overrides={'annotation_length': '20'})
+        service = make_service(general_overrides={'annotation_length': '20'})
 
         annotations = service.build_annotations(
             (('some_author', LONG_MESSAGE),), 'example.com'
@@ -71,7 +72,7 @@ class TestService(ServiceBase):
         assert annotations == ['@some_author - Some message that is...']
 
     def test_build_annotations_limitless(self):
-        service = self.makeService(general_overrides={'annotation_length': None})
+        service = make_service(general_overrides={'annotation_length': None})
 
         annotations = service.build_annotations(
             (('some_author', LONG_MESSAGE),), 'example.com'
@@ -83,7 +84,7 @@ class TestService(ServiceBase):
             DumbService, 'API_VERSION', new=services.LATEST_API_VERSION + 1
         ):
             with pytest.raises(ValueError, match="Incompatible Service"):
-                self.makeService()
+                make_service()
 
     def test_api_latest_version(self):
         basedir = pathlib.Path(__file__).parent.parent
@@ -104,34 +105,34 @@ class TestService(ServiceBase):
 
         service_config = ServiceConfig(service='legacy', target='legacy-target')
         with unittest.mock.patch(
-            'bugwarrior.config.schema.get_service', lambda _: LegacyService
+            'bugwarrior.config.schema.get_service', return_value=LegacyService
         ):
             assert service_config.keyring_service == 'legacy://legacy-target'
 
 
-class TestIssue(ServiceBase):
+class TestIssue:
     def test_architecture(self):
-        self.checkArchitecture(services.Issue)
+        check_architecture(services.Issue)
 
     def test_build_default_description_default(self):
-        issue = self.makeIssue()
+        issue = make_issue()
 
         description = issue.build_default_description(LONG_MESSAGE)
         assert description == '(bw)Is# - Some message that is over 100 chara'
 
     def test_build_default_description_limited(self):
-        issue = self.makeIssue(general_overrides={'description_length': '20'})
+        issue = make_issue(general_overrides={'description_length': '20'})
 
         description = issue.build_default_description(LONG_MESSAGE)
         assert description == '(bw)Is# - Some message that is'
 
     def test_build_default_description_limitless(self):
-        issue = self.makeIssue(general_overrides={'description_length': None})
+        issue = make_issue(general_overrides={'description_length': None})
 
         description = issue.build_default_description(LONG_MESSAGE)
         assert description == f'(bw)Is# - {LONG_MESSAGE}'
 
     def test_get_tags_from_labels_normalization(self):
-        issue = self.makeIssue(config_overrides={'import_labels_as_tags': True})
+        issue = make_issue(config_overrides={'import_labels_as_tags': True})
 
         assert issue.get_tags_from_labels(['needs work']) == ['needs_work']

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -7,27 +7,14 @@ import unittest.mock
 import pytest
 
 from bugwarrior import services
-from bugwarrior.config import ServiceConfig, schema
+from bugwarrior.config import ServiceConfig
 
-from .base import DumbConfig, DumbService
+from .base import DumbService, make_issue, make_service
 
 LONG_MESSAGE = """\
 Some message that is over 100 characters. This message is so long it's
 going to fill up your floppy disk taskwarrior backup. Actually it's not
 that long.""".replace('\n', ' ')
-
-
-def make_service(general_overrides=None, config_overrides=None):
-    main_config = schema.MainSectionConfig(
-        targets=['test'], **(general_overrides or {})
-    )
-    service_config = DumbConfig(target='test', **(config_overrides or {}))
-    return DumbService(service_config, main_config)
-
-
-def make_issue(general_overrides=None, config_overrides=None):
-    service = make_service(general_overrides, config_overrides)
-    return service.get_issue_for_record({})
 
 
 def check_architecture(klass: abc.ABCMeta):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,14 +1,12 @@
 from bugwarrior.collect import TaskConstructor
 from bugwarrior.config.schema import MainSectionConfig
 
-from .base import ConfigTest, DumbConfig, DumbIssue
+from .base import DumbConfig, DumbIssue
 
 
-class TestTemplates(ConfigTest):
-    def setUp(self):
-        super().setUp()
-        self.arbitrary_default_description = 'Construct Library on Terminus'
-        self.arbitrary_issue = {'project': 'end_of_empire', 'priority': 'H'}
+class TestTemplates:
+    arbitrary_default_description = 'Construct Library on Terminus'
+    arbitrary_issue = {'project': 'end_of_empire', 'priority': 'H'}
 
     def get_issue(self, templates=None, issue=None, description=None, add_tags=None):
         templates = {} if templates is None else templates

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,81 +1,83 @@
+import pytest
+
 from bugwarrior.collect import TaskConstructor
 
 from .base import make_issue
 
+DEFAULT_DESCRIPTION = 'Construct Library on Terminus'
 
-class TestTemplates:
-    arbitrary_default_description = 'Construct Library on Terminus'
-    arbitrary_issue = {'project': 'end_of_empire', 'priority': 'H'}
 
-    def get_issue(self, templates=None, add_tags=None):
+@pytest.fixture
+def record():
+    return {'project': 'end_of_empire', 'priority': 'H'}
+
+
+@pytest.fixture
+def get_issue(record):
+    def get(templates=None, add_tags=None):
         templates = {} if templates is None else templates
         overrides = {f'{key}_template': value for key, value in templates.items()}
         if add_tags:
             overrides['add_tags'] = add_tags
 
         issue = make_issue(config_overrides=overrides)
-        issue.to_taskwarrior = lambda: self.arbitrary_issue
-        issue.get_default_description = lambda: self.arbitrary_default_description
+        issue.to_taskwarrior = lambda: record
+        issue.get_default_description = lambda: DEFAULT_DESCRIPTION
         return issue
 
-    def test_default_taskwarrior_record(self):
-        issue = self.get_issue({})
+    return get
 
-        record = TaskConstructor(issue).get_taskwarrior_record()
-        expected_record = self.arbitrary_issue.copy()
-        expected_record.update(
-            {'description': self.arbitrary_default_description, 'tags': []}
-        )
 
-        assert record == expected_record
+class TestTemplates:
+    def test_default_taskwarrior_record(self, get_issue, record):
+        issue = get_issue({})
 
-    def test_override_description(self):
+        actual = TaskConstructor(issue).get_taskwarrior_record()
+        expected_record = record.copy()
+        expected_record.update({'description': DEFAULT_DESCRIPTION, 'tags': []})
+
+        assert actual == expected_record
+
+    def test_override_description(self, get_issue, record):
         description_template = "{{ priority }} - {{ description }}"
 
-        issue = self.get_issue({'description': description_template})
+        issue = get_issue({'description': description_template})
 
-        record = TaskConstructor(issue).get_taskwarrior_record()
-        expected_record = self.arbitrary_issue.copy()
+        actual = TaskConstructor(issue).get_taskwarrior_record()
+        expected_record = record.copy()
         expected_record.update(
             {
-                'description': '%s - %s'
-                % (
-                    self.arbitrary_issue['priority'],
-                    self.arbitrary_default_description,
-                ),
+                'description': '%s - %s' % (record['priority'], DEFAULT_DESCRIPTION),
                 'tags': [],
             }
         )
 
-        assert record == expected_record
+        assert actual == expected_record
 
-    def test_override_project(self):
+    def test_override_project(self, get_issue, record):
         project_template = "wat_{{ project|upper }}"
 
-        issue = self.get_issue({'project': project_template})
+        issue = get_issue({'project': project_template})
 
-        record = TaskConstructor(issue).get_taskwarrior_record()
-        expected_record = self.arbitrary_issue.copy()
+        actual = TaskConstructor(issue).get_taskwarrior_record()
+        expected_record = record.copy()
         expected_record.update(
             {
-                'description': self.arbitrary_default_description,
-                'project': 'wat_%s' % self.arbitrary_issue['project'].upper(),
+                'description': DEFAULT_DESCRIPTION,
+                'project': 'wat_%s' % record['project'].upper(),
                 'tags': [],
             }
         )
 
-        assert record == expected_record
+        assert actual == expected_record
 
-    def test_tag_templates(self):
-        issue = self.get_issue(add_tags=['one', '{{ project }}'])
+    def test_tag_templates(self, get_issue, record):
+        issue = get_issue(add_tags=['one', '{{ project }}'])
 
-        record = TaskConstructor(issue).get_taskwarrior_record()
-        expected_record = self.arbitrary_issue.copy()
+        actual = TaskConstructor(issue).get_taskwarrior_record()
+        expected_record = record.copy()
         expected_record.update(
-            {
-                'description': self.arbitrary_default_description,
-                'tags': ['one', self.arbitrary_issue['project']],
-            }
+            {'description': DEFAULT_DESCRIPTION, 'tags': ['one', record['project']]}
         )
 
-        assert record == expected_record
+        assert actual == expected_record

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -33,10 +33,9 @@ class TestTemplates:
         issue = get_issue({})
 
         actual = TaskConstructor(issue).get_taskwarrior_record()
-        expected_record = record.copy()
-        expected_record.update({'description': DEFAULT_DESCRIPTION, 'tags': []})
+        record.update({'description': DEFAULT_DESCRIPTION, 'tags': []})
 
-        assert actual == expected_record
+        assert actual == record
 
     def test_override_description(self, get_issue, record):
         description_template = "{{ priority }} - {{ description }}"
@@ -44,15 +43,14 @@ class TestTemplates:
         issue = get_issue({'description': description_template})
 
         actual = TaskConstructor(issue).get_taskwarrior_record()
-        expected_record = record.copy()
-        expected_record.update(
+        record.update(
             {
                 'description': '%s - %s' % (record['priority'], DEFAULT_DESCRIPTION),
                 'tags': [],
             }
         )
 
-        assert actual == expected_record
+        assert actual == record
 
     def test_override_project(self, get_issue, record):
         project_template = "wat_{{ project|upper }}"
@@ -60,8 +58,7 @@ class TestTemplates:
         issue = get_issue({'project': project_template})
 
         actual = TaskConstructor(issue).get_taskwarrior_record()
-        expected_record = record.copy()
-        expected_record.update(
+        record.update(
             {
                 'description': DEFAULT_DESCRIPTION,
                 'project': 'wat_%s' % record['project'].upper(),
@@ -69,15 +66,14 @@ class TestTemplates:
             }
         )
 
-        assert actual == expected_record
+        assert actual == record
 
     def test_tag_templates(self, get_issue, record):
         issue = get_issue(add_tags=['one', '{{ project }}'])
 
         actual = TaskConstructor(issue).get_taskwarrior_record()
-        expected_record = record.copy()
-        expected_record.update(
+        record.update(
             {'description': DEFAULT_DESCRIPTION, 'tags': ['one', record['project']]}
         )
 
-        assert actual == expected_record
+        assert actual == record

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,28 +1,21 @@
 from bugwarrior.collect import TaskConstructor
-from bugwarrior.config.schema import MainSectionConfig
 
-from .base import DumbConfig, DumbIssue
+from .base import make_issue
 
 
 class TestTemplates:
     arbitrary_default_description = 'Construct Library on Terminus'
     arbitrary_issue = {'project': 'end_of_empire', 'priority': 'H'}
 
-    def get_issue(self, templates=None, issue=None, description=None, add_tags=None):
+    def get_issue(self, templates=None, add_tags=None):
         templates = {} if templates is None else templates
-        template_kwargs = {f'{key}_template': value for key, value in templates.items()}
-        config = DumbConfig(
-            target='dummy', add_tags=add_tags if add_tags else [], **template_kwargs
-        )
-        main_config = MainSectionConfig(targets=[])
+        overrides = {f'{key}_template': value for key, value in templates.items()}
+        if add_tags:
+            overrides['add_tags'] = add_tags
 
-        issue = DumbIssue({}, config, main_config, {})
-        issue.to_taskwarrior = lambda: (
-            self.arbitrary_issue if description is None else description
-        )
-        issue.get_default_description = lambda: (
-            self.arbitrary_default_description if description is None else description
-        )
+        issue = make_issue(config_overrides=overrides)
+        issue.to_taskwarrior = lambda: self.arbitrary_issue
+        issue.get_default_description = lambda: self.arbitrary_default_description
         return issue
 
     def test_default_taskwarrior_record(self):


### PR DESCRIPTION
Last PR to close #1160 

This PR mostly does 2 things: 
1. migrate everything to more standard pytest (fixtures, parametrize...)
2. Improve consistency across service test files.

### Standard Pytest
This change is quite opinionated, but here is why I think it improves the code:
* Remove *a lot* of silent mutations. The tests used to rely on manual copies, setting / unsetting environment variable etc to make everything works. Tests are now isolated by construction. We use standard fixture for tmp paths, env variable overrides, and we define our own to create services, issues etc.
* composition over inheritance. Standard principle too, we used to rely a lot on test class inheritance, which is quite fragile, and prevented us to easily modify tests (hence this big PR)
* warnings are now considered as errors, so we can detect and fix them (except for taskw deprecation warnings, as we can't really do anything about that for now). Several bugs were detected and fixed thanks to that. 

### Service tests consistency
Each service test was defining and using its data differently, once again making it harder to add a change for all services at once, I tried to make them a bit more similar. I added a few tests to ensure basic consistency


I tried to create atomic commits to ease the review. If that's still too much, I can create multiple PRs