### PR TITLE
logseq: coerce block id to int for stable unique key

### DIFF
--- a/bugwarrior/services/logseq.py
+++ b/bugwarrior/services/logseq.py
@@ -304,7 +304,7 @@ class LogseqIssue(Issue):
             "scheduled": scheduled_date,
             "wait": wait_date if self._is_waiting() else None,
             "status": self.STATE_MAP[self.get_logseq_state()],
-            self.ID: self.record["id"],
+            self.ID: int(self.record["id"]),
             self.UUID: self.record["uuid"],
             self.STATE: self.record["marker"],
             self.TITLE: self.get_formatted_title(),

--- a/tests/services/test_logseq.py
+++ b/tests/services/test_logseq.py
@@ -118,6 +118,17 @@ class TestLogseqIssue:
 
         assert actual == expected
 
+    def test_to_taskwarrior_float_id(self, service, record, extra):
+        # Logseq may return the block id as a float (7146.0), which would
+        # otherwise be stored as the string "7146.000000" and break the
+        # unique key across syncs.
+        record["id"] = float(record["id"])
+        issue = service.get_issue_for_record(record, extra)
+
+        actual = issue.to_taskwarrior()
+
+        assert str(actual[issue.ID]) == "7146"
+
     def test_to_taskwarrior_with_tags(self, make_service, record, extra):
         overrides = {"import_labels_as_tags": "True"}
         service = make_service(**overrides)


### PR DESCRIPTION
Closes #1168

Logseq sometimes returns a block id as a float (`7146.0`), so the `logseqid` UDA was stored as `"7146.000000"`. Because `UNIQUE_KEY = (ID, UUID)`, the task stopped matching on the next sync and bugwarrior closed it and created a duplicate. Coercing the id to `int` keeps the key stable, as suggested by @scross01 on the issue.
